### PR TITLE
fix(): delete VpnKeyRotation CR on SliceConfig removal and guard stale reconciles

### DIFF
--- a/service/mocks/IVpnKeyRotationService.go
+++ b/service/mocks/IVpnKeyRotationService.go
@@ -80,6 +80,20 @@ func (_m *IVpnKeyRotationService) ReconcileVpnKeyRotation(ctx context.Context, r
 	return r0, r1
 }
 
+// DeleteVpnKeyRotationConfig provides a mock function with given fields: ctx, sliceName, namespace
+func (_m *IVpnKeyRotationService) DeleteVpnKeyRotationConfig(ctx context.Context, sliceName string, namespace string) error {
+	ret := _m.Called(ctx, sliceName, namespace)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = rf(ctx, sliceName, namespace)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 type mockConstructorTestingTNewIVpnKeyRotationService interface {
 	mock.TestingT
 	Cleanup(func())

--- a/service/slice_config_service.go
+++ b/service/slice_config_service.go
@@ -267,6 +267,10 @@ func (s *SliceConfigService) cleanUpSliceConfigResources(ctx context.Context,
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+	err = s.vpn.DeleteVpnKeyRotationConfig(ctx, slice.Name, namespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/service/slice_config_service_test.go
+++ b/service/slice_config_service_test.go
@@ -70,6 +70,7 @@ var SliceConfigTestBed = map[string]func(*testing.T){
 	"SliceConfig_ErrorOnDeleteWorkerSliceGatewaysByLabel":        SliceConfigErrorOnDeleteWorkerSliceGatewaysByLabel,
 	"SliceConfig_ErrorOnDeleteWorkerSliceConfigByLabel":          SliceConfigErrorOnDeleteWorkerSliceConfigByLabel,
 	"SliceConfig_ErrorOnDeleteWorkerSliceGatewayRecyclerByLabel": SliceConfigErrorOnDeleteWorkerSliceGatewayRecyclerByLabel,
+	"SliceConfig_ErrorOnDeleteVpnKeyRotationConfig":              SliceConfigErrorOnDeleteVpnKeyRotationConfig,
 	"SliceConfig_ErrorOnUpdatingTheFinalizer":                    SliceConfigErrorOnUpdatingTheFinalizer,
 	"SliceConfig_RemoveFinalizerErrorOnUpdate":                   SliceConfigRemoveFinalizerErrorOnUpdate,
 	"SliceConfig_RemoveFinalizerErrorOnGetAfterUpdate":           SliceConfigRemoveFinalizerErrorOnGetAfterUpdate,
@@ -81,7 +82,7 @@ var SliceConfigTestBed = map[string]func(*testing.T){
 }
 
 func SliceConfigReconciliationCompleteHappyCase(t *testing.T) {
-	workerSliceGatewayMock, workerSliceConfigMock, _, workerServiceImportMock, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock := setupSliceConfigTest("slice_config", "namespace")
+	workerSliceGatewayMock, workerSliceConfigMock, _, workerServiceImportMock, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock, _ := setupSliceConfigTest("slice_config", "namespace")
 	mMock.On("WithProject", mock.AnythingOfType("string")).Return(&metrics.MetricRecorder{}).Once()
 	clientMock.On("Get", ctx, requestObj.NamespacedName, sliceConfig).Return(nil).Once()
 	clientMock.On("Update", ctx, mock.Anything).Return(nil).Once()
@@ -133,7 +134,7 @@ func SliceConfigReconciliationCompleteHappyCase(t *testing.T) {
 }
 
 func SliceConfigReconciliationNoNetCompleteHappyCase(t *testing.T) {
-	_, workerSliceConfigMock, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock := setupSliceConfigTest("slice_config", "namespace")
+	_, workerSliceConfigMock, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock, _ := setupSliceConfigTest("slice_config", "namespace")
 	mMock.On("WithProject", mock.AnythingOfType("string")).Return(&metrics.MetricRecorder{}).Once()
 	clientMock.On("Get", ctx, requestObj.NamespacedName, sliceConfig).Return(nil).Run(func(args mock.Arguments) {
 		arg := args.Get(2).(*controllerv1alpha1.SliceConfig)
@@ -166,7 +167,7 @@ func SliceConfigReconciliationNoNetCompleteHappyCase(t *testing.T) {
 }
 
 func SliceConfigGetObjectErrorOtherThanNotFound(t *testing.T) {
-	_, _, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, _ := setupSliceConfigTest("slice_config", "namespace")
+	_, _, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, _, _ := setupSliceConfigTest("slice_config", "namespace")
 	err1 := errors.New("internal_error")
 	clientMock.On("Get", ctx, requestObj.NamespacedName, sliceConfig).Return(err1).Once()
 	result, err2 := sliceConfigService.ReconcileSliceConfig(ctx, requestObj)
@@ -179,7 +180,7 @@ func SliceConfigGetObjectErrorOtherThanNotFound(t *testing.T) {
 }
 
 func SliceConfigGetObjectErrorNotFound(t *testing.T) {
-	_, _, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, _ := setupSliceConfigTest("slice_config", "namespace")
+	_, _, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, _, _ := setupSliceConfigTest("slice_config", "namespace")
 	notFoundError := k8sError.NewNotFound(util.Resource("SliceConfigTest"), "isNotFound")
 	clientMock.On("Get", ctx, requestObj.NamespacedName, sliceConfig).Return(notFoundError).Once()
 	result, err2 := sliceConfigService.ReconcileSliceConfig(ctx, requestObj)
@@ -192,7 +193,7 @@ func SliceConfigGetObjectErrorNotFound(t *testing.T) {
 }
 
 func SliceConfigDeleteTheObjectHappyCase(t *testing.T) {
-	workerSliceGatewayMock, workerSliceConfigMock, serviceExportConfigMock, _, workerSliceGatewayRecyclerMock, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock := setupSliceConfigTest("slice_config", "namespace")
+	workerSliceGatewayMock, workerSliceConfigMock, serviceExportConfigMock, _, workerSliceGatewayRecyclerMock, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock, vpnMock := setupSliceConfigTest("slice_config", "namespace")
 	time := metav1.Now()
 	mMock.On("WithProject", mock.AnythingOfType("string")).Return(&metrics.MetricRecorder{}).Once()
 	clientMock.On("Get", ctx, requestObj.NamespacedName, sliceConfig).Return(nil).Run(func(args mock.Arguments) {
@@ -206,6 +207,7 @@ func SliceConfigDeleteTheObjectHappyCase(t *testing.T) {
 		"slice_name": requestObj.Name,
 	}
 	workerSliceGatewayRecyclerMock.On("DeleteWorkerSliceGatewayRecyclersByLabel", ctx, recyclerLabel, requestObj.Namespace).Return(nil).Once()
+	vpnMock.On("DeleteVpnKeyRotationConfig", ctx, requestObj.Name, requestObj.Namespace).Return(nil).Once()
 	// remove finalizer
 	clientMock.On("Update", ctx, mock.Anything).Return(nil).Once()
 	clientMock.On("Create", ctx, mock.AnythingOfType("*v1.Event")).Return(nil).Once()
@@ -224,7 +226,7 @@ func SliceConfigDeleteTheObjectHappyCase(t *testing.T) {
 }
 
 func SliceConfigObjectNamespaceNotFound(t *testing.T) {
-	_, _, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock := setupSliceConfigTest("slice_config", "namespace")
+	_, _, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock, _ := setupSliceConfigTest("slice_config", "namespace")
 	mMock.On("WithProject", mock.AnythingOfType("string")).Return(&metrics.MetricRecorder{}).Once()
 	clientMock.On("Get", ctx, requestObj.NamespacedName, sliceConfig).Return(nil).Once()
 	clientMock.On("Update", ctx, mock.Anything).Return(nil).Once()
@@ -250,7 +252,7 @@ func SliceConfigObjectNamespaceNotFound(t *testing.T) {
 }
 
 func SliceConfigObjectNotInProjectNamespace(t *testing.T) {
-	_, _, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock := setupSliceConfigTest("slice_config", "namespace")
+	_, _, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock, _ := setupSliceConfigTest("slice_config", "namespace")
 	mMock.On("WithProject", mock.AnythingOfType("string")).Return(&metrics.MetricRecorder{}).Once()
 	clientMock.On("Get", ctx, requestObj.NamespacedName, sliceConfig).Return(nil).Once()
 	clientMock.On("Update", ctx, mock.Anything).Return(nil).Once()
@@ -275,7 +277,7 @@ func SliceConfigObjectNotInProjectNamespace(t *testing.T) {
 }
 
 func SliceConfigObjectWithDuplicateClustersInSpec(t *testing.T) {
-	_, _, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock := setupSliceConfigTest("slice_config", "namespace")
+	_, _, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock, _ := setupSliceConfigTest("slice_config", "namespace")
 	mMock.On("WithProject", mock.AnythingOfType("string")).Return(&metrics.MetricRecorder{}).Once()
 	clientMock.On("Get", ctx, requestObj.NamespacedName, sliceConfig).Return(nil).Run(func(args mock.Arguments) {
 		arg := args.Get(2).(*controllerv1alpha1.SliceConfig)
@@ -295,7 +297,7 @@ func SliceConfigObjectWithDuplicateClustersInSpec(t *testing.T) {
 }
 
 func SliceConfigErrorOnCreateWorkerSliceConfig(t *testing.T) {
-	_, workerSliceConfigMock, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock := setupSliceConfigTest("slice_config", "namespace")
+	_, workerSliceConfigMock, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock, _ := setupSliceConfigTest("slice_config", "namespace")
 	mMock.On("WithProject", mock.AnythingOfType("string")).Return(&metrics.MetricRecorder{}).Once()
 	clientMock.On("Get", ctx, requestObj.NamespacedName, sliceConfig).Return(nil).Once()
 	clientMock.On("Update", ctx, mock.Anything).Return(nil).Once()
@@ -328,7 +330,7 @@ func SliceConfigErrorOnCreateWorkerSliceConfig(t *testing.T) {
 }
 
 func SliceConfigErrorOnCreateWorkerSliceGateway(t *testing.T) {
-	workerSliceGatewayMock, workerSliceConfigMock, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock := setupSliceConfigTest("slice_config", "namespace")
+	workerSliceGatewayMock, workerSliceConfigMock, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock, _ := setupSliceConfigTest("slice_config", "namespace")
 	mMock.On("WithProject", mock.AnythingOfType("string")).Return(&metrics.MetricRecorder{}).Once()
 	clientMock.On("Get", ctx, requestObj.NamespacedName, sliceConfig).Return(nil).Once()
 	clientMock.On("Update", ctx, mock.Anything).Return(nil).Once()
@@ -364,7 +366,7 @@ func SliceConfigErrorOnCreateWorkerSliceGateway(t *testing.T) {
 }
 
 func SliceConfigErrorOnDeleteWorkerSliceGatewaysByLabel(t *testing.T) {
-	workerSliceGatewayMock, _, serviceExportConfigMock, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock := setupSliceConfigTest("slice_config", "namespace")
+	workerSliceGatewayMock, _, serviceExportConfigMock, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock, _ := setupSliceConfigTest("slice_config", "namespace")
 	time := metav1.Now()
 	mMock.On("WithProject", mock.AnythingOfType("string")).Return(&metrics.MetricRecorder{}).Once()
 	clientMock.On("Get", ctx, requestObj.NamespacedName, sliceConfig).Return(nil).Run(func(args mock.Arguments) {
@@ -386,7 +388,7 @@ func SliceConfigErrorOnDeleteWorkerSliceGatewaysByLabel(t *testing.T) {
 }
 
 func SliceConfigErrorOnDeleteWorkerSliceConfigByLabel(t *testing.T) {
-	workerSliceGatewayMock, workerSliceConfigMock, serviceExportConfigMock, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock := setupSliceConfigTest("slice_config", "namespace")
+	workerSliceGatewayMock, workerSliceConfigMock, serviceExportConfigMock, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock, _ := setupSliceConfigTest("slice_config", "namespace")
 	time := metav1.Now()
 	mMock.On("WithProject", mock.AnythingOfType("string")).Return(&metrics.MetricRecorder{}).Once()
 	clientMock.On("Get", ctx, requestObj.NamespacedName, sliceConfig).Return(nil).Run(func(args mock.Arguments) {
@@ -410,7 +412,7 @@ func SliceConfigErrorOnDeleteWorkerSliceConfigByLabel(t *testing.T) {
 }
 
 func SliceConfigErrorOnDeleteWorkerSliceGatewayRecyclerByLabel(t *testing.T) {
-	workerSliceGatewayMock, workerSliceConfigMock, serviceExportConfigMock, _, workerSliceGatewayRecyclerMock, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock := setupSliceConfigTest("slice_config", "namespace")
+	workerSliceGatewayMock, workerSliceConfigMock, serviceExportConfigMock, _, workerSliceGatewayRecyclerMock, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock, _ := setupSliceConfigTest("slice_config", "namespace")
 	time := metav1.Now()
 	mMock.On("WithProject", mock.AnythingOfType("string")).Return(&metrics.MetricRecorder{}).Once()
 	clientMock.On("Get", ctx, requestObj.NamespacedName, sliceConfig).Return(nil).Run(func(args mock.Arguments) {
@@ -438,8 +440,39 @@ func SliceConfigErrorOnDeleteWorkerSliceGatewayRecyclerByLabel(t *testing.T) {
 	mMock.AssertExpectations(t)
 }
 
+func SliceConfigErrorOnDeleteVpnKeyRotationConfig(t *testing.T) {
+	workerSliceGatewayMock, workerSliceConfigMock, serviceExportConfigMock, _, workerSliceGatewayRecyclerMock, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock, vpnMock := setupSliceConfigTest("slice_config", "namespace")
+	time := metav1.Now()
+	mMock.On("WithProject", mock.AnythingOfType("string")).Return(&metrics.MetricRecorder{}).Once()
+	clientMock.On("Get", ctx, requestObj.NamespacedName, sliceConfig).Return(nil).Run(func(args mock.Arguments) {
+		arg := args.Get(2).(*controllerv1alpha1.SliceConfig)
+		arg.Name = requestObj.Name
+		arg.ObjectMeta.DeletionTimestamp = &time
+	}).Once()
+	workerSliceGatewayMock.On("DeleteWorkerSliceGatewaysByLabel", ctx, mock.Anything, requestObj.Namespace).Return(nil).Once()
+	workerSliceConfigMock.On("DeleteWorkerSliceConfigByLabel", ctx, mock.Anything, requestObj.Namespace).Return(nil).Once()
+	recyclerLabel := map[string]string{
+		"slice_name": requestObj.Name,
+	}
+	workerSliceGatewayRecyclerMock.On("DeleteWorkerSliceGatewayRecyclersByLabel", ctx, recyclerLabel, requestObj.Namespace).Return(nil).Once()
+	err1 := errors.New("internal_error")
+	vpnMock.On("DeleteVpnKeyRotationConfig", ctx, requestObj.Name, requestObj.Namespace).Return(err1).Once()
+	result, err2 := sliceConfigService.ReconcileSliceConfig(ctx, requestObj)
+	expectedResult := ctrl.Result{}
+	require.Error(t, err2)
+	require.Equal(t, expectedResult, result)
+	require.Equal(t, err1, err2)
+	require.False(t, result.Requeue)
+	clientMock.AssertExpectations(t)
+	serviceExportConfigMock.AssertExpectations(t)
+	workerSliceGatewayMock.AssertExpectations(t)
+	workerSliceConfigMock.AssertExpectations(t)
+	vpnMock.AssertExpectations(t)
+	mMock.AssertExpectations(t)
+}
+
 func SliceConfigErrorOnUpdatingTheFinalizer(t *testing.T) {
-	_, _, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock := setupSliceConfigTest("slice_config", "namespace")
+	_, _, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock, _ := setupSliceConfigTest("slice_config", "namespace")
 	mMock.On("WithProject", mock.AnythingOfType("string")).Return(&metrics.MetricRecorder{}).Once()
 	clientMock.On("Get", ctx, requestObj.NamespacedName, sliceConfig).Return(nil).Once()
 	err1 := errors.New("internal_error")
@@ -455,7 +488,7 @@ func SliceConfigErrorOnUpdatingTheFinalizer(t *testing.T) {
 }
 
 func SliceConfigRemoveFinalizerErrorOnUpdate(t *testing.T) {
-	workerSliceGatewayMock, workerSliceConfigMock, serviceExportConfigMock, _, workerSliceGatewayRecyclerMock, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock := setupSliceConfigTest("slice_config", "namespace")
+	workerSliceGatewayMock, workerSliceConfigMock, serviceExportConfigMock, _, workerSliceGatewayRecyclerMock, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock, vpnMock := setupSliceConfigTest("slice_config", "namespace")
 	time := metav1.Now()
 	mMock.On("WithProject", mock.AnythingOfType("string")).Return(&metrics.MetricRecorder{}).Once()
 	clientMock.On("Get", ctx, requestObj.NamespacedName, sliceConfig).Return(nil).Run(func(args mock.Arguments) {
@@ -469,6 +502,7 @@ func SliceConfigRemoveFinalizerErrorOnUpdate(t *testing.T) {
 		"slice_name": requestObj.Name,
 	}
 	workerSliceGatewayRecyclerMock.On("DeleteWorkerSliceGatewayRecyclersByLabel", ctx, recyclerLabel, requestObj.Namespace).Return(nil).Once()
+	vpnMock.On("DeleteVpnKeyRotationConfig", ctx, requestObj.Name, requestObj.Namespace).Return(nil).Once()
 	err1 := errors.New("internal_error")
 	clientMock.On("Update", ctx, mock.Anything).Return(err1).Once()
 	clientMock.On("Create", ctx, mock.AnythingOfType("*v1.Event")).Return(nil).Once()
@@ -487,7 +521,7 @@ func SliceConfigRemoveFinalizerErrorOnUpdate(t *testing.T) {
 }
 
 func SliceConfigRemoveFinalizerErrorOnGetAfterUpdate(t *testing.T) {
-	workerSliceGatewayMock, workerSliceConfigMock, serviceExportConfigMock, _, workerSliceGatewayRecyclerMock, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock := setupSliceConfigTest("slice_config", "namespace")
+	workerSliceGatewayMock, workerSliceConfigMock, serviceExportConfigMock, _, workerSliceGatewayRecyclerMock, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock, vpnMock := setupSliceConfigTest("slice_config", "namespace")
 	time := metav1.Now()
 	mMock.On("WithProject", mock.AnythingOfType("string")).Return(&metrics.MetricRecorder{}).Once()
 	clientMock.On("Get", ctx, requestObj.NamespacedName, sliceConfig).Return(nil).Run(func(args mock.Arguments) {
@@ -501,6 +535,7 @@ func SliceConfigRemoveFinalizerErrorOnGetAfterUpdate(t *testing.T) {
 		"slice_name": requestObj.Name,
 	}
 	workerSliceGatewayRecyclerMock.On("DeleteWorkerSliceGatewayRecyclersByLabel", ctx, recyclerLabel, requestObj.Namespace).Return(nil).Once()
+	vpnMock.On("DeleteVpnKeyRotationConfig", ctx, requestObj.Name, requestObj.Namespace).Return(nil).Once()
 	err1 := errors.New("internal_error")
 	clientMock.On("Update", ctx, mock.Anything).Return(err1).Once()
 	clientMock.On("Create", ctx, mock.AnythingOfType("*v1.Event")).Return(nil).Once()
@@ -521,7 +556,7 @@ func SliceConfigRemoveFinalizerErrorOnGetAfterUpdate(t *testing.T) {
 func SliceConfigDeleteHappyCase(t *testing.T) {
 	name := "slice-1"
 	namespace := "namespace"
-	_, _, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock := setupSliceConfigTest(name, namespace)
+	_, _, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock, _ := setupSliceConfigTest(name, namespace)
 	mMock.On("WithProject", mock.AnythingOfType("string")).Return(&metrics.MetricRecorder{}).Once()
 	clientMock.On("List", ctx, &controllerv1alpha1.SliceConfigList{}, client.InNamespace(requestObj.Namespace)).Return(nil).Run(func(args mock.Arguments) {
 		arg := args.Get(1).(*controllerv1alpha1.SliceConfigList)
@@ -551,7 +586,7 @@ func SliceConfigDeleteHappyCase(t *testing.T) {
 func SliceConfigDeleteErrorOnList(t *testing.T) {
 	name := "slice-1"
 	namespace := "namespace"
-	_, _, _, _, _, clientMock, _, ctx, sliceConfigService, requestObj, _ := setupSliceConfigTest(name, namespace)
+	_, _, _, _, _, clientMock, _, ctx, sliceConfigService, requestObj, _, _ := setupSliceConfigTest(name, namespace)
 	err1 := errors.New("internal_error")
 	clientMock.On("List", ctx, &controllerv1alpha1.SliceConfigList{}, client.InNamespace(requestObj.Namespace)).Return(err1).Run(func(args mock.Arguments) {
 		arg := args.Get(1).(*controllerv1alpha1.SliceConfigList)
@@ -576,7 +611,7 @@ func SliceConfigDeleteErrorOnList(t *testing.T) {
 func SliceConfigDeleteErrorOnDelete(t *testing.T) {
 	name := "slice-1"
 	namespace := "namespace"
-	_, _, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock := setupSliceConfigTest(name, namespace)
+	_, _, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock, _ := setupSliceConfigTest(name, namespace)
 	mMock.On("WithProject", mock.AnythingOfType("string")).Return(&metrics.MetricRecorder{}).Once()
 	clientMock.On("List", ctx, &controllerv1alpha1.SliceConfigList{}, client.InNamespace(requestObj.Namespace)).Return(nil).Run(func(args mock.Arguments) {
 		arg := args.Get(1).(*controllerv1alpha1.SliceConfigList)
@@ -606,7 +641,7 @@ func SliceConfigDeleteErrorOnDelete(t *testing.T) {
 }
 
 func SliceConfigErrorOnListingServiceExport(t *testing.T) {
-	workerSliceGatewayMock, workerSliceConfigMock, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock := setupSliceConfigTest("slice_config", "namespace")
+	workerSliceGatewayMock, workerSliceConfigMock, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock, _ := setupSliceConfigTest("slice_config", "namespace")
 	mMock.On("WithProject", mock.AnythingOfType("string")).Return(&metrics.MetricRecorder{}).Once()
 	clientMock.On("Get", ctx, requestObj.NamespacedName, sliceConfig).Return(nil).Once()
 	clientMock.On("Update", ctx, mock.Anything).Return(nil).Once()
@@ -646,7 +681,7 @@ func SliceConfigErrorOnListingServiceExport(t *testing.T) {
 }
 
 func SliceConfigErrorOnCreateOrUpdateServiceImport(t *testing.T) {
-	workerSliceGatewayMock, workerSliceConfigMock, _, workerServiceImportMock, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock := setupSliceConfigTest("slice_config", "namespace")
+	workerSliceGatewayMock, workerSliceConfigMock, _, workerServiceImportMock, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock, _ := setupSliceConfigTest("slice_config", "namespace")
 	mMock.On("WithProject", mock.AnythingOfType("string")).Return(&metrics.MetricRecorder{}).Once()
 	clientMock.On("Get", ctx, requestObj.NamespacedName, sliceConfig).Return(nil).Once()
 	clientMock.On("Update", ctx, mock.Anything).Return(nil).Once()
@@ -698,14 +733,14 @@ func SliceConfigErrorOnCreateOrUpdateServiceImport(t *testing.T) {
 	mMock.AssertExpectations(t)
 }
 
-func setupSliceConfigTest(name string, namespace string) (*mocks.IWorkerSliceGatewayService, *mocks.IWorkerSliceConfigService, *mocks.IServiceExportConfigService, *mocks.IWorkerServiceImportService, *mocks.IWorkerSliceGatewayRecyclerService, *utilMock.Client, *controllerv1alpha1.SliceConfig, context.Context, SliceConfigService, ctrl.Request, *metricMock.IMetricRecorder) {
+func setupSliceConfigTest(name string, namespace string) (*mocks.IWorkerSliceGatewayService, *mocks.IWorkerSliceConfigService, *mocks.IServiceExportConfigService, *mocks.IWorkerServiceImportService, *mocks.IWorkerSliceGatewayRecyclerService, *utilMock.Client, *controllerv1alpha1.SliceConfig, context.Context, SliceConfigService, ctrl.Request, *metricMock.IMetricRecorder, *mocks.IVpnKeyRotationService) {
 	workerSliceGatewayMock := &mocks.IWorkerSliceGatewayService{}
 	workerSliceConfigMock := &mocks.IWorkerSliceConfigService{}
 	serviceExportConfigMock := &mocks.IServiceExportConfigService{}
 	workerServiceImportMock := &mocks.IWorkerServiceImportService{}
 	workerSliceGatewayRecyclerMock := &mocks.IWorkerSliceGatewayRecyclerService{}
 	mMock := &metricMock.IMetricRecorder{}
-	vpn := mocks.IVpnKeyRotationService{}
+	vpn := &mocks.IVpnKeyRotationService{}
 	sliceConfigService := SliceConfigService{
 		sgs:   workerSliceGatewayMock,
 		ms:    workerSliceConfigMock,
@@ -713,7 +748,7 @@ func setupSliceConfigTest(name string, namespace string) (*mocks.IWorkerSliceGat
 		si:    workerServiceImportMock,
 		wsgrs: workerSliceGatewayRecyclerMock,
 		mf:    mMock,
-		vpn:   &vpn,
+		vpn:   vpn,
 	}
 	namespacedName := types.NamespacedName{
 		Name:      name,
@@ -735,5 +770,5 @@ func setupSliceConfigTest(name string, namespace string) (*mocks.IWorkerSliceGat
 	vpn.On("CreateMinimalVpnKeyRotationConfig", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	vpn.On("ReconcileClusters", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
 	ctx := util.PrepareKubeSliceControllersRequestContext(context.Background(), clientMock, scheme, "SliceConfigServiceTest", &eventRecorder)
-	return workerSliceGatewayMock, workerSliceConfigMock, serviceExportConfigMock, workerServiceImportMock, workerSliceGatewayRecyclerMock, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock
+	return workerSliceGatewayMock, workerSliceConfigMock, serviceExportConfigMock, workerServiceImportMock, workerSliceGatewayRecyclerMock, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock, vpn
 }

--- a/service/vpn_key_rotation_service.go
+++ b/service/vpn_key_rotation_service.go
@@ -40,6 +40,7 @@ type IVpnKeyRotationService interface {
 	CreateMinimalVpnKeyRotationConfig(ctx context.Context, sliceName, namespace string, r int) error
 	ReconcileClusters(ctx context.Context, sliceName, namespace string, clusters []string) (*controllerv1alpha1.VpnKeyRotation, error)
 	ReconcileVpnKeyRotation(ctx context.Context, req ctrl.Request) (ctrl.Result, error)
+	DeleteVpnKeyRotationConfig(ctx context.Context, sliceName, namespace string) error
 }
 
 type VpnKeyRotationService struct {
@@ -164,6 +165,10 @@ func (v *VpnKeyRotationService) ReconcileVpnKeyRotation(ctx context.Context, req
 	if err != nil {
 		logger.Errorf("Err getting sliceconfig: %s", err.Error())
 		return ctrl.Result{}, err
+	}
+	if s == nil {
+		logger.Infof("SliceConfig %s not found, VpnKeyRotation CR will be garbage collected", req.Name)
+		return ctrl.Result{}, nil
 	}
 	if vpnKeyRotationConfig.GetOwnerReferences() == nil {
 		if err := controllerutil.SetControllerReference(s, vpnKeyRotationConfig, util.GetKubeSliceControllerRequestContext(ctx).Scheme); err != nil {
@@ -378,7 +383,7 @@ func (v *VpnKeyRotationService) listWorkerSliceGateways(ctx context.Context, lab
 	return &workerSliceGatewaysList, nil
 }
 
-// getSliceConfig
+// getSliceConfig returns the named SliceConfig, or (nil, nil) when it does not exist.
 func (v *VpnKeyRotationService) getSliceConfig(ctx context.Context, name, namespace string) (*controllerv1alpha1.SliceConfig, error) {
 	s := controllerv1alpha1.SliceConfig{}
 	found, err := util.GetResourceIfExist(ctx, types.NamespacedName{
@@ -389,9 +394,34 @@ func (v *VpnKeyRotationService) getSliceConfig(ctx context.Context, name, namesp
 		return nil, err
 	}
 	if !found {
-		return nil, fmt.Errorf("sliceconfig %s not found", name)
+		return nil, nil
 	}
 	return &s, nil
+}
+
+// DeleteVpnKeyRotationConfig deletes the VpnKeyRotation CR for the given slice if it exists.
+func (v *VpnKeyRotationService) DeleteVpnKeyRotationConfig(ctx context.Context, sliceName, namespace string) error {
+	logger := util.CtxLogger(ctx).
+		With("name", "DeleteVpnKeyRotationConfig").
+		With("reconciler", "VpnKeyRotationConfig")
+
+	vpnKeyRotationConfig := controllerv1alpha1.VpnKeyRotation{}
+	found, err := util.GetResourceIfExist(ctx, types.NamespacedName{
+		Namespace: namespace,
+		Name:      sliceName,
+	}, &vpnKeyRotationConfig)
+	if err != nil {
+		logger.Errorf("error fetching vpnKeyRotationConfig %s. Err: %s", sliceName, err.Error())
+		return err
+	}
+	if found {
+		if err := util.DeleteResource(ctx, &vpnKeyRotationConfig); err != nil {
+			logger.Errorf("error deleting vpnKeyRotationConfig %s. Err: %s", sliceName, err.Error())
+			return err
+		}
+		logger.Debugf("deleted vpnKeyRotationConfig %s", sliceName)
+	}
+	return nil
 }
 
 func (v *VpnKeyRotationService) listClientPairGateway(wl *workerv1alpha1.WorkerSliceGatewayList, clientGatewayName string) (*workerv1alpha1.WorkerSliceGateway, error) {

--- a/service/vpn_key_rotation_service_test.go
+++ b/service/vpn_key_rotation_service_test.go
@@ -335,7 +335,7 @@ type getSliceConfigTestCase struct {
 func Test_getSliceConfig(t *testing.T) {
 	testCases := []getSliceConfigTestCase{
 		{
-			name:         "it should return error in sliceconfig not found",
+			name:         "it should return error on API failure",
 			sliceName:    "test-slice",
 			namespace:    "test-ns",
 			expectedResp: nil,
@@ -360,6 +360,17 @@ func Test_getSliceConfig(t *testing.T) {
 			getArg2:     mock.Anything,
 			getArg3:     mock.Anything,
 			getRet1:     nil,
+		},
+		{
+			name:         "it should return nil when sliceconfig does not exist",
+			sliceName:    "test-slice",
+			namespace:    "test-ns",
+			expectedResp: nil,
+			expectedErr:  nil,
+			getArg1:      mock.Anything,
+			getArg2:      mock.Anything,
+			getArg3:      mock.Anything,
+			getRet1:      kubeerrors.NewNotFound(util.Resource("SliceConfig"), "test-slice"),
 		},
 	}
 	for _, tc := range testCases {
@@ -1362,4 +1373,87 @@ func runReconcileVpnKeyRotation(t *testing.T, tc reconcileVpnKeyRotationTestCase
 	require.Equal(t, tc.expectedError, gotErr)
 	require.Equal(t, tc.expectedResponse, gotResp)
 
+}
+
+type deleteVpnKeyRotationConfigTestCase struct {
+	name                      string
+	sliceName                 string
+	namespace                 string
+	expectedErr               error
+	getArg1, getArg2, getArg3 interface{}
+	getRet1                   interface{}
+	deleteArg1, deleteArg2    interface{}
+	deleteRet1                interface{}
+}
+
+func Test_DeleteVpnKeyRotationConfig(t *testing.T) {
+	testCases := []deleteVpnKeyRotationConfigTestCase{
+		{
+			name:        "should delete vpnkeyrotation config successfully",
+			sliceName:   "demo-slice",
+			namespace:   "demo-namespace",
+			expectedErr: nil,
+			getArg1:     mock.Anything,
+			getArg2:     mock.Anything,
+			getArg3:     mock.Anything,
+			getRet1:     nil,
+			deleteArg1:  mock.Anything,
+			deleteArg2:  mock.Anything,
+			deleteRet1:  nil,
+		},
+		{
+			name:        "should return nil when vpnkeyrotation config does not exist",
+			sliceName:   "demo-slice",
+			namespace:   "demo-namespace",
+			expectedErr: nil,
+			getArg1:     mock.Anything,
+			getArg2:     mock.Anything,
+			getArg3:     mock.Anything,
+			getRet1:     kubeerrors.NewNotFound(util.Resource("VpnKeyRotation"), "demo-slice"),
+		},
+		{
+			name:        "should return error if fetching vpnkeyrotation config fails",
+			sliceName:   "demo-slice",
+			namespace:   "demo-namespace",
+			expectedErr: errors.New("failed to fetch vpnkeyrotation"),
+			getArg1:     mock.Anything,
+			getArg2:     mock.Anything,
+			getArg3:     mock.Anything,
+			getRet1:     errors.New("failed to fetch vpnkeyrotation"),
+		},
+		{
+			name:        "should return error if deleting vpnkeyrotation config fails",
+			sliceName:   "demo-slice",
+			namespace:   "demo-namespace",
+			expectedErr: errors.New("failed to delete vpnkeyrotation"),
+			getArg1:     mock.Anything,
+			getArg2:     mock.Anything,
+			getArg3:     mock.Anything,
+			getRet1:     nil,
+			deleteArg1:  mock.Anything,
+			deleteArg2:  mock.Anything,
+			deleteRet1:  errors.New("failed to delete vpnkeyrotation"),
+		},
+	}
+	for _, tc := range testCases {
+		runDeleteVpnKeyRotationConfigTestCase(t, tc)
+	}
+}
+
+func runDeleteVpnKeyRotationConfigTestCase(t *testing.T, tc deleteVpnKeyRotationConfigTestCase) {
+	ctx, clientMock, vpn, _, _ := setupTestCase()
+
+	clientMock.
+		On("Get", tc.getArg1, tc.getArg2, tc.getArg3).
+		Return(tc.getRet1).Once()
+
+	if tc.deleteArg1 != nil {
+		clientMock.
+			On("Delete", tc.deleteArg1, tc.deleteArg2).
+			Return(tc.deleteRet1).Once()
+	}
+
+	gotErr := vpn.DeleteVpnKeyRotationConfig(ctx, tc.sliceName, tc.namespace)
+	require.Equal(t, tc.expectedErr, gotErr)
+	clientMock.AssertExpectations(t)
 }


### PR DESCRIPTION
## Problem

When a SliceConfig is deleted, `cleanUpSliceConfigResources` removed gateways,
service import/export configs, and the slice recycler — but left the
`VpnKeyRotation` CR orphaned in the namespace.

Two consequences:

1. **Orphaned CR triggers endless reconcile errors.**  
   `ReconcileVpnKeyRotation` calls `getSliceConfig` to look up the parent slice,
   which returned `fmt.Errorf("sliceconfig %s not found", name)`.  
   controller-runtime treats any non-nil error as a signal to requeue, so the
   reconciler re-ran on every backoff interval, flooding logs with
   `"sliceconfig <name> not found"` errors until the process restarted.

2. **`VpnKeyRotation` CRs accumulate in the namespace.**  
   Each deleted slice leaves behind a stale CR that is never collected,
   gradually polluting `kubectl get vpnkeyrotation -n <project-namespace>` output
   and consuming etcd storage.

## Fix

**`service/vpn_key_rotation_service.go`**

- Added `DeleteVpnKeyRotationConfig` to the `IVpnKeyRotationService` interface.
- Implemented it: fetches the `VpnKeyRotation` CR by slice name/namespace and
  deletes it if present; no-ops when already absent so repeated calls are safe.
- Changed `getSliceConfig` to return `(nil, nil)` instead of a non-nil error
  when the SliceConfig is not found (API returns 404). A missing slice config is
  an expected condition during GC propagation, not a controller error.
- Added a nil guard in `ReconcileVpnKeyRotation`: if `getSliceConfig` returns
  `nil`, log at Info level and return `(ctrl.Result{}, nil)` — no requeue, no
  error counter increment.

**`service/slice_config_service.go`**

- Called `vpn.DeleteVpnKeyRotationConfig` at the end of
  `cleanUpSliceConfigResources`, after the slice recycler is removed.

**`service/mocks/IVpnKeyRotationService.go`**

- Added mock implementation for the new `DeleteVpnKeyRotationConfig` method.

## Tests

**`service/vpn_key_rotation_service_test.go`**

- `Test_getSliceConfig`: renamed the first case to clarify it covers API errors,
  and added a new case asserting `(nil, nil)` is returned on 404.
- `Test_DeleteVpnKeyRotationConfig`: four cases — happy path delete, idempotent
  no-op when CR is already absent, error on fetch, error on delete.

**`service/slice_config_service_test.go`**

- `setupSliceConfigTest` now returns the `*mocks.IVpnKeyRotationService` so
  deletion-path tests can set expectations on it.
- Three existing deletion tests updated to expect a `DeleteVpnKeyRotationConfig`
  call.
- New test `SliceConfigErrorOnDeleteVpnKeyRotationConfig`: verifies that an error
  from `DeleteVpnKeyRotationConfig` is propagated correctly and stops further
  processing.

Signed-off-by: pradhyum6144 <pradhyum314@gmail.com>