### PR TITLE
fix(): persist VPN key rotation in-progress state in CR status

### DIFF
--- a/apis/controller/v1alpha1/vpnkeyrotation_types.go
+++ b/apis/controller/v1alpha1/vpnkeyrotation_types.go
@@ -46,6 +46,10 @@ type VpnKeyRotationStatus struct {
 	CurrentRotationState map[string]StatusOfKeyRotation `json:"currentRotationState,omitempty"`
 	// This is circular array of last n number of rotation status.
 	StatusHistory map[string][]StatusOfKeyRotation `json:"statusHistory,omitempty"`
+	// RotationInProgress indicates that cert-generation jobs have been triggered
+	// for this slice and are not yet complete. Persisted in etcd so that pod
+	// restarts and leader-election failovers preserve the state correctly.
+	RotationInProgress bool `json:"rotationInProgress,omitempty"`
 }
 
 // StatusOfKeyRotation represent per gateway status

--- a/config/crd/bases/controller.kubeslice.io_vpnkeyrotations.yaml
+++ b/config/crd/bases/controller.kubeslice.io_vpnkeyrotations.yaml
@@ -88,6 +88,10 @@ spec:
                   type: object
                 description: This is map of gateway name to the current rotation state
                 type: object
+              rotationInProgress:
+                description: RotationInProgress indicates that cert-generation jobs
+                  have been triggered for this slice and are not yet complete.
+                type: boolean
               statusHistory:
                 additionalProperties:
                   items:

--- a/service/vpn_key_rotation_service.go
+++ b/service/vpn_key_rotation_service.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"sync/atomic"
 	"time"
 
 	controllerv1alpha1 "github.com/kubeslice/kubeslice-controller/apis/controller/v1alpha1"
@@ -43,9 +42,8 @@ type IVpnKeyRotationService interface {
 }
 
 type VpnKeyRotationService struct {
-	wsgs                  IWorkerSliceGatewayService
-	wscs                  IWorkerSliceConfigService
-	jobCreationInProgress atomic.Bool
+	wsgs IWorkerSliceGatewayService
+	wscs IWorkerSliceConfigService
 }
 
 // JobStatus represents the status of a job.
@@ -266,14 +264,17 @@ func (v *VpnKeyRotationService) reconcileVpnKeyRotationConfig(ctx context.Contex
 
 	} else {
 		if now.After(copyVpnConfig.Spec.CertificateExpiryTime.Time) {
-			if !v.jobCreationInProgress.Load() {
+			if !copyVpnConfig.Status.RotationInProgress {
 				if err := v.triggerJobsForCertCreation(ctx, copyVpnConfig, s); err != nil {
 					logger.Error("error creating new certs", err)
 					// register an event
 					util.RecordEvent(ctx, eventRecorder, copyVpnConfig, nil, events.EventCertificateJobCreationFailed)
 					return ctrl.Result{}, nil, err
 				}
-				v.jobCreationInProgress.Store(true)
+				copyVpnConfig.Status.RotationInProgress = true
+				if err := util.UpdateStatus(ctx, copyVpnConfig); err != nil {
+					return ctrl.Result{}, nil, err
+				}
 				logger.Debugf("jobs triggered for creating new certs for slice %s", s.Name)
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil, nil
 			}
@@ -302,8 +303,10 @@ func (v *VpnKeyRotationService) reconcileVpnKeyRotationConfig(ctx context.Contex
 			if err := util.UpdateResource(ctx, copyVpnConfig); err != nil {
 				return ctrl.Result{}, nil, err
 			}
-			// restore the variable jobCreationInProgress to false
-			v.jobCreationInProgress.Store(false)
+			copyVpnConfig.Status.RotationInProgress = false
+			if err := util.UpdateStatus(ctx, copyVpnConfig); err != nil {
+				return ctrl.Result{}, nil, err
+			}
 			//register an event
 			util.RecordEvent(ctx, eventRecorder, copyVpnConfig, nil, events.EventVPNKeyRotationStart)
 		}

--- a/service/vpn_key_rotation_service_test.go
+++ b/service/vpn_key_rotation_service_test.go
@@ -401,6 +401,7 @@ func Test_reconcileVpnKeyRotationConfig(t *testing.T) {
 	ts := metav1.NewTime(time.Date(2021, 06, 16, 20, 34, 58, 651387237, time.UTC))
 	expiryTs := metav1.NewTime(ts.AddDate(0, 0, 30).Add(-1 * time.Hour))
 	newTs := metav1.NewTime(time.Date(2021, 07, 16, 20, 34, 58, 651387237, time.UTC))
+	newExpiryTs := metav1.NewTime(newTs.AddDate(0, 0, 30).Add(-1 * time.Hour))
 	testCases := []reconcileVpnKeyRotationConfigTestCase{
 		{
 			name: "should update CertCreation TS and Expiry TS when it is nil",
@@ -474,6 +475,56 @@ func Test_reconcileVpnKeyRotationConfig(t *testing.T) {
 			updateRet1:      nil,
 			now:             newTs,
 			reconcileResult: ctrl.Result{RequeueAfter: 30 * time.Second},
+		},
+		{
+			name: "should clear RotationInProgress and update timestamps after jobs complete",
+			arg1: &controllerv1alpha1.VpnKeyRotation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-slice",
+					Namespace: "test-ns",
+				},
+				Spec: controllerv1alpha1.VpnKeyRotationSpec{
+					SliceName:               "test-slice",
+					Clusters:                []string{"worker-1", "worker-2"},
+					RotationInterval:        30,
+					CertificateCreationTime: &ts,
+					CertificateExpiryTime:   &expiryTs,
+					RotationCount:           1,
+				},
+				Status: controllerv1alpha1.VpnKeyRotationStatus{
+					RotationInProgress: true,
+				},
+			},
+			arg2: &controllerv1alpha1.SliceConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-slice",
+					Namespace: "test-ns",
+				},
+			},
+			expectedErr: nil,
+			expectedResp: &controllerv1alpha1.VpnKeyRotation{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-slice",
+					Namespace: "test-ns",
+				},
+				Spec: controllerv1alpha1.VpnKeyRotationSpec{
+					SliceName:               "test-slice",
+					Clusters:                []string{"worker-1", "worker-2"},
+					RotationInterval:        30,
+					CertificateCreationTime: &newTs,
+					CertificateExpiryTime:   &newExpiryTs,
+					RotationCount:           2,
+				},
+				Status: controllerv1alpha1.VpnKeyRotationStatus{
+					RotationInProgress: false,
+				},
+			},
+			updateArg1:      mock.Anything,
+			updateArg2:      mock.Anything,
+			updateArg3:      mock.Anything,
+			updateRet1:      nil,
+			now:             newTs,
+			reconcileResult: ctrl.Result{},
 		},
 	}
 	for _, tc := range testCases {
@@ -591,8 +642,15 @@ func runReconcileVpnKeyRotationConfig(t *testing.T, tc *reconcileVpnKeyRotationC
 
 	wg.On("GenerateCerts", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
+	// Status().Update() is called when setting or clearing RotationInProgress on the status subresource.
+	clientMock.On("Status").Return(clientMock)
 	clientMock.
 		On("Update", tc.updateArg1, tc.updateArg2).Return(tc.updateRet1).Once()
+	// Second Update covers the status subresource write (triggered via util.UpdateStatus).
+	clientMock.
+		On("Update", tc.updateArg1, tc.updateArg2).Return(tc.updateRet1).Once()
+	// Get re-fetches the object after util.UpdateStatus completes.
+	clientMock.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	reconcileResult, gotResp, gotErr := vpn.reconcileVpnKeyRotationConfig(ctx, tc.arg1, tc.arg2)
 	require.Equal(t, gotErr, tc.expectedErr)


### PR DESCRIPTION
# Description

`VpnKeyRotationService` held an `atomic.Bool` named `jobCreationInProgress` on the struct. This caused two correctness problems in HA/multi-slice deployments:

1. **HA/restart unsafety** — the flag lives only in-process. On pod restart or leader-election failover it silently resets, causing the reconciler to retrigger cert-generation jobs for every active slice and potentially overwrite valid VPN certificates.

2. **Global blocking across all slices** — `VpnKeyRotationService` is a singleton. The single flag was shared across all slices: if slice A is rotating certs, slice B's rotation is blocked by A's state, not its own. The reconciler silently skipped B's rotation with a blind 30-second requeue and no log or event.

**Fix:** Add `RotationInProgress bool` to `VpnKeyRotationStatus` (per-CR, persisted in etcd) and replace all reads/writes of the in-process flag with reads/writes of this status field via `util.UpdateStatus`. Kubernetes optimistic concurrency (`ResourceVersion`) on `Status().Update()` handles write conflicts naturally through the controller-runtime retry loop. Concurrent slice rotations are now fully independent.

Fixes #

## How Has This Been Tested?

**Unit tests** — `service/vpn_key_rotation_service_test.go`:

- [x] Existing test `should requeue after firing new jobs` updated to mock `Status().Update()` and the subsequent re-fetch `Get()` for the new status write path.
- [x] New test case `should clear RotationInProgress and update timestamps after jobs complete` covers the second-pass path: `RotationInProgress=true` pre-set in CR status, jobs return `JobStatusComplete`, spec timestamps advanced, `RotationInProgress` cleared via `UpdateStatus`.
- [x] All existing test cases continue to pass unmodified (`should update CertCreation TS and Expiry TS when it is nil`, `should wait and requeue till all the jobs are in completion state`, `should successfully requeue before 1 hour of expiry`).

**Build** — `go build ./...` passes cleanly.

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?

No. `RotationInProgress` is a new optional field on `VpnKeyRotationStatus` (`omitempty`). Existing CRs without the field continue to function: a missing/false value means no rotation is in progress, which is the same starting condition as before. No changes to worker-operator are required.

```release-note

```