### PR TITLE
fix(): block cluster removal from SliceConfig while namespaces are still deboarding

### DIFF
--- a/service/slice_config_webhook_validation.go
+++ b/service/slice_config_webhook_validation.go
@@ -331,11 +331,50 @@ func validateClustersOnCreate(ctx context.Context, sliceConfig *controllerv1alph
 	return nil
 }
 
+// checkClusterRemovalSafety blocks removal of a cluster from a slice while its
+// WorkerSliceConfig still has onboarded or pending-deboard namespaces.
+func checkClusterRemovalSafety(ctx context.Context, sliceConfig *controllerv1alpha1.SliceConfig, removedCluster string) *field.Error {
+	workerSlices := &workerv1alpha1.WorkerSliceConfigList{}
+	labels := map[string]string{
+		"original-slice-name": sliceConfig.Name,
+		"worker-cluster":      removedCluster,
+	}
+	if err := util.ListResources(ctx, workerSlices, client.MatchingLabels(labels), client.InNamespace(sliceConfig.Namespace)); err != nil {
+		return nil
+	}
+	for _, slice := range workerSlices.Items {
+		if len(slice.Spec.NamespaceIsolationProfile.ApplicationNamespaces) > 0 {
+			return &field.Error{
+				Type:     field.ErrorTypeForbidden,
+				Field:    field.NewPath("Spec").Child("Clusters").String(),
+				BadValue: removedCluster,
+				Detail:   fmt.Sprintf("deboard namespaces from cluster %q before removal: %d namespace(s) still configured", removedCluster, len(slice.Spec.NamespaceIsolationProfile.ApplicationNamespaces)),
+			}
+		}
+		if len(slice.Status.OnboardedAppNamespaces) > 0 {
+			return &field.Error{
+				Type:     field.ErrorTypeInternal,
+				Field:    field.NewPath("Spec").Child("Clusters").String(),
+				BadValue: removedCluster,
+				Detail:   fmt.Sprintf("namespace deboarding in progress for cluster %q: %d namespace(s) still onboarded, please try after some time", removedCluster, len(slice.Status.OnboardedAppNamespaces)),
+			}
+		}
+	}
+	return nil
+}
+
 // validateClustersOnUpdate is function to validate the cluster specification
 func validateClustersOnUpdate(ctx context.Context, sliceConfig *controllerv1alpha1.SliceConfig, old runtime.Object) *field.Error {
 	oldSc := old.(*controllerv1alpha1.SliceConfig)
 	if duplicate, value := util.CheckDuplicateInArray(sliceConfig.Spec.Clusters); duplicate {
 		return field.Duplicate(field.NewPath("Spec").Child("Clusters"), strings.Join(value, ", "))
+	}
+	// Guard cluster removal: block if the outgoing cluster still has active namespaces.
+	removedClusters := util.DifferenceOfArray(oldSc.Spec.Clusters, sliceConfig.Spec.Clusters)
+	for _, clusterName := range removedClusters {
+		if err := checkClusterRemovalSafety(ctx, sliceConfig, clusterName); err != nil {
+			return err
+		}
 	}
 	newlyAddedClusters := util.DifferenceOfArray(sliceConfig.Spec.Clusters, oldSc.Spec.Clusters)
 	for _, clusterName := range newlyAddedClusters {

--- a/service/slice_config_webhook_validation_test.go
+++ b/service/slice_config_webhook_validation_test.go
@@ -119,6 +119,9 @@ var SliceConfigWebhookValidationTestBed = map[string]func(*testing.T){
 	"TestValidateRotationInterval_NoChange":                                                                                    TestValidateRotationInterval_NoChange,
 	"SliceConfigWebhookValidation_UpdateValidateSliceConfigUpdatingVPNCipher":                                                  UpdateValidateSliceConfigUpdatingVPNCipher,
 	"Test_validateSlicegatewayServiceType":                                                                                     test_validateSlicegatewayServiceType,
+	"SliceConfigWebhookValidation_UpdateValidateSliceConfigRemoveClusterWithOnboardedNamespaces":                               UpdateValidateSliceConfigRemoveClusterWithOnboardedNamespaces,
+	"SliceConfigWebhookValidation_UpdateValidateSliceConfigRemoveClusterWithApplicationNamespaces":                             UpdateValidateSliceConfigRemoveClusterWithApplicationNamespaces,
+	"SliceConfigWebhookValidation_UpdateValidateSliceConfigRemoveClusterAllNamespacesDrained":                                  UpdateValidateSliceConfigRemoveClusterAllNamespacesDrained,
 }
 
 func test_validateSlicegatewayServiceType(t *testing.T) {
@@ -2315,4 +2318,92 @@ func setupSliceConfigWebhookValidationTest(name string, namespace string) (*util
 
 	ctx := util.PrepareKubeSliceControllersRequestContext(context.Background(), clientMock, nil, "SliceConfigWebhookValidationServiceTest", nil)
 	return clientMock, sliceConfig, ctx
+}
+
+// UpdateValidateSliceConfigRemoveClusterWithOnboardedNamespaces verifies that removing a cluster
+// is blocked when its WorkerSliceConfig still has OnboardedAppNamespaces in status (deboarding in progress).
+func UpdateValidateSliceConfigRemoveClusterWithOnboardedNamespaces(t *testing.T) {
+	name := "slice_config"
+	namespace := "namespace"
+	clientMock, newSliceConfig, ctx := setupSliceConfigWebhookValidationTest(name, namespace)
+
+	oldSliceConfig := &controllerv1alpha1.SliceConfig{}
+	oldSliceConfig.Spec.Clusters = []string{"cluster-1", "cluster-2"}
+
+	newSliceConfig.Spec.Clusters = []string{"cluster-1"}
+	newSliceConfig.Spec.OverlayNetworkDeploymentMode = controllerv1alpha1.NONET
+
+	// List WorkerSliceConfigs for cluster-2 — still has onboarded namespaces.
+	workerSliceConfig := &workerv1alpha1.WorkerSliceConfigList{}
+	clientMock.On("List", ctx, workerSliceConfig, mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		arg := args.Get(1).(*workerv1alpha1.WorkerSliceConfigList)
+		arg.Items = make([]workerv1alpha1.WorkerSliceConfig, 1)
+		arg.Items[0].Status.OnboardedAppNamespaces = []workerv1alpha1.NamespaceConfig{
+			{Name: "ns-alpha"},
+			{Name: "ns-beta"},
+		}
+	}).Once()
+
+	err := validateClustersOnUpdate(ctx, newSliceConfig, oldSliceConfig)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "namespace deboarding in progress for cluster")
+	clientMock.AssertExpectations(t)
+}
+
+// UpdateValidateSliceConfigRemoveClusterWithApplicationNamespaces verifies that removing a cluster
+// is blocked when its WorkerSliceConfig still has ApplicationNamespaces in spec (not yet deboarded).
+func UpdateValidateSliceConfigRemoveClusterWithApplicationNamespaces(t *testing.T) {
+	name := "slice_config"
+	namespace := "namespace"
+	clientMock, newSliceConfig, ctx := setupSliceConfigWebhookValidationTest(name, namespace)
+
+	oldSliceConfig := &controllerv1alpha1.SliceConfig{}
+	oldSliceConfig.Spec.Clusters = []string{"cluster-1", "cluster-2"}
+
+	newSliceConfig.Spec.Clusters = []string{"cluster-1"}
+	newSliceConfig.Spec.OverlayNetworkDeploymentMode = controllerv1alpha1.NONET
+
+	// List WorkerSliceConfigs for cluster-2 — ApplicationNamespaces not yet cleared.
+	workerSliceConfig := &workerv1alpha1.WorkerSliceConfigList{}
+	clientMock.On("List", ctx, workerSliceConfig, mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		arg := args.Get(1).(*workerv1alpha1.WorkerSliceConfigList)
+		arg.Items = make([]workerv1alpha1.WorkerSliceConfig, 1)
+		arg.Items[0].Spec.NamespaceIsolationProfile.ApplicationNamespaces = []string{"ns-alpha", "ns-beta"}
+	}).Once()
+
+	err := validateClustersOnUpdate(ctx, newSliceConfig, oldSliceConfig)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "deboard namespaces from cluster")
+	clientMock.AssertExpectations(t)
+}
+
+// UpdateValidateSliceConfigRemoveClusterAllNamespacesDrained verifies that removing a cluster
+// is allowed when all namespaces have been deboarded (both Spec and Status are clean).
+func UpdateValidateSliceConfigRemoveClusterAllNamespacesDrained(t *testing.T) {
+	name := "slice_config"
+	namespace := "namespace"
+	clientMock, newSliceConfig, ctx := setupSliceConfigWebhookValidationTest(name, namespace)
+
+	oldSliceConfig := &controllerv1alpha1.SliceConfig{}
+	oldSliceConfig.Spec.Clusters = []string{"cluster-1", "cluster-2"}
+
+	newSliceConfig.Spec.Clusters = []string{"cluster-1"}
+	newSliceConfig.Spec.OverlayNetworkDeploymentMode = controllerv1alpha1.NONET
+
+	// List WorkerSliceConfigs for cluster-2 — fully drained, empty items.
+	workerSliceConfig := &workerv1alpha1.WorkerSliceConfigList{}
+	clientMock.On("List", ctx, workerSliceConfig, mock.Anything, mock.Anything).Return(nil).Once()
+
+	// Get for cluster-1 in the all-clusters validation loop.
+	clientMock.On("Get", ctx, client.ObjectKey{
+		Name:      "cluster-1",
+		Namespace: namespace,
+	}, &controllerv1alpha1.Cluster{}).Return(nil).Run(func(args mock.Arguments) {
+		arg := args.Get(2).(*controllerv1alpha1.Cluster)
+		arg.Spec.NodeIPs = []string{"10.10.1.1"}
+	}).Once()
+
+	err := validateClustersOnUpdate(ctx, newSliceConfig, oldSliceConfig)
+	require.Nil(t, err)
+	clientMock.AssertExpectations(t)
 }


### PR DESCRIPTION
# Description

Removing a cluster from `sliceConfig.Spec.Clusters` immediately triggers gateway and WorkerSliceConfig deletion in the reconciler. There is no pre-removal check, so in-flight traffic is dropped with no warning if namespaces are still active on that cluster.

This PR adds a webhook validation guard that runs before the reconciler ever touches the cluster.

**Root cause:**
`validateClustersOnUpdate` used `DifferenceOfArray` to find *newly added* clusters and validate them, but had no corresponding check for *removed* clusters.

**Changes:**

*`service/slice_config_webhook_validation.go`*
- Added `checkClusterRemovalSafety(ctx, sliceConfig, removedCluster)`: lists the `WorkerSliceConfig` for the outgoing cluster (filtered by `original-slice-name` + `worker-cluster` labels) and returns a `field.Error` if either:
  - `Spec.NamespaceIsolationProfile.ApplicationNamespaces` is non-empty (namespaces still configured, not yet deboarded)
  - `Status.OnboardedAppNamespaces` is non-empty (deboarding in progress on the worker)
- Wired into `validateClustersOnUpdate`: computes `removedClusters = DifferenceOfArray(old, new)` and calls `checkClusterRemovalSafety` for each before any other update logic

*`service/slice_config_webhook_validation_test.go`*
- `UpdateValidateSliceConfigRemoveClusterWithOnboardedNamespaces`: removal blocked when `Status.OnboardedAppNamespaces` is non-empty
- `UpdateValidateSliceConfigRemoveClusterWithApplicationNamespaces`: removal blocked when `Spec.NamespaceIsolationProfile.ApplicationNamespaces` is non-empty
- `UpdateValidateSliceConfigRemoveClusterAllNamespacesDrained`: removal allowed when both lists are empty

The pattern is intentionally consistent with `checkNamespaceDeboardingStatus` used in `ValidateSliceConfigDelete`.

Fixes #

## How Has This Been Tested?

- [x] `go build ./...` — clean
- [x] Three new tests covering both block paths and the safe-removal pass path
- [x] Verified mock expectations align with the two-label `List` call for the specific cluster

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [x] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?

No — this is a webhook admission change only. Existing slices are unaffected until a cluster removal is attempted while namespaces are active.

```release-note
fix: cluster removal from SliceConfig is now blocked at admission if the outgoing cluster still has onboarded or pending-deboard namespaces, preventing silent in-flight traffic drops
```