### PR TITLE
fix: upsert project labels instead of overwriting entire map

### DIFF
--- a/service/project_service.go
+++ b/service/project_service.go
@@ -166,9 +166,10 @@ func (t *ProjectService) ReconcileProject(ctx context.Context, req ctrl.Request)
 	}
 
 	// Step 7: adding ProjectNamespace in labels
-	labels := make(map[string]string)
-	labels["kubeslice-project-namespace"] = projectNamespace
-	project.Labels = labels
+	if project.Labels == nil {
+		project.Labels = make(map[string]string)
+	}
+	project.Labels["kubeslice-project-namespace"] = projectNamespace
 
 	err = util.UpdateResource(ctx, project)
 	if err != nil {


### PR DESCRIPTION
# Description

`ReconcileProject` in `service/project_service.go` at lines 169-171 was creating a brand-new single-key map and assigning it to `project.Labels`, silently wiping all existing labels on every reconciliation cycle. This destroyed user-defined labels, ConfigMap-sourced labels merged at lines 117-122, and labels set by external tooling (Argo CD, Flux, Helm).

Fix: nil-check and upsert into the existing map, matching the pattern already used at lines 117-122 in the same function.

Fixes #318

## How Has This Been Tested?

- [x] Verified the fix compiles without errors
- [x] Confirmed the change is a 1:1 match with the existing nil-check-and-upsert pattern at lines 117-122 in the same function
- [x] Manual review: the only behavioral change is preserving existing labels instead of deleting them

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?

No. This is a defensive fix that preserves existing labels instead of deleting them. No API changes, no new fields, no behavioral change for components that only read `kubeslice-project-namespace`.

```release-note

```