### PR TITLE
feat(topology): implement Hub-and-Spoke Partial Mesh MVP (issue #300)

### DIFF
--- a/docs/adr/hub-and-spoke-topology.md
+++ b/docs/adr/hub-and-spoke-topology.md
@@ -1,6 +1,6 @@
 # ADR: Partial Mesh MVP — Hub-and-Spoke Topology
 
-- **Status:** Accepted
+- **Status:** Proposed
 - **Issue:** [#300](https://github.com/kubeslice/kubeslice-controller/issues/300)
 - **Date:** 2026-05-05
 

--- a/docs/adr/hub-and-spoke-topology.md
+++ b/docs/adr/hub-and-spoke-topology.md
@@ -1,0 +1,198 @@
+# ADR: Partial Mesh MVP — Hub-and-Spoke Topology
+
+- **Status:** Accepted
+- **Issue:** [#300](https://github.com/kubeslice/kubeslice-controller/issues/300)
+- **Date:** 2026-05-05
+
+---
+
+## Context
+
+KubeSlice currently establishes a **full mesh** of VPN gateways between all member clusters of a Slice. For N clusters this creates N×(N−1)/2 bidirectional gateway pairs. While full mesh delivers the lowest latency between any two clusters, it becomes operationally expensive at scale:
+
+- 5 clusters → 10 gateway pairs, 10 cert-rotation cycles, 10 VPN tunnels
+- 10 clusters → 45 gateway pairs
+
+Many real workloads follow a **hub-and-spoke** pattern (e.g., centralised services cluster feeding edge/regional clusters). In such cases spoke-to-spoke links are unnecessary; eliminating them reduces resource usage, operational overhead, and failure blast-radius.
+
+---
+
+## Decision
+
+Introduce a **`HubAndSpoke`** topology mode as the first and only topology type in the Partial Mesh MVP.
+
+### Scope
+
+**In scope:**
+- API/CRD changes to `SliceConfig` (`topologyMode`, `hubs`, `spokes`)
+- Controller computes desired gateway edges and reconciles `WorkerSliceGateway` objects
+- `SliceConfig.Status.Topology` aggregates readiness summary
+- Webhook validation for the new fields
+- Kubernetes observability events for topology state
+
+**Out of scope (non-goals for MVP):**
+- Arbitrary adjacency-list / matrix graphs
+- Auto hub-selection or optimization
+- Multiple topology modes simultaneously
+- Large-scale performance tuning
+
+---
+
+## Spec Examples (YAML)
+
+### Example 1: One hub, spokes default to all other member clusters
+
+```yaml
+apiVersion: controller.kubeslice.io/v1alpha1
+kind: SliceConfig
+metadata:
+  name: my-slice
+  namespace: kubeslice-demo
+spec:
+  sliceSubnet: 192.168.0.0/16
+  topologyMode: HubAndSpoke
+  hubs:
+    - hub-cluster
+  clusters:
+    - hub-cluster
+    - spoke-a
+    - spoke-b
+    - spoke-c
+```
+
+Resulting edges: `hub-cluster ↔ spoke-a`, `hub-cluster ↔ spoke-b`, `hub-cluster ↔ spoke-c`  
+*(No spoke-a ↔ spoke-b or spoke-a ↔ spoke-c links)*
+
+### Example 2: Two hubs, explicit spoke list
+
+```yaml
+spec:
+  topologyMode: HubAndSpoke
+  hubs:
+    - hub-east
+    - hub-west
+  spokes:
+    - edge-1
+    - edge-2
+  clusters:
+    - hub-east
+    - hub-west
+    - edge-1
+    - edge-2
+    - edge-3   # edge-3 is excluded because spokes list is explicit
+```
+
+Resulting edges: `hub-east ↔ edge-1`, `hub-east ↔ edge-2`, `hub-west ↔ edge-1`, `hub-west ↔ edge-2`
+
+### Example 3: Full mesh (no topologyMode set — backward compatible)
+
+```yaml
+spec:
+  clusters:
+    - cluster-a
+    - cluster-b
+    - cluster-c
+  # topologyMode not set → full mesh (default existing behaviour)
+```
+
+---
+
+## Edge Computation Rules
+
+The controller computes the set of desired gateway pairs using `computeDesiredPairs()`:
+
+| Condition | Result |
+|-----------|--------|
+| `topologyMode` is empty | Full mesh: all N×(N−1)/2 pairs |
+| `topologyMode: HubAndSpoke` | Only Hub↔Spoke pairs (see below) |
+| `spokes` is empty | All clusters not in `hubs` become spokes automatically |
+| `spokes` is non-empty | Only the listed clusters are spokes |
+| Hub equals a spoke | Rejected by webhook validation |
+
+**HubAndSpoke pair generation:**
+```
+For each hub H in hubs:
+  For each spoke S in effective_spokes:
+    if H ≠ S:
+      add pair (H, S)
+```
+
+Pairs are **bidirectional**: a pair `(H, S)` generates one server-gateway on H and one client-gateway on S.
+
+**Obsolete gateway cleanup:** Any existing `WorkerSliceGateway` whose pair is not in the desired set is deleted during reconciliation.
+
+---
+
+## Validation Rules and Error Handling
+
+All rules are enforced by the admission webhook (`validateTopology`):
+
+| Rule | Error type | Message |
+|------|-----------|---------|
+| `topologyMode` set to unknown value | `Invalid` | `"unsupported topology mode"` |
+| `hubs` or `spokes` non-empty but `topologyMode` is empty | `Invalid` | `"TopologyMode is required when hubs or spokes are set"` |
+| `hubs` list is empty when `topologyMode: HubAndSpoke` | `Required` | `"at least one hub is required for HubAndSpoke topology"` |
+| `hubs` list has more than 2 entries | `Invalid` | `"HubAndSpoke topology supports a maximum of 2 hub clusters"` |
+| Duplicate cluster names in `hubs` | `Duplicate` | field path `Spec.Hubs` |
+| Duplicate cluster names in `spokes` | `Duplicate` | field path `Spec.Spokes` |
+| Hub cluster not in `spec.clusters` | `Invalid` | `"hub must be part of clusters"` |
+| Spoke cluster not in `spec.clusters` | `Invalid` | `"spoke must be part of clusters"` |
+| A cluster appears in both `hubs` and `spokes` | `Invalid` | `"spoke cannot also be a hub"` |
+
+---
+
+## Topology Status (Observability)
+
+After each reconciliation, `SliceConfig.Status.Topology` is updated:
+
+```yaml
+status:
+  topology:
+    mode: HubAndSpoke
+    expectedConnections: 4   # number of desired hub↔spoke pairs
+    createdConnections: 4    # number of WorkerSliceGateways matching desired pairs
+    ready: true              # true when createdConnections == expectedConnections
+```
+
+### Kubernetes Events
+
+| Event | Type | Trigger |
+|-------|------|---------|
+| `SliceTopologyHubAndSpokeEnabled` | Normal | Each reconcile when `topologyMode: HubAndSpoke` is set |
+| `SliceTopologyReady` | Normal | When `createdConnections == expectedConnections` |
+| `SliceTopologyDegraded` | Warning | When `createdConnections < expectedConnections` |
+
+---
+
+## Upgrade / Backward Compatibility Notes
+
+1. **Existing slices without `topologyMode`** continue to behave as full mesh. No migration is required.
+2. **Adding `topologyMode: HubAndSpoke` to an existing slice** triggers immediate cleanup of non-hub-spoke gateway pairs during the next reconciliation. This is a **disruptive operation** for spoke-to-spoke traffic — operators should plan a maintenance window.
+3. **Changing hubs** (e.g., swapping hub-east for hub-west) causes the old hub's gateway pairs to be deleted and new pairs to be created. The topology status will transition through `Degraded → Ready` while new certs are generated.
+4. **Removing `topologyMode`** (reverting to full mesh) is not yet supported via webhook (`preventUpdate` will reject changes to immutable fields in a future release). Currently, delete and recreate the SliceConfig.
+5. The `TopologyStatus` sub-resource is additive — older controllers that do not understand it will ignore the field.
+
+---
+
+## Invariants
+
+- A hub **must** be a member of `spec.clusters`.
+- A spoke **must** be a member of `spec.clusters`.
+- A cluster **cannot** appear in both `hubs` and `spokes`.
+- `hubs` must contain **1 or 2** clusters (MVP constraint).
+- When `spokes` is empty, all clusters in `spec.clusters` not in `hubs` automatically become spokes.
+- If all clusters are hubs (i.e., effective spokes list is empty after defaulting), no gateway pairs are created and `TopologyStatus.Ready` is `true` with `expectedConnections: 0`.
+
+---
+
+## Consequences
+
+### Positive
+- Reduces gateway/cert count significantly for hub-spoke workload patterns
+- Simpler failure domain: a spoke outage does not affect other spokes
+- Aligns with common multi-cluster deployment topologies (e.g., central management + edge clusters)
+
+### Negative / Trade-offs
+- Spoke-to-spoke communication must route through a hub (increased latency for cross-spoke traffic)
+- Hub is a single point of failure for spokes that rely on cross-cluster services
+- With 2 hubs, each spoke maintains 2 tunnels instead of 1 (mitigated by the overall reduction vs full mesh)

--- a/events/events_generated.go
+++ b/events/events_generated.go
@@ -734,6 +734,30 @@ var EventsMap = map[events.EventName]*events.EventSchema{
 		ReportingController: "controller",
 		Message:             "Warning - Certificate Creation job Failed",
 	},
+	"SliceTopologyHubAndSpokeEnabled": {
+		Name:                "SliceTopologyHubAndSpokeEnabled",
+		Reason:              "SliceTopologyHubAndSpokeEnabled",
+		Action:              "SetTopologyMode",
+		Type:                events.EventTypeNormal,
+		ReportingController: "controller",
+		Message:             "Slice topology mode set to HubAndSpoke.",
+	},
+	"SliceTopologyReady": {
+		Name:                "SliceTopologyReady",
+		Reason:              "SliceTopologyReady",
+		Action:              "TopologyStatusUpdate",
+		Type:                events.EventTypeNormal,
+		ReportingController: "controller",
+		Message:             "All expected HubAndSpoke connections are established. Topology is ready.",
+	},
+	"SliceTopologyDegraded": {
+		Name:                "SliceTopologyDegraded",
+		Reason:              "SliceTopologyDegraded",
+		Action:              "TopologyStatusUpdate",
+		Type:                events.EventTypeWarning,
+		ReportingController: "controller",
+		Message:             "HubAndSpoke topology is degraded: one or more expected connections are missing.",
+	},
 }
 
 var (
@@ -826,4 +850,7 @@ var (
 	EventCertificatesRenewNow                 events.EventName = "CertificatesRenewNow"
 	EventIllegalVPNKeyRotationConfigDelete    events.EventName = "IllegalVPNKeyRotationConfigDelete"
 	EventCertificateJobFailed                 events.EventName = "CertificateJobFailed"
+	EventSliceTopologyHubAndSpokeEnabled      events.EventName = "SliceTopologyHubAndSpokeEnabled"
+	EventSliceTopologyReady                   events.EventName = "SliceTopologyReady"
+	EventSliceTopologyDegraded               events.EventName = "SliceTopologyDegraded"
 )

--- a/service/slice_config_service.go
+++ b/service/slice_config_service.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/kubeslice/kubeslice-controller/apis/controller/v1alpha1"
+	workerv1alpha1 "github.com/kubeslice/kubeslice-controller/apis/worker/v1alpha1"
 	"github.com/kubeslice/kubeslice-controller/events"
 	"github.com/kubeslice/kubeslice-controller/util"
 	corev1 "k8s.io/api/core/v1"
@@ -187,7 +188,13 @@ func (s *SliceConfigService) ReconcileSliceConfig(ctx context.Context, req ctrl.
 
 	if sliceConfig.Spec.OverlayNetworkDeploymentMode == v1alpha1.NONET {
 		err = s.ms.CreateMinimalWorkerSliceConfigForNoNetworkSlice(ctx, sliceConfig.Spec.Clusters, req.Namespace, ownershipLabel, sliceConfig.Name)
-		return ctrl.Result{}, err
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if err := s.updateTopologyStatus(ctx, sliceConfig, ownershipLabel, req.Namespace); err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
 	}
 
 	// Step 4: Creation of worker slice Objects and Cluster Labels
@@ -204,11 +211,37 @@ func (s *SliceConfigService) ReconcileSliceConfig(ctx context.Context, req ctrl.
 	}
 
 	// Step 5: Create gateways with minimum specification
-	_, err = s.sgs.CreateMinimumWorkerSliceGateways(ctx, sliceConfig.Name, sliceConfig.Spec.Clusters, req.Namespace, ownershipLabel, clusterMap, sliceConfig.Spec.SliceSubnet, clusterCidr, sliceGwSvcTypeMap)
+	_, err = s.sgs.CreateMinimumWorkerSliceGateways(
+		ctx,
+		sliceConfig.Name,
+		sliceConfig.Spec.Clusters,
+		req.Namespace,
+		ownershipLabel,
+		clusterMap,
+		sliceConfig.Spec.SliceSubnet,
+		clusterCidr,
+		sliceGwSvcTypeMap,
+		sliceConfig.Spec.TopologyMode,
+		sliceConfig.Spec.Hubs,
+		sliceConfig.Spec.Spokes,
+	)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 	logger.Infof("sliceConfig %v reconciled", req.NamespacedName)
+
+	// Fire HubAndSpoke topology enabled event on every reconcile when mode is set
+	if sliceConfig.Spec.TopologyMode == v1alpha1.TopologyModeHubAndSpoke {
+		eventRecorder := util.CtxEventRecorder(ctx).
+			WithProject(util.GetProjectName(sliceConfig.Namespace)).
+			WithNamespace(sliceConfig.Namespace).
+			WithSlice(sliceConfig.Name)
+		util.RecordEvent(ctx, eventRecorder, sliceConfig, nil, events.EventSliceTopologyHubAndSpokeEnabled)
+	}
+
+	if err := s.updateTopologyStatus(ctx, sliceConfig, ownershipLabel, req.Namespace); err != nil {
+		return ctrl.Result{}, err
+	}
 
 	// Step 6: Create VPNKeyRotation CR
 	// TODO(rahul): handle change in rotation interval
@@ -239,6 +272,70 @@ func (s *SliceConfigService) ReconcileSliceConfig(ctx context.Context, req ctrl.
 	}
 
 	return ctrl.Result{}, nil
+}
+
+func (s *SliceConfigService) updateTopologyStatus(ctx context.Context, sliceConfig *v1alpha1.SliceConfig, ownerLabel map[string]string, namespace string) error {
+	eventRecorder := util.CtxEventRecorder(ctx).
+		WithProject(util.GetProjectName(namespace)).
+		WithNamespace(namespace).
+		WithSlice(sliceConfig.Name)
+
+	expectedPairs := buildExpectedPairKeySet(sliceConfig)
+	createdConnections := 0
+	if len(expectedPairs) > 0 {
+		gateways, err := s.sgs.ListWorkerSliceGateways(ctx, ownerLabel, namespace)
+		if err != nil {
+			return err
+		}
+		createdConnections = countCreatedConnections(gateways, expectedPairs)
+	}
+	ready := len(expectedPairs) == createdConnections
+
+	// Fire topology observability events for HubAndSpoke mode
+	if sliceConfig.Spec.TopologyMode == v1alpha1.TopologyModeHubAndSpoke {
+		if ready {
+			util.RecordEvent(ctx, eventRecorder, sliceConfig, nil, events.EventSliceTopologyReady)
+		} else {
+			util.RecordEvent(ctx, eventRecorder, sliceConfig, nil, events.EventSliceTopologyDegraded)
+		}
+	}
+
+	sliceConfig.Status.Topology = &v1alpha1.TopologyStatus{
+		Mode:                sliceConfig.Spec.TopologyMode,
+		ExpectedConnections: len(expectedPairs),
+		CreatedConnections:  createdConnections,
+		Ready:               ready,
+	}
+	kubeSliceCtx := util.GetKubeSliceControllerRequestContext(ctx)
+	return kubeSliceCtx.Status().Update(ctx, sliceConfig)
+}
+
+func buildExpectedPairKeySet(sliceConfig *v1alpha1.SliceConfig) map[string]struct{} {
+	if sliceConfig.Spec.OverlayNetworkDeploymentMode == v1alpha1.NONET {
+		return map[string]struct{}{}
+	}
+	pairs := computeDesiredPairs(sliceConfig.Spec.Clusters, sliceConfig.Spec.TopologyMode, sliceConfig.Spec.Hubs, sliceConfig.Spec.Spokes)
+	result := make(map[string]struct{}, len(pairs))
+	for _, pair := range pairs {
+		result[buildPairKey(pair.source, pair.destination)] = struct{}{}
+	}
+	return result
+}
+
+func countCreatedConnections(gateways []workerv1alpha1.WorkerSliceGateway, expected map[string]struct{}) int {
+	if len(expected) == 0 {
+		return 0
+	}
+	seen := make(map[string]struct{})
+	for _, gateway := range gateways {
+		clusterSource := gateway.Spec.LocalGatewayConfig.ClusterName
+		clusterDestination := gateway.Spec.RemoteGatewayConfig.ClusterName
+		pairKey := buildPairKey(clusterSource, clusterDestination)
+		if _, ok := expected[pairKey]; ok {
+			seen[pairKey] = struct{}{}
+		}
+	}
+	return len(seen)
 }
 
 // checkForProjectNamespace is a function to check the namespace is in proper format

--- a/service/slice_config_webhook_validation.go
+++ b/service/slice_config_webhook_validation.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"strconv"
 	"strings"
 	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -45,6 +46,9 @@ func ValidateSliceConfigCreate(ctx context.Context, sliceConfig *controllerv1alp
 		return nil, apierrors.NewInvalid(schema.GroupKind{Group: apiGroupKubeSliceControllers, Kind: "SliceConfig"}, sliceConfig.Name, field.ErrorList{err})
 	}
 	if err := validateClustersOnCreate(ctx, sliceConfig); err != nil {
+		return nil, apierrors.NewInvalid(schema.GroupKind{Group: apiGroupKubeSliceControllers, Kind: "SliceConfig"}, sliceConfig.Name, field.ErrorList{err})
+	}
+	if err := validateTopology(sliceConfig); err != nil {
 		return nil, apierrors.NewInvalid(schema.GroupKind{Group: apiGroupKubeSliceControllers, Kind: "SliceConfig"}, sliceConfig.Name, field.ErrorList{err})
 	}
 	if err := validateApplicationNamespaces(ctx, sliceConfig); err != nil {
@@ -95,6 +99,9 @@ func ValidateSliceConfigUpdate(ctx context.Context, sliceConfig *controllerv1alp
 
 	// Common validations to be done irrespective of overlay network deployment mode
 	if err := validateClustersOnUpdate(ctx, sliceConfig, old); err != nil {
+		return nil, apierrors.NewInvalid(schema.GroupKind{Group: apiGroupKubeSliceControllers, Kind: "SliceConfig"}, sliceConfig.Name, field.ErrorList{err})
+	}
+	if err := validateTopology(sliceConfig); err != nil {
 		return nil, apierrors.NewInvalid(schema.GroupKind{Group: apiGroupKubeSliceControllers, Kind: "SliceConfig"}, sliceConfig.Name, field.ErrorList{err})
 	}
 	if err := validateApplicationNamespaces(ctx, sliceConfig); err != nil {
@@ -372,6 +379,45 @@ func validateClustersOnUpdate(ctx context.Context, sliceConfig *controllerv1alph
 					return field.Invalid(field.NewPath("Spec").Child("SliceSubnet"), sliceConfig.Spec.SliceSubnet, "must not overlap with CniSubnet "+cniSubnet+" of cluster "+clusterName)
 				}
 			}
+		}
+	}
+	return nil
+}
+
+func validateTopology(sliceConfig *controllerv1alpha1.SliceConfig) *field.Error {
+	mode := sliceConfig.Spec.TopologyMode
+	if mode == "" {
+		if len(sliceConfig.Spec.Hubs) > 0 || len(sliceConfig.Spec.Spokes) > 0 {
+			return field.Invalid(field.NewPath("Spec").Child("TopologyMode"), mode, "TopologyMode is required when hubs or spokes are set")
+		}
+		return nil
+	}
+	if mode != controllerv1alpha1.TopologyModeHubAndSpoke {
+		return field.Invalid(field.NewPath("Spec").Child("TopologyMode"), mode, "unsupported topology mode")
+	}
+	if len(sliceConfig.Spec.Hubs) == 0 {
+		return field.Required(field.NewPath("Spec").Child("Hubs"), "at least one hub is required for HubAndSpoke topology")
+	}
+	if len(sliceConfig.Spec.Hubs) > 2 {
+		return field.Invalid(field.NewPath("Spec").Child("Hubs"), sliceConfig.Spec.Hubs, "HubAndSpoke topology supports a maximum of 2 hub clusters")
+	}
+	if duplicate, value := util.CheckDuplicateInArray(sliceConfig.Spec.Hubs); duplicate {
+		return field.Duplicate(field.NewPath("Spec").Child("Hubs"), strings.Join(value, ", "))
+	}
+	if duplicate, value := util.CheckDuplicateInArray(sliceConfig.Spec.Spokes); duplicate {
+		return field.Duplicate(field.NewPath("Spec").Child("Spokes"), strings.Join(value, ", "))
+	}
+	for _, hub := range sliceConfig.Spec.Hubs {
+		if !util.ContainsString(sliceConfig.Spec.Clusters, hub) {
+			return field.Invalid(field.NewPath("Spec").Child("Hubs"), hub, "hub must be part of clusters")
+		}
+	}
+	for _, spoke := range sliceConfig.Spec.Spokes {
+		if !util.ContainsString(sliceConfig.Spec.Clusters, spoke) {
+			return field.Invalid(field.NewPath("Spec").Child("Spokes"), spoke, "spoke must be part of clusters")
+		}
+		if util.ContainsString(sliceConfig.Spec.Hubs, spoke) {
+			return field.Invalid(field.NewPath("Spec").Child("Spokes"), spoke, "spoke cannot also be a hub")
 		}
 	}
 	return nil

--- a/service/slice_config_webhook_validation_test.go
+++ b/service/slice_config_webhook_validation_test.go
@@ -90,6 +90,11 @@ var SliceConfigWebhookValidationTestBed = map[string]func(*testing.T){
 	"SliceConfigWebhookValidation_UpdateValidateSliceConfigWithExternalGatewayConfigHasDuplicateClusters":                      UpdateValidateSliceConfigWithExternalGatewayConfigHasDuplicateClusters,
 	"SliceConfigWebhookValidation_UpdateValidateSliceConfigWithoutErrors":                                                      UpdateValidateSliceConfigWithoutErrors,
 	"SliceConfigWebhookValidation_UpdateValidateSliceGatewayServiceType":                                                       UpdateValidateSliceConfig_PreventUpdate_SliceGatewayServiceType,
+	"SliceConfigWebhookValidation_ValidateTopologyHubNotInClusters":                                                            ValidateTopologyHubNotInClusters,
+	"SliceConfigWebhookValidation_ValidateTopologyDuplicateHubs":                                                               ValidateTopologyDuplicateHubs,
+	"SliceConfigWebhookValidation_ValidateTopologySpokesDefault":                                                               ValidateTopologySpokesDefault,
+	"SliceConfigWebhookValidation_ValidateTopologySpokeIsHub":                                                                  ValidateTopologySpokeIsHub,
+	"SliceConfigWebhookValidation_ValidateTopologyMaxHubs":                                                                     ValidateTopologyMaxHubs,
 	"SliceConfigWebhookValidation_DeleteValidateSliceConfigWithApplicationNamespacesNotEmpty":                                  DeleteValidateSliceConfigWithApplicationNamespacesAndAllowedNamespacesNotEmpty,
 	"SliceConfigWebhookValidation_DeleteValidateSliceConfigWithOnboardedAppNamespacesNotEmpty":                                 DeleteValidateSliceConfigWithOnboardedAppNamespacesNotEmpty,
 	"SliceConfigWebhookValidation_validateAllowedNamespacesWithDuplicateClusters":                                              ValidateAllowedNamespacesWithDuplicateClusters,
@@ -205,6 +210,73 @@ func test_validateSlicegatewayServiceType(t *testing.T) {
 	sliceConfig.Spec.Clusters = []string{"demo-cluster", "c2", "cx"}
 	err = validateSlicegatewayServiceType(ctx, sliceConfig)
 	require.Nil(t, err)
+	clientMock.AssertExpectations(t)
+}
+
+func ValidateTopologyHubNotInClusters(t *testing.T) {
+	name := "test-slice"
+	namespace := "test-ns"
+	clientMock, sliceConfig, _ := setupSliceConfigWebhookValidationTest(name, namespace)
+	sliceConfig.Spec.TopologyMode = controllerv1alpha1.TopologyModeHubAndSpoke
+	sliceConfig.Spec.Hubs = []string{"c1"}
+	sliceConfig.Spec.Clusters = []string{"c2"}
+	err := validateTopology(sliceConfig)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "hub must be part of clusters")
+	clientMock.AssertExpectations(t)
+}
+
+func ValidateTopologyDuplicateHubs(t *testing.T) {
+	name := "test-slice"
+	namespace := "test-ns"
+	clientMock, sliceConfig, _ := setupSliceConfigWebhookValidationTest(name, namespace)
+	sliceConfig.Spec.TopologyMode = controllerv1alpha1.TopologyModeHubAndSpoke
+	sliceConfig.Spec.Hubs = []string{"c1", "c1"}
+	sliceConfig.Spec.Clusters = []string{"c1", "c2"}
+	err := validateTopology(sliceConfig)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Duplicate value")
+	clientMock.AssertExpectations(t)
+}
+
+func ValidateTopologySpokesDefault(t *testing.T) {
+	name := "test-slice"
+	namespace := "test-ns"
+	clientMock, sliceConfig, _ := setupSliceConfigWebhookValidationTest(name, namespace)
+	sliceConfig.Spec.TopologyMode = controllerv1alpha1.TopologyModeHubAndSpoke
+	sliceConfig.Spec.Hubs = []string{"c1"}
+	sliceConfig.Spec.Clusters = []string{"c1", "c2"}
+	err := validateTopology(sliceConfig)
+	require.Nil(t, err)
+	clientMock.AssertExpectations(t)
+}
+
+func ValidateTopologySpokeIsHub(t *testing.T) {
+	name := "test-slice"
+	namespace := "test-ns"
+	clientMock, sliceConfig, _ := setupSliceConfigWebhookValidationTest(name, namespace)
+	sliceConfig.Spec.TopologyMode = controllerv1alpha1.TopologyModeHubAndSpoke
+	sliceConfig.Spec.Hubs = []string{"c1"}
+	sliceConfig.Spec.Spokes = []string{"c1", "c2"}
+	sliceConfig.Spec.Clusters = []string{"c1", "c2"}
+	err := validateTopology(sliceConfig)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "spoke cannot also be a hub")
+	clientMock.AssertExpectations(t)
+}
+
+// ValidateTopologyMaxHubs verifies that specifying more than 2 hubs is rejected.
+// Issue #300 specifies: "hubs: 1–2 hub cluster names (must be members of the slice)"
+func ValidateTopologyMaxHubs(t *testing.T) {
+	name := "test-slice"
+	namespace := "test-ns"
+	clientMock, sliceConfig, _ := setupSliceConfigWebhookValidationTest(name, namespace)
+	sliceConfig.Spec.TopologyMode = controllerv1alpha1.TopologyModeHubAndSpoke
+	sliceConfig.Spec.Hubs = []string{"c1", "c2", "c3"} // 3 hubs — exceeds max of 2
+	sliceConfig.Spec.Clusters = []string{"c1", "c2", "c3", "c4"}
+	err := validateTopology(sliceConfig)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "HubAndSpoke topology supports a maximum of 2 hub clusters")
 	clientMock.AssertExpectations(t)
 }
 


### PR DESCRIPTION
# Description


This PR implements the Hub-and-Spoke topology mode for KubeSlice as part of the Partial Mesh MVP. Currently, KubeSlice defaults to a full-mesh topology where every cluster connects to every other cluster. This new mode allows users to define specific clusters as Hubs and others as Spokes, where connectivity is only established between Hubs and Spokes, significantly reducing the number of VPN tunnels and certificate rotations for large slices.

### Key changes:
- **API/CRD**: Updated `SliceConfig` to support `topologyMode`, `hubs`, and `spokes` fields.
- **Logic**: Implemented edge computation logic in `worker_slice_gateway_service.go` to ensure only Hub-to-Spoke pairs are generated.
- **Validation**: Enhanced webhook validation in `slice_config_webhook_validation.go` to enforce 1-2 hubs constraint, prevent hub/spoke overlap, and ensure membership integrity.
- **Observability**: Implemented topology health aggregation in `slice_config_service.go` and added new Kubernetes events: `SliceTopologyHubAndSpokeEnabled`, `SliceTopologyReady`, and `SliceTopologyDegraded`.
- **Documentation**: Authored the primary Architecture Decision Record (ADR) in `docs/adr/hub-and-spoke-topology.md`.

Fixes #300

## How Has This Been Tested?
- **Unit Tests**: Added/updated tests in `service/slice_config_webhook_validation_test.go` and `service/worker_slice_gateway_service_test.go`.
- **Max Hubs Validation**: Verified that specifying >2 hubs returns an error.
- **Edge Computation**: Verified that `computeDesiredPairs` correctly generates only Hub-to-Spoke links.
- **Build Verification**: Ran `go build ./...` to ensure compilation integrity.

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR requires documentation updates?
* [x] I've updated documentation as required by this PR (ADR created).
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [x] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?
No. This change is backward compatible. If `topologyMode` is not specified, it defaults to the existing Full Mesh behavior.

```release-note
Implemented Hub-and-Spoke topology mode for SliceConfig to support Partial Mesh MVP.
