### PR TITLE
hotfix(AM-7432): added validations for NodeIPs

### DIFF
--- a/service/cluster_service.go
+++ b/service/cluster_service.go
@@ -132,7 +132,7 @@ func (c *ClusterService) ReconcileCluster(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, err
 	}
 
-	// This logic it to set NodeIPs to nil, if an empty string is set in the first index.
+	// This logic is to set NodeIPs to nil, if an empty string is set in the first index.
 	if len(cluster.Spec.NodeIPs) > 0 && cluster.Spec.NodeIPs[0] == "" {
 		cluster.Spec.NodeIPs = nil
 		err = util.UpdateResource(ctx, cluster)

--- a/service/cluster_service.go
+++ b/service/cluster_service.go
@@ -131,6 +131,16 @@ func (c *ClusterService) ReconcileCluster(ctx context.Context, req ctrl.Request)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+
+	// This logic it to set NodeIPs to nil, if an empty string is set in the first index.
+	if len(cluster.Spec.NodeIPs) > 0 && cluster.Spec.NodeIPs[0] == "" {
+		cluster.Spec.NodeIPs = nil
+		err = util.UpdateResource(ctx, cluster)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
 	// this logic is for backward compatibility- check crds for more.
 	if len(cluster.Spec.NodeIPs) < 2 && len(cluster.Spec.NodeIP) != 0 {
 		if len(cluster.Spec.NodeIPs) == 0 {

--- a/service/cluster_service_test.go
+++ b/service/cluster_service_test.go
@@ -62,6 +62,7 @@ var ClusterTestbed = map[string]func(*testing.T){
 	"TestDeleteClustersListFail":                   testDeleteClustersListFail,
 	"TestDeleteClusterDeleteFail":                  testDeleteClusterDeleteFail,
 	"TestClusterPass":                              testClusterPass,
+	"TestClusterResetNodeIPsIfEmptyString":         testClusterResetNodeIPsIfEmptyString,
 	"TestReconcileClusterUpdateSecretFail":         testReconcileClusterUpdateSecretFail,
 	"TestReconcileClusterServiceAccountSecretNil":  testReconcileClusterServiceAccountSecretNil,
 }
@@ -326,6 +327,82 @@ func testClusterPass(t *testing.T) {
 
 	clientMock.On("Update", ctx, mock.Anything).Return(nil).Once()
 	clientMock.On("Get", ctx, mock.AnythingOfType("types.NamespacedName"), mock.AnythingOfType("*v1alpha1.Cluster")).Return(nil).Once()
+	serviceAccount := &corev1.ServiceAccount{} //Secrets: nil, //secret= nil should return requeue true and requeuetime>0
+	clientMock.On("Get", ctx, mock.Anything, serviceAccount).Return(nil).Run(func(args mock.Arguments) {
+		arg := args.Get(2).(*corev1.ServiceAccount)
+		if arg.Secrets == nil {
+			arg.Secrets = make([]corev1.ObjectReference, 1)
+			arg.Secrets[0].Name = "random"
+		}
+	}).Once()
+	acsService.On("ReconcileWorkerClusterServiceAccountAndRoleBindings", ctx, requestObj.Name, requestObj.Namespace, mock.Anything).Return(ctrl.Result{}, nil)
+	clientMock.On("Get", ctx, serviceAccountSecretNamespacedName, secret).Return(nil).Run(func(args mock.Arguments) {
+		arg := args.Get(2).(*corev1.Secret)
+		if arg.Data == nil {
+			arg.Data = make(map[string][]byte, 2)
+		}
+	})
+
+	clientMock.On("Status").Return(clientMock)
+	clientMock.On("Update", mock.Anything, mock.Anything).Return(nil)
+	clientMock.On("Get", ctx, mock.Anything, mock.Anything).Return(nil)
+	clientMock.On("Update", ctx, mock.Anything, mock.Anything).Return(nil)
+	clientMock.On("Get", ctx, mock.Anything, mock.Anything).Return(nil)
+	ssgService.On("NodeIpReconciliationOfWorkerSliceGateways", ctx, mock.Anything, requestObj.Namespace).Return(nil)
+	result, err := clusterService.ReconcileCluster(ctx, requestObj)
+	require.False(t, result.Requeue)
+	require.Nil(t, err)
+	clientMock.AssertExpectations(t)
+}
+
+func testClusterResetNodeIPsIfEmptyString(t *testing.T) {
+	nsServiceMock := &mocks.INamespaceService{}
+	//var errList errorList
+	acsService := &mocks.IAccessControlService{}
+	ssgService := &mocks.IWorkerSliceGatewayService{}
+
+	clusterService := ClusterService{
+		ns:   nsServiceMock,
+		acs:  acsService,
+		sgws: ssgService,
+	}
+
+	clusterName := types.NamespacedName{
+		Namespace: "cisco",
+		Name:      "cluster-1",
+	}
+	requestObj := ctrl.Request{
+		clusterName,
+	}
+	clientMock := &utilmock.Client{}
+	cluster := &controllerv1alpha1.Cluster{}
+	//	}
+	nsResource := &corev1.Namespace{}
+
+	secret := &corev1.Secret{}
+	serviceAccountSecretNamespacedName := types.NamespacedName{
+		Namespace: requestObj.Namespace,
+		Name:      "random",
+	}
+	ctx := prepareTestContext(context.Background(), clientMock, nil)
+	clientMock.On("Get", ctx, requestObj.NamespacedName, cluster).Return(nil)
+	clientMock.On("Get", ctx, client.ObjectKey{
+		Name: requestObj.Namespace,
+	}, nsResource).Return(nil).Run(func(args mock.Arguments) {
+		arg := args.Get(2).(*corev1.Namespace)
+		if arg.Labels == nil {
+			arg.Labels = make(map[string]string)
+		}
+		arg.Labels[util.LabelName] = fmt.Sprintf(util.LabelValue, "Project", requestObj.Namespace)
+		arg.Name = "cisco"
+	})
+
+	clientMock.On("Update", ctx, mock.Anything).Return(nil).Once()
+	clientMock.On("Get", ctx, mock.AnythingOfType("types.NamespacedName"), mock.AnythingOfType("*v1alpha1.Cluster")).Return(nil).Run(func(args mock.Arguments) {
+		arg := args.Get(2).(*controllerv1alpha1.Cluster)
+		arg.Spec.NodeIPs = make([]string, 1)
+		arg.Spec.NodeIPs[0] = ""
+	}).Once()
 	serviceAccount := &corev1.ServiceAccount{} //Secrets: nil, //secret= nil should return requeue true and requeuetime>0
 	clientMock.On("Get", ctx, mock.Anything, serviceAccount).Return(nil).Run(func(args mock.Arguments) {
 		arg := args.Get(2).(*corev1.ServiceAccount)


### PR DESCRIPTION

# Description
- Added webhook validations for invalid NodeIPs
- If nodeIPs has empty string as a value, setting it to nil.

Fixes AM-7432

## How Has This Been Tested?
- [x] Unit Tests 

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [x] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

