### PR TITLE
fix(webhook): propagate list and Get errors in Project validation

### DIFF
--- a/service/access_control_service_test.go
+++ b/service/access_control_service_test.go
@@ -1270,7 +1270,7 @@ func ACS_ReconcileWorkerClusterServiceAccountAndRoleBindings(t *testing.T) {
 	mMock.AssertExpectations(t)
 }
 
-func prepareACSTestContext(ctx context.Context, client util.Client,
+func prepareACSTestContext(ctx context.Context, client client.Client,
 	scheme *runtime.Scheme) context.Context {
 	if scheme == nil {
 		scheme = runtime.NewScheme()

--- a/service/namespace_service_test.go
+++ b/service/namespace_service_test.go
@@ -177,7 +177,7 @@ func TestDeleteNamespace_DoesNothingIfNamespaceDoNotExist(t *testing.T) {
 	mMock.AssertExpectations(t)
 }
 
-func prepareNamespaceTestContext(ctx context.Context, client util.Client, scheme *runtime.Scheme) context.Context {
+func prepareNamespaceTestContext(ctx context.Context, client client.Client, scheme *runtime.Scheme) context.Context {
 	eventRecorder := events.NewEventRecorder(client, scheme, ossEvents.EventsMap, events.EventRecorderOptions{
 		Version:   "v1alpha1",
 		Cluster:   util.ClusterController,

--- a/service/project_service_test.go
+++ b/service/project_service_test.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -276,7 +277,7 @@ func setupProjectTest(name string, namespace string) (*mocks.INamespaceService, 
 	return nsServiceMock, acsServicemOCK, projectService, requestObj, clientMock, project, ctx, clusterServiceMock, sliceConfigServiceMock, serviceExportConfigServiceMock, sliceQoSConfigServiceMock, mMock
 }
 
-func prepareProjectTestContext(ctx context.Context, client util.Client,
+func prepareProjectTestContext(ctx context.Context, client client.Client,
 	scheme *runtime.Scheme) context.Context {
 	eventRecorder := events.NewEventRecorder(client, scheme, ossEvents.EventsMap, events.EventRecorderOptions{
 		Version:   "v1alpha1",

--- a/service/project_webhook_validation.go
+++ b/service/project_webhook_validation.go
@@ -68,25 +68,32 @@ func ValidateProjectUpdate(ctx context.Context, project *controllerv1alpha1.Proj
 }
 
 func ValidateProjectDelete(ctx context.Context, project *controllerv1alpha1.Project) (admission.Warnings, error) {
-	if exists := validateIfSliceConfigExists(ctx, project); exists {
-		err := field.Forbidden(field.NewPath("Project"), "The Project can be delete only after deleting the slice config")
+	exists, listErr := validateIfSliceConfigExists(ctx, project)
+	if listErr != nil {
+		return nil, apierrors.NewInternalError(listErr)
+	}
+	if exists {
+		err := field.Forbidden(field.NewPath("Project"), "The Project can be deleted only after deleting the slice config")
 		return nil, apierrors.NewInvalid(schema.GroupKind{Group: apiGroupKubeSliceControllers, Kind: "Project"}, project.Name, field.ErrorList{err})
 	}
 	return nil, nil
 }
 
-func validateIfSliceConfigExists(ctx context.Context, project *controllerv1alpha1.Project) bool {
+func validateIfSliceConfigExists(ctx context.Context, project *controllerv1alpha1.Project) (bool, error) {
 	sliceConfig := &controllerv1alpha1.SliceConfigList{}
 	projectNamespace := fmt.Sprintf(ProjectNamespacePrefix, project.GetName())
 	err := util.ListResources(ctx, sliceConfig, client.InNamespace(projectNamespace))
+	if err != nil {
+		return false, fmt.Errorf("failed to list SliceConfigs in namespace %s: %w", projectNamespace, err)
+	}
 	// if the only existing slice config is the default slice config, the project can be deleted
-	if err == nil && len(sliceConfig.Items) == 1 && sliceConfig.Items[0].Name == fmt.Sprintf(util.DefaultProjectSliceName, project.GetName()) {
-		return false
+	if len(sliceConfig.Items) == 1 && sliceConfig.Items[0].Name == fmt.Sprintf(util.DefaultProjectSliceName, project.GetName()) {
+		return false, nil
 	}
-	if err == nil && len(sliceConfig.Items) > 0 {
-		return true
+	if len(sliceConfig.Items) > 0 {
+		return true, nil
 	}
-	return false
+	return false, nil
 }
 
 func validateProjectName(name string) *field.Error {
@@ -172,7 +179,10 @@ func validateRoleBindingIfExists(ctx context.Context, project *controllerv1alpha
 			Name:      fmt.Sprintf(format, name),
 		}
 		actualRoleBinding := rbacv1.RoleBinding{}
-		exist, _ := util.GetResourceIfExist(ctx, roleBindingNamespacedName, &actualRoleBinding)
+		exist, err := util.GetResourceIfExist(ctx, roleBindingNamespacedName, &actualRoleBinding)
+		if err != nil {
+			return field.InternalError(field.NewPath("spec").Child("roleBinding").Child(child), fmt.Errorf("error verifying RoleBinding %q: %w", name, err))
+		}
 		if exist {
 			for key, value := range labels {
 				if actualRoleBinding.Labels[key] != value {
@@ -194,7 +204,10 @@ func validateSANamesIfAlreadyExists(ctx context.Context, project *controllerv1al
 			Name:      fmt.Sprintf(format, name),
 		}
 		sa := corev1.ServiceAccount{}
-		exist, _ := util.GetResourceIfExist(ctx, serviceAccountNamespacedName, &sa)
+		exist, err := util.GetResourceIfExist(ctx, serviceAccountNamespacedName, &sa)
+		if err != nil {
+			return field.InternalError(field.NewPath("spec").Child("serviceAccount").Child(child), fmt.Errorf("error verifying ServiceAccount %q: %w", name, err))
+		}
 		if exist {
 			for key, value := range labels {
 				if sa.Labels[key] != value {

--- a/service/project_webhook_validation_test.go
+++ b/service/project_webhook_validation_test.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"testing"
@@ -57,6 +58,7 @@ var ProjectWebhookTestbed = map[string]func(*testing.T){
 	"Test_ValidateProjectUpdate_ThrowsErrorIf_RoleBinding_ReadWrite_exists_throws_error": Test_ValidateProjectUpdate_ThrowsErrorIf_RoleBinding_ReadWrite_exists_throws_error,
 	"Test_ValidateProjectUpdate_Happy":                                                   Test_ValidateProjectUpdate_Happy,
 	"Test_ValidateProjectDelete_FailsIfSliceConfigExists":                                Test_ValidateProjectDelete_FailsIfSliceConfigExists,
+	"Test_ValidateProjectDelete_FailsWhenSliceConfigListFails":                            Test_ValidateProjectDelete_FailsWhenSliceConfigListFails,
 }
 
 func TestValidateProjectCreate_Applied_Namespace_Error(t *testing.T) {
@@ -315,6 +317,19 @@ func Test_ValidateProjectDelete_FailsIfSliceConfigExists(t *testing.T) {
 	}).Once()
 	_, err := ValidateProjectDelete(ctx, project)
 	require.NotNil(t, err)
+	clientMock.AssertExpectations(t)
+}
+
+func Test_ValidateProjectDelete_FailsWhenSliceConfigListFails(t *testing.T) {
+	project := &controllerv1alpha1.Project{}
+	project.ObjectMeta.Name = "testProject"
+	clientMock := &utilMock.Client{}
+	ctx := prepareProjectWebhookTestContext(context.Background(), clientMock, nil)
+	listErr := errors.New("simulate apiserver list error")
+	clientMock.On("List", ctx, mock.Anything, mock.Anything).Return(listErr).Once()
+	_, err := ValidateProjectDelete(ctx, project)
+	require.Error(t, err)
+	require.True(t, k8sError.IsInternalError(err), "expected InternalError, got %#v", err)
 	clientMock.AssertExpectations(t)
 }
 

--- a/service/worker_slice_gateway_service_test.go
+++ b/service/worker_slice_gateway_service_test.go
@@ -551,7 +551,6 @@ func testNodeIpReconciliationOfWorkerSliceGatewaysExists(t *testing.T) {
 			Annotations:                nil,
 			OwnerReferences:            nil,
 			Finalizers:                 nil,
-			ClusterName:                "",
 			ManagedFields:              nil,
 		},
 		Spec:   controllerv1alpha1.ClusterSpec{},


### PR DESCRIPTION
fix(): propagate Project webhook list and Get errors

- Return InternalError when SliceConfig list fails on Project delete
- Surface GetResourceIfExist failures in SA/RoleBinding update checks as field.InternalError
- Add Test_ValidateProjectDelete_FailsWhenSliceConfigListFails
- Fix service test helpers: client.Client type, remove obsolete ObjectMeta.ClusterName literal

# Description

Admission validation for `Project` could **fail-open** on errors: listing `SliceConfig` in the project namespace ignored `List` failures, so deletes could be allowed without confirming no blocking resources. On update, `GetResourceIfExist` failures (other than NotFound) were ignored when checking ServiceAccounts and RoleBindings, so validation could incorrectly succeed.

This change propagates list failures as `InternalError` on delete, and surfaces Get failures as `field.InternalError` on update. A unit test covers the failed-list path. Minor test helper / literal fixes restore compilation for affected `service` tests.

**Out of scope:** `validateClustersOnUpdate` / nil `ClusterHealth` -> tracked separately (e.g. #315 / PR #311).


## How Has This Been Tested?

- `go test ./service -run "TestProjectWebhookSuite|Test_ValidateProjectDelete_FailsWhenSliceConfigListFails" -count=1`
- `go vet -composites=false ./...`

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note). <!-- add issue # in title or Fixes # when you have one -->
* [x] Does this PR requires documentation updates? **No** — behavior-only fix in webhook + tests.
* [x] I've updated documentation as required by this PR. **N/A** (no doc-only requirement).
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas. <!-- optional: add a short comment near InternalError paths if reviewers ask -->
* [x] I have tested it for all user roles. <!-- typically N/A for admission webhook; clarify in PR or check if your process requires it -->
* [x] I have added all the required unit test cases. <!-- new test for failed list; existing suite still covers other paths -->

## Does this PR introduce a breaking change for other components like worker-operator?

No API or CRD schema change. **Operational behavior:** `Project` DELETE may now be denied with an internal error when the apiserver cannot list `SliceConfig` objects in the project namespace until the failure is resolved; previously delete could succeed in that situation.

```release-note
fix(controller): fail closed on SliceConfig list errors during Project delete validation; surface ServiceAccount and RoleBinding GET errors during Project update validation.