### PR TITLE
fix(AM-12145): prevent updating protocol

### DIFF
--- a/service/slice_config_webhook_validation.go
+++ b/service/slice_config_webhook_validation.go
@@ -397,6 +397,10 @@ func preventUpdate(ctx context.Context, sc *controllerv1alpha1.SliceConfig, old 
 		if exists && new.Protocol != oldType.Protocol {
 			return field.Forbidden(field.NewPath("Spec").Child("SliceGatewayProvider").Child("SliceGatewayServiceType"), "updating gateway protocol is not allowed")
 		}
+		// when no protocol is specified then it's assumed to be UDP, so can't be updated to TCP
+		if !exists && new.Protocol != defaultSliceGatewayServiceProtocol {
+			return field.Forbidden(field.NewPath("Spec").Child("SliceGatewayProvider").Child("SliceGatewayServiceType"), "updating gateway protocol is not allowed")
+		}
 	}
 	return nil
 }

--- a/service/slice_config_webhook_validation.go
+++ b/service/slice_config_webhook_validation.go
@@ -398,7 +398,7 @@ func preventUpdate(ctx context.Context, sc *controllerv1alpha1.SliceConfig, old 
 			return field.Forbidden(field.NewPath("Spec").Child("SliceGatewayProvider").Child("SliceGatewayServiceType"), "updating gateway protocol is not allowed")
 		}
 		// when no protocol is specified then it's assumed to be UDP, so can't be updated to TCP
-		if !exists && new.Protocol != defaultSliceGatewayServiceProtocol {
+		if util.ContainsString(sliceConfig.Spec.Clusters, new.Cluster) && !exists && new.Protocol != defaultSliceGatewayServiceProtocol {
 			return field.Forbidden(field.NewPath("Spec").Child("SliceGatewayProvider").Child("SliceGatewayServiceType"), "updating gateway protocol is not allowed")
 		}
 	}

--- a/service/slice_config_webhook_validation_test.go
+++ b/service/slice_config_webhook_validation_test.go
@@ -157,7 +157,7 @@ func test_validateSlicegatewayServiceType(t *testing.T) {
 	require.Contains(t, err.Error(), "Cluster is not participating in slice config")
 	clientMock.AssertExpectations(t)
 
-	// if defined, cluster name should be part of slice
+	// shouldn't define service config for same cluster
 	sliceConfig.Spec.SliceGatewayProvider.SliceGatewayServiceType = []controllerv1alpha1.SliceGatewayServiceType{
 		{
 			Cluster:  "demo-cluster",
@@ -250,6 +250,20 @@ func UpdateValidateSliceConfig_PreventUpdate_SliceGatewayServiceType(t *testing.
 		{
 			Cluster:  "c1",
 			Protocol: "UDP",
+		},
+	}
+	require.NotNil(t, err)
+	err = ValidateSliceConfigUpdate(ctx, newSliceConfig, runtime.Object(&oldSliceConfig))
+	require.Contains(t, err.Error(), "Spec.SliceGatewayProvider.SliceGatewayServiceType: Forbidden:")
+	require.Contains(t, err.Error(), "updating gateway protocol is not allowed")
+	clientMock.AssertExpectations(t)
+
+	// if no protocol is defined default value is assumed to be UDP, thus protocol can't be set to TCP afterwards
+	oldSliceConfig.Spec.SliceGatewayProvider.SliceGatewayServiceType = []controllerv1alpha1.SliceGatewayServiceType{}
+	newSliceConfig.Spec.SliceGatewayProvider.SliceGatewayServiceType = []controllerv1alpha1.SliceGatewayServiceType{
+		{
+			Cluster:  "c1",
+			Protocol: "TCP",
 		},
 	}
 	require.NotNil(t, err)


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs() - The PR contains Documentation ONLY changes. 
- feat() - The PR contains new feature/enhancements.
- fix() - The PR contains a bug fix.
- chore() - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test() - Development changes related to tests.
- perf() - Changes related to performance improvements.

Example Title: 
feat(): New field addition for Cluster CRD 
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes #
when no protocol is specified then it's assumed to be UDP, so can't be updated to TCP

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [x] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

