### PR TITLE
  chore(ci): update Dockerfiles to use golang:1.24 matching go.mod

### DIFF
--- a/integration.dockerfile
+++ b/integration.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.10 as builder
+FROM golang:1.24 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/unit_tests.dockerfile
+++ b/unit_tests.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19 as builder
+FROM golang:1.24 as builder
 COPY . /build
 WORKDIR /build/service
 ENV ALLURE_RESULTS_PATH=/build


### PR DESCRIPTION
  # Description

  Both `unit_tests.dockerfile` and `integration.dockerfile` referenced outdated Go base images that cannot compile this module. `unit_tests.dockerfile` used `golang:1.19` and `integration.dockerfile` used `golang:1.21.10`; `go.mod` declares `go 1.24.0`. The Go toolchain rejects both builds with `note: module requires Go >= 1.24`, breaking all CI Docker build jobs. This PR updates both files to `golang:1.24`.

  ## How Has This Been Tested?

  - `unit_tests.dockerfile:1` changed from `golang:1.19` to `golang:1.24`.
  - `integration.dockerfile:1` changed from `golang:1.21.10` to `golang:1.24`.
  - Both match `go.mod:3` (`go 1.24.0`).
  - No Go source files were touched — both changes are single-line Dockerfile updates.
  - `make fmt vet` and `go build ./...` pass locally in WSL.

  ## Checklist:

  * [x] The title of the PR states what changed and the related issues number (used for the release note).
  * [x] Does this PR requires documentation updates? — No.
  * [x] I've updated documentation as required by this PR.
  * [x] I have performed a self-review of my own code.
  * [x] I have commented my code, particularly in hard-to-understand areas. — N/A.
  * [x] I have tested it for all user roles. — N/A.
  * [ ] I have added all the required unit test cases.

  ## Does this PR introduce a breaking change for other components like worker-operator?

  No

  ```release-note
Fix unit_tests.dockerfile and integration.dockerfile to use golang:1.24, matching the go.mod minimum version requirement