### PR TITLE
fix(): use gatewayNumber as VPN address octet to prevent collision in multi-cluster slices

### DIFF
--- a/service/mocks/IWorkerSliceGatewayService.go
+++ b/service/mocks/IWorkerSliceGatewayService.go
@@ -20,13 +20,13 @@ type IWorkerSliceGatewayService struct {
 	mock.Mock
 }
 
-// BuildNetworkAddresses provides a mock function with given fields: sliceSubnet, sourceClusterName, destinationClusterName, clusterMap, clusterCidr
-func (_m *IWorkerSliceGatewayService) BuildNetworkAddresses(sliceSubnet string, sourceClusterName string, destinationClusterName string, clusterMap map[string]int, clusterCidr string) util.WorkerSliceGatewayNetworkAddresses {
-	ret := _m.Called(sliceSubnet, sourceClusterName, destinationClusterName, clusterMap, clusterCidr)
+// BuildNetworkAddresses provides a mock function with given fields: sliceSubnet, sourceClusterName, destinationClusterName, clusterMap, clusterCidr, gatewayNumber
+func (_m *IWorkerSliceGatewayService) BuildNetworkAddresses(sliceSubnet string, sourceClusterName string, destinationClusterName string, clusterMap map[string]int, clusterCidr string, gatewayNumber int) util.WorkerSliceGatewayNetworkAddresses {
+	ret := _m.Called(sliceSubnet, sourceClusterName, destinationClusterName, clusterMap, clusterCidr, gatewayNumber)
 
 	var r0 util.WorkerSliceGatewayNetworkAddresses
-	if rf, ok := ret.Get(0).(func(string, string, string, map[string]int, string) util.WorkerSliceGatewayNetworkAddresses); ok {
-		r0 = rf(sliceSubnet, sourceClusterName, destinationClusterName, clusterMap, clusterCidr)
+	if rf, ok := ret.Get(0).(func(string, string, string, map[string]int, string, int) util.WorkerSliceGatewayNetworkAddresses); ok {
+		r0 = rf(sliceSubnet, sourceClusterName, destinationClusterName, clusterMap, clusterCidr, gatewayNumber)
 	} else {
 		r0 = ret.Get(0).(util.WorkerSliceGatewayNetworkAddresses)
 	}

--- a/service/vpn_key_rotation_service.go
+++ b/service/vpn_key_rotation_service.go
@@ -354,7 +354,7 @@ func (v *VpnKeyRotationService) triggerJobsForCertCreation(ctx context.Context, 
 			}
 			clusterMap := v.wscs.ComputeClusterMap(s.Spec.Clusters, workerSliceConfigs)
 			// contruct gw address
-			gatewayAddresses := v.wsgs.BuildNetworkAddresses(s.Spec.SliceSubnet, gateway.Spec.LocalGatewayConfig.ClusterName, gateway.Spec.RemoteGatewayConfig.ClusterName, clusterMap, clusterCidr)
+			gatewayAddresses := v.wsgs.BuildNetworkAddresses(s.Spec.SliceSubnet, gateway.Spec.LocalGatewayConfig.ClusterName, gateway.Spec.RemoteGatewayConfig.ClusterName, clusterMap, clusterCidr, gateway.Spec.GatewayNumber)
 			// call GenerateCerts()
 			if err := v.wsgs.GenerateCerts(ctx, s.Name, s.Namespace, gateway.Spec.GatewayProtocol, &gateway, cl, gatewayAddresses); err != nil {
 				return err

--- a/service/vpn_key_rotation_service_test.go
+++ b/service/vpn_key_rotation_service_test.go
@@ -587,7 +587,7 @@ func runReconcileVpnKeyRotationConfig(t *testing.T, tc *reconcileVpnKeyRotationC
 
 	gwAddress := util.WorkerSliceGatewayNetworkAddresses{}
 
-	wg.On("BuildNetworkAddresses", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(gwAddress).Once()
+	wg.On("BuildNetworkAddresses", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(gwAddress).Once()
 
 	wg.On("GenerateCerts", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
@@ -1101,7 +1101,7 @@ func runTriggerJobsForCertCreation(t *testing.T, tc triggerJobsForCertCreationTe
 
 	gwAddress := util.WorkerSliceGatewayNetworkAddresses{}
 
-	wg.On("BuildNetworkAddresses", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(gwAddress).Once()
+	wg.On("BuildNetworkAddresses", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(gwAddress).Once()
 
 	wg.On("GenerateCerts", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tc.generateCertsRet1).Once()
 

--- a/service/worker_slice_gateway_service.go
+++ b/service/worker_slice_gateway_service.go
@@ -54,7 +54,7 @@ type IWorkerSliceGatewayService interface {
 		serverGateway *v1alpha1.WorkerSliceGateway, clientGateway *v1alpha1.WorkerSliceGateway,
 		gatewayAddresses util.WorkerSliceGatewayNetworkAddresses) error
 	BuildNetworkAddresses(sliceSubnet, sourceClusterName, destinationClusterName string,
-		clusterMap map[string]int, clusterCidr string) util.WorkerSliceGatewayNetworkAddresses
+		clusterMap map[string]int, clusterCidr string, gatewayNumber int) util.WorkerSliceGatewayNetworkAddresses
 }
 
 // WorkerSliceGatewayService is a schema for interfaces JobService, WorkerSliceConfigService, SecretService
@@ -454,7 +454,7 @@ func (s *WorkerSliceGatewayService) createMinimumGatewaysIfNotExists(ctx context
 		for j := i + 1; j < noClusters; j++ {
 			sourceCluster, destinationCluster := clusterMapping[clusterNames[i]], clusterMapping[clusterNames[j]]
 			gatewayNumber := s.calculateGatewayNumber(clusterMap[sourceCluster.Name], clusterMap[destinationCluster.Name])
-			gatewayAddresses := s.BuildNetworkAddresses(sliceSubnet, sourceCluster.Name, destinationCluster.Name, clusterMap, clusterCidr)
+			gatewayAddresses := s.BuildNetworkAddresses(sliceSubnet, sourceCluster.Name, destinationCluster.Name, clusterMap, clusterCidr, gatewayNumber)
 			// determine the gateway svc parameters
 			sliceGwSvcType := defaultSliceGatewayServiceType
 			gwSvcProtocol := defaultSliceGatewayServiceProtocol
@@ -576,7 +576,7 @@ func (s *WorkerSliceGatewayService) createMinimumGateWayPairIfNotExists(ctx cont
 
 // buildNetworkAddresses - function generates the object of WorkerSliceGatewayNetworkAddresses
 func (s *WorkerSliceGatewayService) BuildNetworkAddresses(sliceSubnet, sourceClusterName, destinationClusterName string,
-	clusterMap map[string]int, clusterCidr string) util.WorkerSliceGatewayNetworkAddresses {
+	clusterMap map[string]int, clusterCidr string, gatewayNumber int) util.WorkerSliceGatewayNetworkAddresses {
 	gatewayAddresses := util.WorkerSliceGatewayNetworkAddresses{}
 	ipr := strings.Split(sliceSubnet, ".")
 	serverSubnet := util.GetClusterPrefixPool(sliceSubnet, clusterMap[sourceClusterName], clusterCidr)
@@ -585,9 +585,9 @@ func (s *WorkerSliceGatewayService) BuildNetworkAddresses(sliceSubnet, sourceClu
 	gatewayAddresses.ClientNetwork = strings.SplitN(clientSubnet, "/", -1)[0]
 	gatewayAddresses.ServerSubnet = serverSubnet
 	gatewayAddresses.ClientSubnet = clientSubnet
-	gatewayAddresses.ServerVpnNetwork = fmt.Sprintf("%s.%s.%d.%s", ipr[0], ipr[1], 255, "0")
-	gatewayAddresses.ServerVpnAddress = fmt.Sprintf("%s.%s.%d.%s", ipr[0], ipr[1], 255, "1")
-	gatewayAddresses.ClientVpnAddress = fmt.Sprintf("%s.%s.%d.%s", ipr[0], ipr[1], 255, "2")
+	gatewayAddresses.ServerVpnNetwork = fmt.Sprintf("%s.%s.%d.%s", ipr[0], ipr[1], gatewayNumber, "0")
+	gatewayAddresses.ServerVpnAddress = fmt.Sprintf("%s.%s.%d.%s", ipr[0], ipr[1], gatewayNumber, "1")
+	gatewayAddresses.ClientVpnAddress = fmt.Sprintf("%s.%s.%d.%s", ipr[0], ipr[1], gatewayNumber, "2")
 	return gatewayAddresses
 }
 


### PR DESCRIPTION
# Description

`BuildNetworkAddresses` hardcoded octet `255` for all gateway VPN addresses regardless of which cluster pair was being configured. For a slice with clusters A, B, C, the gateway pairs A↔B and A↔C both received the same VPN addresses (`10.x.255.1` / `10.x.255.2`), causing routing conflicts and broken connectivity for any slice with 3+ clusters.

`calculateGatewayNumber` already produces a unique integer per pair (stored in `gateway.Spec.GatewayNumber`), but it was unused in address allocation.

**Changes:**
- Added `gatewayNumber int` parameter to `BuildNetworkAddresses` (interface + implementation)
- Replaced hardcoded `255` with `gatewayNumber` as the third octet in `ServerVpnNetwork`, `ServerVpnAddress`, and `ClientVpnAddress`
- Updated call site in `createMinimumGatewaysIfNotExists` to pass the already-computed `gatewayNumber`
- Updated call site in `vpn_key_rotation_service.go` to pass `gateway.Spec.GatewayNumber`
- Updated mock and test matchers accordingly

Fixes #

## How Has This Been Tested?

- [x] `go build ./...` — clean
- [x] Mock and interface signatures verified consistent
- [x] `vpn_key_rotation_service_test.go` matchers updated to match new arity
- [x] Verified `calculateGatewayNumber` produces unique values for all cluster pair permutations

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [x] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?

Yes — worker-operator reads `VpnIp` from `WorkerSliceGateway.Spec.LocalGatewayConfig.VpnIp`. Addresses will change for existing gateway pairs on upgrade; tunnels will need re-establishment.

```release-note
fix: VPN address collision for slices with 3+ clusters — gateway pairs now receive unique VPN addresses derived from their gateway number instead of a hardcoded octet
```