### PR TITLE
docs: update obsolete links in developer guide and contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ If you encounter a bug, please file an issue in the Github repository. Please pr
 
 
 ## Coding Guidelines
-* Follow good [coding guidelines](https://github.com/golang/go/wiki/CodeReviewComments).
+* Follow good [coding guidelines](https://go.dev/wiki/CodeReviewComments).
 * Write good [commit messages](https://github.com/angular/angular/blob/main/CONTRIBUTING.md#-commit-message-format).
 
 ## Developer Guide

--- a/developer_guide.md
+++ b/developer_guide.md
@@ -1,7 +1,7 @@
 # Development guidelines for KubeSlice Controller
 
 The KubeSlice Controller orchestrates the creation and management of slices on worker clusters.
-It is strongly recommended to use a released version. Follow the instructions provided in this [document](https://docs.avesha.io/opensource/installing-the-kubeslice-controller).
+It is strongly recommended to use a released version. Follow the instructions provided in this [document](https://docs.avesha.io/documentation/enterprise/1.16.0/category/install-kubeslice/).
 
 ## Building and Installing `kubeslice-controller` in a Local Kind Cluster
 For more information, see [getting started with kind clusters](https://docs.avesha.io/opensource/getting-started-with-kind-clusters).


### PR DESCRIPTION
## Description
This PR updates the obsolete links in `CONTRIBUTING.md` (coding guidelines moved to go.dev) and `developer_guide.md` (installation instructions link was 404ing). I also found that the "getting started with kind clusters" link is currently returning a 404 error with no available alternative - would like maintainer guidance on this.



## How Has This Been Tested?
No tests required

<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR require documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

