### PR TITLE
fix(): add new cluster validations for sliceConfig

### DIFF
--- a/util/common.go
+++ b/util/common.go
@@ -209,3 +209,19 @@ func Retry(ctx context.Context, backoffLimit int, sleep time.Duration, f func() 
 	elapsed := time.Since(start)
 	return fmt.Errorf("retry failed after %d attempts (took %d seconds), last error: %s", backoffLimit, int(elapsed.Seconds()), err)
 }
+
+// Set Difference: A - B
+func DifferenceOfArray(a, b []string) (diff []string) {
+	m := make(map[string]bool)
+
+	for _, item := range b {
+		m[item] = true
+	}
+
+	for _, item := range a {
+		if _, ok := m[item]; !ok {
+			diff = append(diff, item)
+		}
+	}
+	return diff
+}


### PR DESCRIPTION

# Description
- Added new webhook validations for `SliceConfig` related to:
- - Cluster Health Status
- - Cluster Registration Status
- Minor refactors
- Updated UTs

Fixes #

## How Has This Been Tested?

- [x] Unit Tests
- [x] Manual testing

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

