### PR TITLE
fix(AM-7037): Phase out Network Interface validations

### DIFF
--- a/config/samples/controller_v1alpha1_cluster.yaml
+++ b/config/samples/controller_v1alpha1_cluster.yaml
@@ -3,7 +3,6 @@ kind: Cluster
 metadata:
   name: cluster-1
 spec:
-  networkInterface: eth1
   nodeIP: 11.11.14.114
   clusterProperty:
     telemetry:
@@ -24,7 +23,6 @@ kind: Cluster
 metadata:
   name: cluster-2
 spec:
-  networkInterface: eth0
   nodeIP: 11.11.12.11
   clusterProperty:
     telemetry:
@@ -45,7 +43,6 @@ kind: Cluster
 metadata:
   name: cluster-3
 spec:
-  networkInterface: eth0
   nodeIP: 11.11.13.11
   clusterProperty:
     telemetry:
@@ -66,7 +63,6 @@ kind: Cluster
 metadata:
   name: cluster-4
 spec:
-  networkInterface: eth0
   nodeIP: 11.11.14.11
   clusterProperty:
     telemetry:
@@ -87,7 +83,6 @@ kind: Cluster
 metadata:
   name: cluster-5
 spec:
-  networkInterface: eth0
   nodeIP:  11.11.14.189
   clusterProperty:
     telemetry:

--- a/service/cluster_webhook_validation.go
+++ b/service/cluster_webhook_validation.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"context"
+
 	"k8s.io/apimachinery/pkg/runtime"
 
 	controllerv1alpha1 "github.com/kubeslice/kubeslice-controller/apis/controller/v1alpha1"
@@ -43,9 +44,6 @@ func ValidateClusterCreate(ctx context.Context, c *controllerv1alpha1.Cluster) e
 
 // ValidateClusterUpdate is a function to validate to the update of specification of cluster
 func ValidateClusterUpdate(ctx context.Context, c *controllerv1alpha1.Cluster, old runtime.Object) error {
-	if err := validateClusterSpec(ctx, c, old); err != nil {
-		return apierrors.NewInvalid(schema.GroupKind{Group: apiGroupKubeSliceControllers, Kind: "Cluster"}, c.Name, field.ErrorList{err})
-	}
 	if err := validateGeolocation(c); err != nil {
 		return apierrors.NewInvalid(schema.GroupKind{Group: apiGroupKubeSliceControllers, Kind: "Cluster"}, c.Name, field.ErrorList{err})
 	}
@@ -66,15 +64,6 @@ func validateAppliedInProjectNamespace(ctx context.Context, c *controllerv1alpha
 	exist, _ := util.GetResourceIfExist(ctx, client.ObjectKey{Name: c.Namespace}, namespace)
 	if !exist || !util.CheckForProjectNamespace(namespace) {
 		return field.Invalid(field.NewPath("metadata").Child("namespace"), c.Namespace, "cluster must be applied on project namespace")
-	}
-	return nil
-}
-
-// validateClusterSpec is a function to validate the specification of cluster
-func validateClusterSpec(ctx context.Context, c *controllerv1alpha1.Cluster, old runtime.Object) *field.Error {
-	cluster := old.(*controllerv1alpha1.Cluster)
-	if cluster.Spec.NetworkInterface != "" && cluster.Spec.NetworkInterface != c.Spec.NetworkInterface {
-		return field.Invalid(field.NewPath("spec").Child("networkInterface"), c.Spec.NetworkInterface, "network interface can't be changed")
 	}
 	return nil
 }

--- a/service/cluster_webhook_validation_test.go
+++ b/service/cluster_webhook_validation_test.go
@@ -19,9 +19,10 @@ package service
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/kubeslice/kubeslice-controller/util"
 	"k8s.io/apimachinery/pkg/runtime"
-	"testing"
 
 	"github.com/dailymotion/allure-go"
 	controllerv1alpha1 "github.com/kubeslice/kubeslice-controller/apis/controller/v1alpha1"
@@ -45,13 +46,12 @@ func TestClusterWebhookSuite(t *testing.T) {
 }
 
 var ClusterWebHookValidationTestbed = map[string]func(*testing.T){
-	"TestValidateClusterCreateFail":                         testValidateClusterCreateOtherThanProjectNamespace,
-	"TestValidateClusterUpdateFailNetworkInterfaceNotEmpty": testValidateClusterUpdateFailNetworkInterfaceNotEmpty,
-	"TestValidateClusterDeleteFail":                         testValidateClusterDeleteFail,
-	"TestValidateClusterGeolocationFailOnCreate":            testValidateClusterGeolocationFailOnCreate,
-	"TestValidateClusterGeolocationFailOnUpdate":            testValidateClusterGeolocationFailOnUpdate,
-	"TestValidateClusterGeolocationPassOnCreate":            testValidateClusterGeolocationPassOnCreate,
-	"TestValidateClusterGeolocationPassOnUpdate":            testValidateClusterGeolocationPassOnUpdate,
+	"TestValidateClusterCreateFail":              testValidateClusterCreateOtherThanProjectNamespace,
+	"TestValidateClusterDeleteFail":              testValidateClusterDeleteFail,
+	"TestValidateClusterGeolocationFailOnCreate": testValidateClusterGeolocationFailOnCreate,
+	"TestValidateClusterGeolocationFailOnUpdate": testValidateClusterGeolocationFailOnUpdate,
+	"TestValidateClusterGeolocationPassOnCreate": testValidateClusterGeolocationPassOnCreate,
+	"TestValidateClusterGeolocationPassOnUpdate": testValidateClusterGeolocationPassOnUpdate,
 }
 
 func testValidateClusterCreateOtherThanProjectNamespace(t *testing.T) {
@@ -66,25 +66,6 @@ func testValidateClusterCreateOtherThanProjectNamespace(t *testing.T) {
 	ans := ValidateClusterCreate(ctx, cluster)
 	require.NotNil(t, ans)
 	require.Contains(t, ans.Error(), "cluster must be applied on project namespace")
-	clientMock.AssertExpectations(t)
-}
-
-func testValidateClusterUpdateFailNetworkInterfaceNotEmpty(t *testing.T) {
-	clientMock := &utilmock.Client{}
-	ctx := prepareTestContext(context.Background(), clientMock, nil)
-	cluster1 := &controllerv1alpha1.Cluster{
-		Spec: controllerv1alpha1.ClusterSpec{
-			NetworkInterface: "random1",
-		},
-	}
-	cluster2 := &controllerv1alpha1.Cluster{
-		Spec: controllerv1alpha1.ClusterSpec{
-			NetworkInterface: "random2",
-		},
-	}
-	err := ValidateClusterUpdate(ctx, cluster1, runtime.Object(cluster2))
-	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "network interface can't be changed")
 	clientMock.AssertExpectations(t)
 }
 

--- a/service/slice_config_webhook_validation.go
+++ b/service/slice_config_webhook_validation.go
@@ -183,9 +183,6 @@ func validateClusters(ctx context.Context, sliceConfig *controllerv1alpha1.Slice
 		if !exist {
 			return field.Invalid(field.NewPath("Spec").Child("Clusters"), clusterName, "cluster is not registered")
 		}
-		if cluster.Spec.NetworkInterface == "" {
-			return field.Required(field.NewPath("Spec").Child("Clusters").Child("NetworkInterface"), "for cluster "+clusterName)
-		}
 		if len(cluster.Spec.NodeIPs) == 0 && len(cluster.Status.NodeIPs) == 0 {
 			return field.Required(field.NewPath("Spec").Child("Clusters").Child("NodeIPs"), "for cluster "+clusterName)
 		}


### PR DESCRIPTION

# Description
Since the NetworkInterface field of Cluster object is no longer required, we need to:
- Remove all admission webhook validations related to `Cluster.Spec.NetworkInterface`
- Fixes required for UTs

Fixes AM-7037

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
* [x] Unit tests

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [x] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

