### PR TITLE
fix: prevent panic when VPNConfig is removed during SliceConfig update

### DIFF
--- a/service/slice_config_webhook_validation.go
+++ b/service/slice_config_webhook_validation.go
@@ -423,7 +423,7 @@ func preventUpdate(ctx context.Context, sc *controllerv1alpha1.SliceConfig, old 
 		return field.Invalid(field.NewPath("Spec").Child("SliceIpamType"), sc.Spec.SliceIpamType, "cannot be updated")
 	}
 	// required if slice from previous releases is upgraded
-	if sliceConfig.Spec.VPNConfig != nil {
+	if sliceConfig.Spec.VPNConfig != nil && sc.Spec.VPNConfig != nil {
 		if sliceConfig.Spec.VPNConfig.Cipher != sc.Spec.VPNConfig.Cipher {
 			return field.Invalid(field.NewPath("Spec").Child("VPNConfig").Child("Cipher"), sc.Spec.VPNConfig.Cipher, "cannot be updated")
 		}


### PR DESCRIPTION
## Summary

Fixes a nil pointer dereference panic in preventUpdate when updating a SliceConfig that removes the VPNConfig field.

The function checks if the old object has VPNConfig but then unconditionally dereferences the new object VPNConfig.Cipher without checking if the new object VPNConfig is also non-nil.

## Fix

Add a nil check for the new object VPNConfig, matching the pattern already used for SliceGatewayProvider validation on line 414.

One line change: add `&& sc.Spec.VPNConfig != nil` to the existing guard.

## Testing

- All existing VPNConfig tests set both old and new VPNConfig to non-nil, so this change does not affect them
- The fix adds a guard for the previously untested nil case

Fixes #322