### PR TITLE
feat(): Add backward compatibility for legacy 'Local' sliceIpamType value

### DIFF
--- a/apis/controller/v1alpha1/sliceconfig_types.go
+++ b/apis/controller/v1alpha1/sliceconfig_types.go
@@ -55,7 +55,7 @@ type SliceConfigSpec struct {
 	//+kubebuilder:default:=Application
 	SliceType            string                      `json:"sliceType,omitempty"`
 	SliceGatewayProvider *WorkerSliceGatewayProvider `json:"sliceGatewayProvider,omitempty"`
-	//+kubebuilder:validation:Enum:=Static;Dynamic
+	//+kubebuilder:validation:Enum:=Static;Dynamic;Local
 	//+kubebuilder:default:=Static
 	SliceIpamType          string   `json:"sliceIpamType,omitempty"`
 	Clusters               []string `json:"clusters,omitempty"`

--- a/apis/worker/v1alpha1/workersliceconfig_types.go
+++ b/apis/worker/v1alpha1/workersliceconfig_types.go
@@ -43,7 +43,7 @@ type WorkerSliceConfigSpec struct {
 	//+kubebuilder:default:=Application
 	SliceType            string                     `json:"sliceType,omitempty"`
 	SliceGatewayProvider WorkerSliceGatewayProvider `json:"sliceGatewayProvider,omitempty"`
-	//+kubebuilder:validation:Enum:=Static;Dynamic
+	//+kubebuilder:validation:Enum:=Static;Dynamic;Local
 	//+kubebuilder:default:=Static
 	SliceIpamType             string                    `json:"sliceIpamType,omitempty"`
 	QosProfileDetails         QOSProfile                `json:"qosProfileDetails,omitempty"`

--- a/config/crd/bases/controller.kubeslice.io_sliceconfigs.yaml
+++ b/config/crd/bases/controller.kubeslice.io_sliceconfigs.yaml
@@ -222,6 +222,7 @@ spec:
                 enum:
                 - Static
                 - Dynamic
+                - Local
                 type: string
               sliceSubnet:
                 type: string

--- a/config/crd/bases/worker.kubeslice.io_workersliceconfigs.yaml
+++ b/config/crd/bases/worker.kubeslice.io_workersliceconfigs.yaml
@@ -163,6 +163,7 @@ spec:
                 enum:
                 - Static
                 - Dynamic
+                - Local
                 type: string
               sliceName:
                 type: string

--- a/docs/dynamic-ipam/TESTS.md
+++ b/docs/dynamic-ipam/TESTS.md
@@ -90,14 +90,17 @@ This document provides visual proof of all 14 Dynamic IPAM integration tests exe
 
 ## Test 06: Static IPAM Backward Compatibility
 
-**Purpose:** Ensure Static IPAM mode doesn't trigger Dynamic IPAM resources
+**Purpose:** Ensure Static IPAM mode (including legacy "Local" type) doesn't trigger Dynamic IPAM resources
 
 **What This Tests:**
 
-- SliceConfig with `sliceIpamType: Static` - no SliceIpam created
+- CRD accepts all three enum values (Local, Static, Dynamic)
+- SliceConfig with `sliceIpamType: Local` (legacy) - no SliceIpam created
+- SliceConfig with `sliceIpamType: Static` (explicit) - no SliceIpam created
 - SliceConfig with omitted sliceIpamType (defaults to Static) - no SliceIpam created
+- Legacy "Local" value works identically to "Static"
 
-**Result:** ✅ Backward compatibility maintained
+**Result:** ✅ Backward compatibility maintained for all static IPAM types
 
 <img width="2458" height="1985" alt="test-06" src="https://github.com/user-attachments/assets/644866c0-d9d0-452f-b1ad-c7b1c96225fd" />
 
@@ -250,4 +253,3 @@ All tests demonstrate production-ready quality with:
 - ✅ Zero performance impact
 - ✅ Full state recovery
 - ✅ Accurate observability
-

--- a/docs/dynamic-ipam/TESTS.md
+++ b/docs/dynamic-ipam/TESTS.md
@@ -102,7 +102,7 @@ This document provides visual proof of all 14 Dynamic IPAM integration tests exe
 
 **Result:** ✅ Backward compatibility maintained for all static IPAM types
 
-<img width="2458" height="1985" alt="test-06" src="https://github.com/user-attachments/assets/644866c0-d9d0-452f-b1ad-c7b1c96225fd" />
+<img width="2458" height="1985" alt="test-06" src="https://github.com/user-attachments/assets/5bc40b69-0181-4338-9087-676ae5792695" />
 
 ---
 


### PR DESCRIPTION
## Description

This PR adds backward compatibility for the legacy `sliceIpamType: Local` value to prevent breaking changes for existing SliceConfig resources.

**Changes:**
- Updated CRD enum to accept `Local`, `Static`, and `Dynamic` values
- Existing controller logic already treats "Local" as "Static" (via else branch)
- Default value remains `Static` for new resources

**Impact:**
- Zero breaking changes for existing deployments
- Legacy SliceConfigs with `sliceIpamType: Local` continue to work
- "Local" and "Static" are functionally equivalent (both use static IPAM)

Fixes #(issue number if applicable)

## How Has This Been Tested?

- [x] Test 06: Static IPAM Backward Compatibility (updated)
  - Verified CRD accepts all three enum values (Local, Static, Dynamic)
  - Created SliceConfig with `sliceIpamType: Local` - no SliceIpam resource created ✅
  - Created SliceConfig with `sliceIpamType: Static` - no SliceIpam resource created ✅
  - Created SliceConfig with omitted sliceIpamType (defaults to Static) - no SliceIpam resource created ✅
  - All three types coexist without interference ✅

**Test Environment:** Real Kubernetes (kind cluster v1.30.0)  
**Test Results:** 7/7 steps passed (100% success)  
**Test Log:** [`dynamic-ipam-tests/test-06`](https://github.com/user-attachments/assets/5bc40b69-0181-4338-9087-676ae5792695)

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR requires documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [x] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?

```release-note

```
