### PR TITLE
fix: clone labels map in buildMinimumGateway to prevent shared mutation

### DIFF
--- a/service/worker_slice_gateway_service.go
+++ b/service/worker_slice_gateway_service.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"maps"
 	"reflect"
 	"strings"
 	"time"
@@ -595,6 +596,7 @@ func (s *WorkerSliceGatewayService) BuildNetworkAddresses(sliceSubnet, sourceClu
 func (s *WorkerSliceGatewayService) buildMinimumGateway(sourceCluster, destinationCluster *controllerv1alpha1.Cluster,
 	sliceName, namespace, gatewayHostType, gatewayConnType, gatewayProtocol string, labels map[string]string, gatewayNumber int,
 	gatewaySubnet, localVpnAddress, remoteGatewayName, remoteGatewaySubnet, remoteVpnAddress, localGatewayName string) *v1alpha1.WorkerSliceGateway {
+	labels = maps.Clone(labels)
 	labels["worker-cluster"] = sourceCluster.Name
 	labels["remote-cluster"] = destinationCluster.Name
 	labels["kubeslice-manager"] = "controller"


### PR DESCRIPTION
## Summary

Fixes a shared map mutation bug in buildMinimumGateway that corrupts server gateway labels.

The function directly mutates the labels map parameter instead of cloning it first. Since createMinimumGateWayPairIfNotExists calls this function twice with the same labels map, the second call overwrites the first call values. Both gateway objects end up pointing to the same map with the client gateway values, corrupting the server gateway labels.

## Fix

Clone the labels map at the start of buildMinimumGateway using maps.Clone so each gateway gets its own independent labels map.

Two lines changed: add maps import and add maps.Clone(labels) at the start of the function.

## Testing

- All existing tests pass (pre-existing unrelated build failures not caused by this change)
- The fix is a pure defensive copy — existing behavior is preserved for single-call cases, and the shared-mutation bug is fixed for the two-call case

Fixes #324