### PR TITLE
fix(util): correct HasPrefix to check prefix not suffix

### DIFF
--- a/service/slice_config_webhook_validation.go
+++ b/service/slice_config_webhook_validation.go
@@ -264,7 +264,7 @@ func validateSliceSubnet(sliceConfig *controllerv1alpha1.SliceConfig) *field.Err
 	if !util.IsPrivateSubnet(sliceConfig.Spec.SliceSubnet) {
 		return field.Invalid(field.NewPath("Spec").Child("sliceSubnet"), sliceConfig.Spec.SliceSubnet, "must be a private subnet")
 	}
-	if !util.HasPrefix(sliceConfig.Spec.SliceSubnet, "16") {
+	if !strings.HasSuffix(sliceConfig.Spec.SliceSubnet, "/16") {
 		return field.Invalid(field.NewPath("Spec").Child("sliceSubnet"), sliceConfig.Spec.SliceSubnet, "prefix must be 16")
 	}
 	if !util.HasLastTwoOctetsZero(sliceConfig.Spec.SliceSubnet) {

--- a/util/common.go
+++ b/util/common.go
@@ -86,7 +86,7 @@ func IsPrivateSubnet(subnet string) bool {
 
 // HasPrefix is function to check if the string has given prefix
 func HasPrefix(subnet string, prefix string) bool {
-	return subnet[len(subnet)-2:] == prefix
+	return strings.HasPrefix(subnet, prefix)
 }
 
 // HasLastTwoOctetsZero is a function to check if the subnet address's last octet is 0

--- a/util/common_test.go
+++ b/util/common_test.go
@@ -1,0 +1,15 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasPrefix(t *testing.T) {
+	assert.True(t, HasPrefix("10.0.0.0/16", "10."))
+	assert.True(t, HasPrefix("10.0.0.0/16", "10.0.0.0/16"))
+	assert.False(t, HasPrefix("10.0.0.0/16", "/16"))
+	assert.False(t, HasPrefix("10.0.0.0/16", "192."))
+	assert.True(t, HasPrefix("10.0.0.0/16", ""))
+}


### PR DESCRIPTION
# Description

`util.HasPrefix` was implemented as `subnet[len(subnet)-2:] == prefix` — a suffix check, not a prefix check. Fixed to use `strings.HasPrefix`.

The sole caller in `validateSliceSubnet` (`slice_config_webhook_validation.go:267`) was passing `"16"` to check that a CIDR subnet ends with `/16`. This worked by coincidence under the old suffix implementation but would silently reject all valid subnets under the corrected one. The caller is now fixed to use `strings.HasSuffix(subnet, "/16")` directly, which expresses the intent correctly.

Fixes #332 

## How Has This Been Tested?

- [x] Unit tests added in `util/common_test.go` covering prefix, full-string, non-prefix, and empty-string cases
- [x] `go build ./...` passes cleanly

## Checklist:
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR require documentation updates?
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?

No. The CIDR validation behavior is unchanged — `/16` subnets still pass, non-`/16` subnets still fail. Only the implementation correctness and coincidence-dependency are fixed.

```release-note
fix(util): correct HasPrefix to perform a true prefix check; update CIDR mask validator to use strings.HasSuffix
```