### PR TITLE
feat(AM-6038): Graceful cleanup of controller cluster on helm uninstall

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,18 @@ COPY apis/ apis/
 COPY controllers/ controllers/
 COPY service/ service/
 COPY util/ util/
+COPY cleanup/ cleanup/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o cleanup ./cleanup/
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
+COPY --from=builder /workspace/cleanup/cleanup .
 USER 65532:65532
 
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,10 @@ apply-sample: ## Generate sample manifests.
 webhookCA: ## Install the Cert Manager for Admission controller Webhooks.
 	kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.7.0/cert-manager.yaml
 
+.PHONY: cleanup
+cleanup: 
+	kubectl apply -f config/cleanup/cleanup_job.yaml -n=kubeslice-controller
+
 .PHONY: generate-mocks
 generate-mocks: ## Generate mocks for the controller-runtime.
 	mockery --dir service/ --all  --output service/mocks

--- a/cleanup/main.go
+++ b/cleanup/main.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/kubeslice/kubeslice-controller/util"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	controllerv1alpha1 "github.com/kubeslice/kubeslice-controller/apis/controller/v1alpha1"
+	workerv1alpha1 "github.com/kubeslice/kubeslice-controller/apis/worker/v1alpha1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	scheme                     = runtime.NewScheme()
+	logger                     = util.NewLogger().With("controller", "GracefulCleanup")
+	controllerManagerNamespace string
+	ctx                        context.Context
+	noOfRetries                = 3
+	sleepDuration              = 1 * time.Second
+	// Kubeslice resources
+	projects             *controllerv1alpha1.ProjectList
+	sliceConfigs         *controllerv1alpha1.SliceConfigList
+	serviceExportConfigs *controllerv1alpha1.ServiceExportConfigList
+	clusters             *controllerv1alpha1.ClusterList
+	workerSliceConfigs   *workerv1alpha1.WorkerSliceConfigList
+)
+
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(controllerv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(workerv1alpha1.AddToScheme(scheme))
+}
+
+func main() {
+	initialize()
+	cleanupResources()
+}
+
+func initialize() {
+	// Setup
+	config := ctrl.GetConfigOrDie()
+	c, _ := client.New(config, client.Options{Scheme: scheme})
+	ctx = util.PrepareKubeSliceControllersRequestContext(context.Background(), c, c.Scheme(), "CleanupContext")
+	controllerManagerNamespace = os.Getenv("KUBESLICE_CONTROLLER_MANAGER_NAMESPACE")
+
+	// Resource Types
+	projects = &controllerv1alpha1.ProjectList{}
+	sliceConfigs = &controllerv1alpha1.SliceConfigList{}
+	serviceExportConfigs = &controllerv1alpha1.ServiceExportConfigList{}
+	clusters = &controllerv1alpha1.ClusterList{}
+	workerSliceConfigs = &workerv1alpha1.WorkerSliceConfigList{}
+
+}
+
+func cleanupResources() {
+
+	// Delete all Projects
+	logger.Infof("%s Fetching all Projects", util.Find)
+	err := util.Cleanup_ListResources(ctx, projects, client.InNamespace(controllerManagerNamespace))
+	if err != nil {
+		logger.Errorf("%s Unable to fetch Projects. Returning from cleanup. %s", util.Err, err.Error())
+		return
+	}
+	// Returning if no Projects found
+	if len(projects.Items) == 0 {
+		logger.Infof("%s Found 0 Projects. Returning from cleanup", util.Find)
+		return
+	}
+
+	for _, project := range projects.Items {
+
+		projectNamespace := project.Labels["kubeslice-project-namespace"]
+		// Delete all ServiceExports
+		logger.Infof("%s Fetching all ServiceExports for Project %s", util.Find, project.GetName())
+
+		err := util.Cleanup_ListResources(ctx, serviceExportConfigs, client.InNamespace(projectNamespace))
+		if err != nil {
+			logger.Errorf("%sError fetching ServiceExports. %s", util.Err, err.Error())
+		}
+		for _, serviceExportConfig := range serviceExportConfigs.Items {
+			logger.Infof("%s  Deleting ServiceExportConfig %s", util.Bin, serviceExportConfig.GetName())
+			err := util.Cleanup_DeleteResource(ctx, &serviceExportConfig)
+			if err != nil {
+				logger.Errorf("%s Error deleting ServiceExport %s. %s", util.Err, serviceExportConfig.GetName(), err.Error())
+			}
+		}
+		// Delete all sliceConfigs
+		logger.Infof("%s Fetching all SliceConfigs for Project %s", util.Find, project.GetName())
+		err = util.Cleanup_ListResources(ctx, sliceConfigs, client.InNamespace(projectNamespace))
+		if err != nil {
+			logger.Errorf("%s Error fetching SliceConfigs. %s", util.Err, err.Error())
+		}
+		for _, sliceConfig := range sliceConfigs.Items {
+			logger.Infof("%s  Removing ApplicationNamespaces from SliceConfig %s", util.Bin, sliceConfig.GetName())
+
+			// Offboard Application Namespaces
+			if len(sliceConfig.Spec.NamespaceIsolationProfile.ApplicationNamespaces) > 0 {
+				sliceConfig.Spec.NamespaceIsolationProfile.ApplicationNamespaces = nil
+				err := util.Cleanup_UpdateResource(ctx, &sliceConfig)
+				if err != nil {
+					logger.Errorf("%s Error offboarding Application Namespaces from SliceConfig %s. %s", util.Err, sliceConfig.GetName(), err.Error())
+				}
+			}
+			// Fetch all WorkerSliceConfigs to check the status of Namespace offboarding
+			completeResourceName := fmt.Sprintf("%s-%s", util.Cleanup_GetObjectKind(&sliceConfig), sliceConfig.GetName())
+			ownershipLabel := util.Cleanup_GetOwnerLabel(completeResourceName)
+			err := util.Cleanup_ListResources(ctx, workerSliceConfigs, client.MatchingLabels(ownershipLabel), client.InNamespace(projectNamespace))
+			if err != nil {
+				logger.Errorf("%s Error fetching WorkerSliceConfigs %s", util.Err, err)
+			}
+			for _, workerSliceConfig := range workerSliceConfigs.Items {
+				// checking status of workerSliceConfig
+				logger.Infof("%s Checking status of workerSliceConfig %s", util.Find, workerSliceConfig.Name)
+				// add exponential delay for this check and exit after timeout.
+				err := util.Retry(ctx, (noOfRetries + 3), sleepDuration, func() (err error) {
+					util.Cleanup_GetResourceIfExist(ctx, client.ObjectKey{
+						Namespace: workerSliceConfig.Namespace,
+						Name:      workerSliceConfig.Name,
+					}, &workerSliceConfig)
+					if len(workerSliceConfig.Status.OnboardedAppNamespaces) == 0 {
+						return nil
+					}
+					return fmt.Errorf("application Namespaces not offboarded")
+				})
+				if err != nil {
+					logger.Infof("%s WorkerSliceConfig status not updated %s", util.Sad, err.Error())
+					// After timeout update status of workerSliceConfig
+					workerSliceConfig.Status.OnboardedAppNamespaces = nil
+					err = util.Cleanup_UpdateStatus(ctx, &workerSliceConfig)
+					if err != nil {
+						logger.Errorf("%s Error updating status of WorkerSliceConfig %s. %s", util.Err, workerSliceConfig.GetName(), err.Error())
+					}
+				}
+			}
+
+			// Delete the SliceConfig
+			logger.Infof("%s  Deleting SliceConfig %s", util.Bin, sliceConfig.GetName())
+			err = util.Retry(ctx, noOfRetries, sleepDuration, func() (err error) {
+				return util.Cleanup_DeleteResource(ctx, &sliceConfig)
+			})
+			if err != nil {
+				logger.Errorf("%s Error deleting SliceConfig %s. %s", util.Err, sliceConfig.GetName(), err.Error())
+			}
+		}
+
+		// Delete all clusters
+		logger.Infof("%s Fetching all Clusters for Project %s", util.Find, project.GetName())
+		err = util.Cleanup_ListResources(ctx, clusters, client.InNamespace(projectNamespace))
+		if err != nil {
+			logger.Error("%s Error fetching Clusters %s", util.Err, err.Error())
+		}
+		for _, cluster := range clusters.Items {
+			logger.Infof("%s  Deleting Cluster %s", util.Bin, cluster.GetName())
+			err = util.Retry(ctx, noOfRetries, sleepDuration, func() (err error) {
+				return util.Cleanup_DeleteResource(ctx, &cluster)
+			})
+			if err != nil {
+				logger.Errorf("%s Error deleting Cluster %s. %s", util.Err, cluster.GetName(), err.Error())
+			}
+		}
+
+		// Delete the project
+		logger.Infof("%s  Deleting Project %s", util.Bin, project.GetName())
+		err = util.Retry(ctx, noOfRetries, sleepDuration, func() (err error) {
+			return util.Cleanup_DeleteResource(ctx, &project)
+		})
+		if err != nil {
+			logger.Errorf("%s Error deleting Project %s. %s", util.Err, project.GetName(), err.Error())
+		}
+	}
+	if err == nil {
+		logger.Infof("%s Successfully cleaned up all Kubeslice resources.", util.Party)
+	}
+}

--- a/config/cleanup/cleanup_job.yaml
+++ b/config/cleanup/cleanup_job.yaml
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: kubeslice-cleanup
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    spec:
+      serviceAccountName: kubeslice-controller-controller-manager
+      containers:
+        - name: kubeslice-cleanup
+          image: aveshasystems/kubeslice-controller:latest
+          imagePullPolicy: IfNotPresent
+          command:
+            - /cleanup
+          env:
+            - name: KUBESLICE_CONTROLLER_MANAGER_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+      restartPolicy: Never
+  backoffLimit: 1

--- a/service/project_service.go
+++ b/service/project_service.go
@@ -103,6 +103,16 @@ func (t *ProjectService) ReconcileProject(ctx context.Context, req ctrl.Request)
 		projectNamespace, project.Spec.ServiceAccount.ReadWrite, project)); shouldReturn {
 		return result, reconErr
 	}
+
+	// Step 6: adding ProjectNamespace in labels
+	labels := make(map[string]string)
+	labels["kubeslice-project-namespace"] = projectNamespace
+	project.Labels = labels
+	err = util.UpdateResource(ctx, project)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	logger.Infof("project %s reconciled", req.Name)
 	return ctrl.Result{}, nil
 }

--- a/service/project_service_test.go
+++ b/service/project_service_test.go
@@ -106,6 +106,7 @@ func TestReconcileProject_AddsREconciler_CreatesResourcesAndReturnsReconciliatio
 	acsServicemOCK.On("ReconcileReadWriteRole", ctx, projectNamespace, mock.Anything).Return(ctrl.Result{}, nil).Once()
 	acsServicemOCK.On("ReconcileReadOnlyUserServiceAccountAndRoleBindings", ctx, projectNamespace, readOnlyServiceAccounts, mock.Anything).Return(ctrl.Result{}, nil).Once()
 	acsServicemOCK.On("ReconcileReadWriteUserServiceAccountAndRoleBindings", ctx, projectNamespace, readWriteServiceAccounts, mock.Anything).Return(ctrl.Result{}, nil).Once()
+	clientMock.On("Update", ctx, mock.Anything).Return(nil).Once()
 	result, err := projectService.ReconcileProject(ctx, requestObj)
 	expectedResult := ctrl.Result{}
 	require.Equal(t, result, expectedResult)
@@ -137,6 +138,7 @@ func TestReconcileProject_DoNotCallFinalizerIfItExists(t *testing.T) {
 	acsServicemOCK.On("ReconcileReadWriteRole", ctx, projectNamespace, mock.Anything).Return(ctrl.Result{}, nil).Once()
 	acsServicemOCK.On("ReconcileReadOnlyUserServiceAccountAndRoleBindings", ctx, projectNamespace, readOnlyServiceAccounts, mock.Anything).Return(ctrl.Result{}, nil).Once()
 	acsServicemOCK.On("ReconcileReadWriteUserServiceAccountAndRoleBindings", ctx, projectNamespace, readWriteServiceAccounts, mock.Anything).Return(ctrl.Result{}, nil).Once()
+	clientMock.On("Update", ctx, mock.Anything).Return(nil).Once()
 	result, err := projectService.ReconcileProject(ctx, requestObj)
 	expectedResult := ctrl.Result{}
 	require.Equal(t, result, expectedResult)

--- a/util/cleanup_utility.go
+++ b/util/cleanup_utility.go
@@ -29,8 +29,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// GetObjectKindis a function which return the kind of existing resource
-func Cleanup_GetObjectKind(obj runtime.Object) string {
+// GetObjectKind is a function which return the kind of existing resource
+func CleanupGetObjectKind(obj runtime.Object) string {
 	kindPath := reflect.TypeOf(obj)
 	kindPathName := kindPath.String()
 	kindPathNameParts := strings.Split(kindPathName, ".")
@@ -38,21 +38,21 @@ func Cleanup_GetObjectKind(obj runtime.Object) string {
 }
 
 // GetResourceIfExist is a function to get the given resource is in namespace
-func Cleanup_GetResourceIfExist(ctx context.Context, namespacedName client.ObjectKey, object client.Object) (bool,
+func CleanupGetResourceIfExist(ctx context.Context, namespacedName client.ObjectKey, object client.Object) (bool,
 	error) {
 	logger := CtxLogger(ctx)
-	logger.Debugf("Fetching %s %s in namespace %s", Cleanup_GetObjectKind(object),
+	logger.Debugf("Fetching %s %s in namespace %s", CleanupGetObjectKind(object),
 		namespacedName.Name, namespacedName.Namespace)
 	kubeSliceCtx := GetKubeSliceControllerRequestContext(ctx)
 	err := kubeSliceCtx.Get(ctx, namespacedName, object)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			logger.Debugf("%s %s in namespace %s not found", Cleanup_GetObjectKind(object),
+			logger.Debugf("%s %s in namespace %s not found", CleanupGetObjectKind(object),
 				namespacedName.Name, namespacedName.Namespace)
 			return false, nil
 		} else {
 			logger.With(zap.Error(err)).Errorf("%s Error retrieving object of kind %s with name %s in namespace %s", Err,
-				Cleanup_GetObjectKind(object), namespacedName.Name, namespacedName.Namespace)
+				CleanupGetObjectKind(object), namespacedName.Name, namespacedName.Namespace)
 			return false, err
 		}
 	}
@@ -60,9 +60,9 @@ func Cleanup_GetResourceIfExist(ctx context.Context, namespacedName client.Objec
 }
 
 // UpdateResource is a function to update resource
-func Cleanup_UpdateResource(ctx context.Context, object client.Object) error {
+func CleanupUpdateResource(ctx context.Context, object client.Object) error {
 	logger := CtxLogger(ctx)
-	logger.Debugf("Updating %s %s in namespace %s", Cleanup_GetObjectKind(object), object.GetName(),
+	logger.Debugf("Updating %s %s in namespace %s", CleanupGetObjectKind(object), object.GetName(),
 		object.GetNamespace())
 	kubeSliceCtx := GetKubeSliceControllerRequestContext(ctx)
 	err := kubeSliceCtx.Update(ctx, object)
@@ -70,15 +70,15 @@ func Cleanup_UpdateResource(ctx context.Context, object client.Object) error {
 		logger.With(zap.Error(err)).Errorf("Failed to update resource: %v", object)
 		return err
 	}
-	logger.Infof("%s Updated %s %s in namespace %s", Tick, Cleanup_GetObjectKind(object), object.GetName(),
+	logger.Infof("%s Updated %s %s in namespace %s", Tick, CleanupGetObjectKind(object), object.GetName(),
 		object.GetNamespace())
 	return err
 }
 
 // UpdateStatus is a function to update the status of given resource
-func Cleanup_UpdateStatus(ctx context.Context, object client.Object) error {
+func CleanupUpdateStatus(ctx context.Context, object client.Object) error {
 	logger := CtxLogger(ctx)
-	logger.Debugf("Updating status of %s with name %s in namespace %s", Cleanup_GetObjectKind(object), object.GetName(),
+	logger.Debugf("Updating status of %s with name %s in namespace %s", CleanupGetObjectKind(object), object.GetName(),
 		object.GetNamespace())
 	kubeSliceCtx := GetKubeSliceControllerRequestContext(ctx)
 	err := kubeSliceCtx.Status().Update(ctx, object)
@@ -86,7 +86,7 @@ func Cleanup_UpdateStatus(ctx context.Context, object client.Object) error {
 		logger.With(zap.Error(err)).Errorf("%s Failed to update status: %v", Err, object)
 		return err
 	}
-	logger.Infof("%s Updated status of %s %s in namespace %s", Tick, Cleanup_GetObjectKind(object), object.GetName(),
+	logger.Infof("%s Updated status of %s %s in namespace %s", Tick, CleanupGetObjectKind(object), object.GetName(),
 		object.GetNamespace())
 	err = kubeSliceCtx.Get(ctx, client.ObjectKey{
 		Namespace: object.GetNamespace(),
@@ -99,24 +99,24 @@ func Cleanup_UpdateStatus(ctx context.Context, object client.Object) error {
 }
 
 // DeleteResource is a function to delete the resource of given kind
-func Cleanup_DeleteResource(ctx context.Context, object client.Object) error {
+func CleanupDeleteResource(ctx context.Context, object client.Object) error {
 	logger := CtxLogger(ctx)
-	logger.Debugf("Deleting %s %s in namespace %s", Cleanup_GetObjectKind(object), object.GetName(),
+	logger.Debugf("Deleting %s %s in namespace %s", CleanupGetObjectKind(object), object.GetName(),
 		object.GetNamespace())
 	kubeSliceCtx := GetKubeSliceControllerRequestContext(ctx)
 	err := kubeSliceCtx.Delete(ctx, object)
 	if err != nil {
 		return err
 	}
-	logger.Infof("%s Deleted %s %s in namespace %s", Recycle, Cleanup_GetObjectKind(object), object.GetName(),
+	logger.Infof("%s Deleted %s %s in namespace %s", Recycle, CleanupGetObjectKind(object), object.GetName(),
 		object.GetNamespace())
 	return nil
 }
 
 // ListResources is a function to list down the resources/objects of given kind
-func Cleanup_ListResources(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+func CleanupListResources(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 	logger := CtxLogger(ctx)
-	logger.Debugf("Listing %s with options %v", Cleanup_GetObjectKind(list), opts)
+	logger.Debugf("Listing %s with options %v", CleanupGetObjectKind(list), opts)
 
 	kubeSliceCtx := GetKubeSliceControllerRequestContext(ctx)
 	err := kubeSliceCtx.List(ctx, list, opts...)
@@ -124,7 +124,7 @@ func Cleanup_ListResources(ctx context.Context, list client.ObjectList, opts ...
 }
 
 // GetOwnerLabel is a function returns the label of object
-func Cleanup_GetOwnerLabel(completeResourceName string) map[string]string {
+func CleanupGetOwnerLabel(completeResourceName string) map[string]string {
 	label := map[string]string{}
 	for key, value := range LabelsKubeSliceController {
 		label[key] = value
@@ -132,7 +132,7 @@ func Cleanup_GetOwnerLabel(completeResourceName string) map[string]string {
 	lenCompleteResourceName := len(completeResourceName)
 	i := 0
 	j := 0
-	//resourceName = fmt.Sprintf(LabelValue, Cleanup_GetObjectKind(owner), owner.GetName())
+	//resourceName = fmt.Sprintf(LabelValue, CleanupGetObjectKind(owner), owner.GetName())
 	if lenCompleteResourceName > 63 {
 		noOfLabels := lenCompleteResourceName / 63
 		label["kubeslice-controller-resource-name"] = completeResourceName[j:63]

--- a/util/cleanup_utility.go
+++ b/util/cleanup_utility.go
@@ -1,0 +1,154 @@
+/*
+ * 	Copyright (c) 2022 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package util
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"go.uber.org/zap"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetObjectKindis a function which return the kind of existing resource
+func Cleanup_GetObjectKind(obj runtime.Object) string {
+	kindPath := reflect.TypeOf(obj)
+	kindPathName := kindPath.String()
+	kindPathNameParts := strings.Split(kindPathName, ".")
+	return kindPathNameParts[len(kindPathNameParts)-1]
+}
+
+// GetResourceIfExist is a function to get the given resource is in namespace
+func Cleanup_GetResourceIfExist(ctx context.Context, namespacedName client.ObjectKey, object client.Object) (bool,
+	error) {
+	logger := CtxLogger(ctx)
+	logger.Debugf("Fetching %s %s in namespace %s", Cleanup_GetObjectKind(object),
+		namespacedName.Name, namespacedName.Namespace)
+	kubeSliceCtx := GetKubeSliceControllerRequestContext(ctx)
+	err := kubeSliceCtx.Get(ctx, namespacedName, object)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Debugf("%s %s in namespace %s not found", Cleanup_GetObjectKind(object),
+				namespacedName.Name, namespacedName.Namespace)
+			return false, nil
+		} else {
+			logger.With(zap.Error(err)).Errorf("%s Error retrieving object of kind %s with name %s in namespace %s", Err,
+				Cleanup_GetObjectKind(object), namespacedName.Name, namespacedName.Namespace)
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+// UpdateResource is a function to update resource
+func Cleanup_UpdateResource(ctx context.Context, object client.Object) error {
+	logger := CtxLogger(ctx)
+	logger.Debugf("Updating %s %s in namespace %s", Cleanup_GetObjectKind(object), object.GetName(),
+		object.GetNamespace())
+	kubeSliceCtx := GetKubeSliceControllerRequestContext(ctx)
+	err := kubeSliceCtx.Update(ctx, object)
+	if err != nil {
+		logger.With(zap.Error(err)).Errorf("Failed to update resource: %v", object)
+		return err
+	}
+	logger.Infof("%s Updated %s %s in namespace %s", Tick, Cleanup_GetObjectKind(object), object.GetName(),
+		object.GetNamespace())
+	return err
+}
+
+// UpdateStatus is a function to update the status of given resource
+func Cleanup_UpdateStatus(ctx context.Context, object client.Object) error {
+	logger := CtxLogger(ctx)
+	logger.Debugf("Updating status of %s with name %s in namespace %s", Cleanup_GetObjectKind(object), object.GetName(),
+		object.GetNamespace())
+	kubeSliceCtx := GetKubeSliceControllerRequestContext(ctx)
+	err := kubeSliceCtx.Status().Update(ctx, object)
+	if err != nil {
+		logger.With(zap.Error(err)).Errorf("%s Failed to update status: %v", Err, object)
+		return err
+	}
+	logger.Infof("%s Updated status of %s %s in namespace %s", Tick, Cleanup_GetObjectKind(object), object.GetName(),
+		object.GetNamespace())
+	err = kubeSliceCtx.Get(ctx, client.ObjectKey{
+		Namespace: object.GetNamespace(),
+		Name:      object.GetName(),
+	}, object)
+	if err != nil {
+		logger.With(zap.Error(err)).Errorf("%s Failed to fetch object after status update: %+v", Err, object)
+	}
+	return nil
+}
+
+// DeleteResource is a function to delete the resource of given kind
+func Cleanup_DeleteResource(ctx context.Context, object client.Object) error {
+	logger := CtxLogger(ctx)
+	logger.Debugf("Deleting %s %s in namespace %s", Cleanup_GetObjectKind(object), object.GetName(),
+		object.GetNamespace())
+	kubeSliceCtx := GetKubeSliceControllerRequestContext(ctx)
+	err := kubeSliceCtx.Delete(ctx, object)
+	if err != nil {
+		return err
+	}
+	logger.Infof("%s Deleted %s %s in namespace %s", Recycle, Cleanup_GetObjectKind(object), object.GetName(),
+		object.GetNamespace())
+	return nil
+}
+
+// ListResources is a function to list down the resources/objects of given kind
+func Cleanup_ListResources(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	logger := CtxLogger(ctx)
+	logger.Debugf("Listing %s with options %v", Cleanup_GetObjectKind(list), opts)
+
+	kubeSliceCtx := GetKubeSliceControllerRequestContext(ctx)
+	err := kubeSliceCtx.List(ctx, list, opts...)
+	return err
+}
+
+// GetOwnerLabel is a function returns the label of object
+func Cleanup_GetOwnerLabel(completeResourceName string) map[string]string {
+	label := map[string]string{}
+	for key, value := range LabelsKubeSliceController {
+		label[key] = value
+	}
+	lenCompleteResourceName := len(completeResourceName)
+	i := 0
+	j := 0
+	//resourceName = fmt.Sprintf(LabelValue, Cleanup_GetObjectKind(owner), owner.GetName())
+	if lenCompleteResourceName > 63 {
+		noOfLabels := lenCompleteResourceName / 63
+		label["kubeslice-controller-resource-name"] = completeResourceName[j:63]
+		j = 63
+		lenCompleteResourceName = lenCompleteResourceName - 63
+		for i = 1; i <= noOfLabels; i++ {
+			if lenCompleteResourceName < 63 {
+				break
+			}
+			label["kubeslice-controller-resource-name-"+fmt.Sprint(i)] = completeResourceName[j : 63*(i+1)]
+			lenCompleteResourceName = lenCompleteResourceName - 63
+			j = 63 * (i + 1)
+		}
+		label["kubeslice-controller-resource-name-"+fmt.Sprint(i)] = completeResourceName[j:]
+	} else {
+		label["kubeslice-controller-resource-name"] = completeResourceName
+	}
+	return label
+}

--- a/util/constants.go
+++ b/util/constants.go
@@ -1,0 +1,13 @@
+package util
+
+const (
+	Tick    = string(rune(0x2705))
+	Err     = string(rune(0x1F6AB))
+	Sad     = string(rune(0x1F613))
+	Wait    = string(rune(0x23F3))
+	Watch   = string(rune(0x1F440))
+	Find    = string(rune(0x1F50D))
+	Bin     = string(rune(0x1F5D1))
+	Recycle = string(rune(0x267D))
+	Party   = string(rune(0x1F389))
+)


### PR DESCRIPTION
# Description
In context to  [Feature: Uninstall sub command for custom topologies · Issue #25 · kubeslice/kubeslice-cli](https://github.com/kubeslice/kubeslice-cli/issues/25), when performing uninstallation of controller, a graceful cleanup is needed to remove all associated objects so that uninstallation of the controller-manager from controller cluster and slice-operator from worker clusters does not get stuck due to object residuals.

The approach is to create a job which performs a proper cleanup of slices and removes all associated CR objects. This Job would be triggered by the pre-delete webhook during helm uninstall.

## Cleanup steps for OSS
- List all Projects in the controller namespace.
- For each Project, repeat the following:
  - Delete all ServiceExportConfig objects
  - List all sliceConfigs
  - For each SliceConfig object, repeat the following:
    - Offboard Application namespaces slice
    - Wait for namespace offboarding to finish by checking the length of status.onboardedAppNamespace to be equal to zero for each WorkerSliceConfig
    - Delete the sliceConfig object
  - List and Delete all Cluster objects
  - Delete the Project namespace
  - Delete the Project object from controller namespace

Fixes #

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] Manual testing
- [ ] Unit Tests

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?
NO

```release-note

```

