### PR TITLE
fix(): nil dereference in validateClustersOnUpdate and missing CNI overlap check for new clusters

### DIFF
--- a/service/slice_config_webhook_validation.go
+++ b/service/slice_config_webhook_validation.go
@@ -347,8 +347,15 @@ func validateClustersOnUpdate(ctx context.Context, sliceConfig *controllerv1alph
 		if cluster.Status.RegistrationStatus != controllerv1alpha1.RegistrationStatusRegistered {
 			return field.Invalid(field.NewPath("Spec").Child("Clusters"), clusterName, "cluster registration is not completed. Possible cause: Slice Operator installation is pending on the cluster.")
 		}
-		if cluster.Status.ClusterHealth.ClusterHealthStatus != controllerv1alpha1.ClusterHealthStatusNormal {
+		if cluster.Status.ClusterHealth != nil && cluster.Status.ClusterHealth.ClusterHealthStatus != controllerv1alpha1.ClusterHealthStatusNormal {
 			return field.Invalid(field.NewPath("Spec").Child("Clusters"), clusterName, "cluster health is not normal")
+		}
+		if sliceConfig.Spec.OverlayNetworkDeploymentMode != controllerv1alpha1.NONET {
+			for _, cniSubnet := range cluster.Status.CniSubnet {
+				if util.OverlapIP(cniSubnet, sliceConfig.Spec.SliceSubnet) {
+					return field.Invalid(field.NewPath("Spec").Child("SliceSubnet"), sliceConfig.Spec.SliceSubnet, "must not overlap with CniSubnet "+cniSubnet+" of cluster "+clusterName)
+				}
+			}
 		}
 	}
 	for i, clusterName := range sliceConfig.Spec.Clusters {

--- a/service/slice_config_webhook_validation_test.go
+++ b/service/slice_config_webhook_validation_test.go
@@ -77,6 +77,8 @@ var SliceConfigWebhookValidationTestBed = map[string]func(*testing.T){
 	"SliceConfigWebhookValidation_UpdateValidateSliceConfigWithClusterDoesNotExist":                                            UpdateValidateSliceConfigWithClusterDoesNotExist,
 	"SliceConfigWebhookValidation_UpdateValidateSliceConfigWithNewClustersDoesNotExist":                                        UpdateValidateSliceConfigWithNewClustersDoesNotExist,
 	"SliceConfigWebhookValidation_UpdateValidateSliceConfigWithNewClusterUnhealthy":                                            UpdateValidateSliceConfigWithNewClusterUnhealthy,
+	"SliceConfigWebhookValidation_UpdateValidateSliceConfigWithNewClusterNilHealth":                                            UpdateValidateSliceConfigWithNewClusterNilHealth,
+	"SliceConfigWebhookValidation_UpdateValidateSliceConfigWithNewClusterOverlappingCniSubnet":                                 UpdateValidateSliceConfigWithNewClusterOverlappingCniSubnet,
 	"SliceConfigWebhookValidation_UpdateValidateSliceConfigWithNewClusterRegistrationPending":                                  UpdateValidateSliceConfigWithNewClusterRegistrationPending,
 	"SliceConfigWebhookValidation_UpdateValidateSliceConfigWithNodeIPsEmptyInSpecAndStatusForParticipatingCluster":             UpdateValidateSliceConfigWithNodeIPsEmptyInSpecAndStatusForParticipatingCluster,
 	"SliceConfigWebhookValidation_UpdateValidateSliceConfigWithNodeIPsInSpecIsSuccess":                                         UpdateValidateSliceConfigWithNodeIPsInSpecIsSuccess,
@@ -1114,6 +1116,64 @@ func UpdateValidateSliceConfigWithNewClusterUnhealthy(t *testing.T) {
 	require.Contains(t, err.Error(), "Spec.Clusters: Invalid value:")
 	require.Contains(t, err.Error(), "cluster health is not normal")
 	require.Contains(t, err.Error(), newSliceConfig.Spec.Clusters[2])
+	clientMock.AssertExpectations(t)
+}
+
+func UpdateValidateSliceConfigWithNewClusterNilHealth(t *testing.T) {
+	name := "slice_config"
+	namespace := "namespace"
+	clientMock, newSliceConfig, ctx := setupSliceConfigWebhookValidationTest(name, namespace)
+	newSliceConfig.Spec.Clusters = []string{"cluster-1", "cluster-2"}
+	oldSliceConfig := newSliceConfig.DeepCopy()
+	newSliceConfig.Spec.Clusters = []string{"cluster-1", "cluster-2", "cluster-3"}
+	clientMock.On("Get", ctx, client.ObjectKey{
+		Name:      newSliceConfig.Spec.Clusters[2],
+		Namespace: namespace,
+	}, &controllerv1alpha1.Cluster{}).Return(nil).Run(func(args mock.Arguments) {
+		arg := args.Get(2).(*controllerv1alpha1.Cluster)
+		arg.Status.RegistrationStatus = controllerv1alpha1.RegistrationStatusRegistered
+		arg.Status.ClusterHealth = nil
+	}).Once()
+	// cluster has nil ClusterHealth (Slice Operator not yet installed); should not panic
+	// and should proceed past the health check
+	clientMock.On("Get", ctx, client.ObjectKey{
+		Name:      newSliceConfig.Spec.Clusters[0],
+		Namespace: namespace,
+	}, &controllerv1alpha1.Cluster{}).Return(nil).Run(func(args mock.Arguments) {
+		arg := args.Get(2).(*controllerv1alpha1.Cluster)
+		arg.Spec.NodeIPs = []string{"10.0.0.1"}
+	}).Once()
+	_, err := ValidateSliceConfigUpdate(ctx, newSliceConfig, runtime.Object(oldSliceConfig))
+	// no panic; cluster-1 passes (has NodeIPs), so error is nil or about something else — not a crash
+	require.NotContains(t, fmt.Sprintf("%v", err), "nil pointer")
+	clientMock.AssertExpectations(t)
+}
+
+func UpdateValidateSliceConfigWithNewClusterOverlappingCniSubnet(t *testing.T) {
+	name := "slice_config"
+	namespace := "namespace"
+	clientMock, newSliceConfig, ctx := setupSliceConfigWebhookValidationTest(name, namespace)
+	newSliceConfig.Spec.Clusters = []string{"cluster-1", "cluster-2"}
+	oldSliceConfig := newSliceConfig.DeepCopy()
+	newSliceConfig.Spec.Clusters = []string{"cluster-1", "cluster-2", "cluster-3"}
+	newSliceConfig.Spec.SliceSubnet = "192.168.0.0/16"
+	overlappingCniSubnet := "192.168.1.0/16"
+	clientMock.On("Get", ctx, client.ObjectKey{
+		Name:      newSliceConfig.Spec.Clusters[2],
+		Namespace: namespace,
+	}, &controllerv1alpha1.Cluster{}).Return(nil).Run(func(args mock.Arguments) {
+		arg := args.Get(2).(*controllerv1alpha1.Cluster)
+		arg.Status.RegistrationStatus = controllerv1alpha1.RegistrationStatusRegistered
+		arg.Status.ClusterHealth = &controllerv1alpha1.ClusterHealth{
+			ClusterHealthStatus: controllerv1alpha1.ClusterHealthStatusNormal,
+		}
+		arg.Status.CniSubnet = []string{overlappingCniSubnet}
+	}).Once()
+	_, err := ValidateSliceConfigUpdate(ctx, newSliceConfig, runtime.Object(oldSliceConfig))
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "Spec.SliceSubnet: Invalid value:")
+	require.Contains(t, err.Error(), "must not overlap with CniSubnet")
+	require.Contains(t, err.Error(), overlappingCniSubnet)
 	clientMock.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## Problem

### 1. Nil pointer dereference crashes the admission webhook

`validateClustersOnCreate` nil-guards `ClusterHealth` before reading
`ClusterHealthStatus`:

```go
if cluster.Status.ClusterHealth != nil && cluster.Status.ClusterHealth.ClusterHealthStatus != ...
```

`validateClustersOnUpdate` was missing the same guard:

```go
// before fix — panics when ClusterHealth is nil
if cluster.Status.ClusterHealth.ClusterHealthStatus != controllerv1alpha1.ClusterHealthStatusNormal {
```

A cluster that has just been registered but has not yet reported health
(`ClusterHealth == nil`, e.g. Slice Operator installation pending) triggers a
nil pointer dereference the moment any SliceConfig update touches that cluster.
The webhook server panics, the admission request is lost, and the pod restarts.

### 2. CNI subnet overlap not checked for newly added clusters in the first loop

The `newlyAddedClusters` loop validates registration status and health but skips
the CNI subnet overlap check entirely, delegating it to the second all-clusters
loop below. This means:

- The new-cluster onboarding validation is split across two separate loops and
  two separate API fetches for the same cluster object.
- The error field path produced for a newly added cluster with overlapping CNI
  comes from the second loop (`Spec.Clusters[i]`) rather than from the new-cluster
  context, making the error harder to act on.
- The `newlyAddedClusters` loop does not mirror `validateClustersOnCreate`, which
  performs the overlap check inline for each cluster in a single pass.

## Fix

**`service/slice_config_webhook_validation.go`**

- Add `cluster.Status.ClusterHealth != nil &&` guard before the
  `ClusterHealthStatus` comparison in the `newlyAddedClusters` loop, matching
  the existing pattern in `validateClustersOnCreate`.
- Add the CNI subnet overlap check at the end of the `newlyAddedClusters` loop,
  guarded by `OverlayNetworkDeploymentMode != NONET`, so that a newly added
  cluster is fully validated in a single pass before the all-clusters loop runs.

## Tests

**`service/slice_config_webhook_validation_test.go`**

- `UpdateValidateSliceConfigWithNewClusterNilHealth`: adds a cluster whose
  `ClusterHealth` is `nil`; asserts the webhook does not panic and that the
  response does not contain a nil pointer error.
- `UpdateValidateSliceConfigWithNewClusterOverlappingCniSubnet`: adds a cluster
  whose CNI subnet overlaps with the slice subnet; asserts the first loop now
  returns the overlap error with `Spec.SliceSubnet` field path.

Signed-off-by: pradhyum6144 <pradhyum314@gmail.com>