### PR TITLE
feat(): add HA kustomize overlay for controller

### DIFF
--- a/config/ha/kustomization.yaml
+++ b/config/ha/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+  - ../default
+
+resources:
+  - pdb.yaml
+
+patchesStrategicMerge:
+  - manager_ha_patch.yaml

--- a/config/ha/manager_ha_patch.yaml
+++ b/config/ha/manager_ha_patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: manager
+  namespace: system
+spec:
+  replicas: 2
+  template:
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    control-plane: controller-manager

--- a/config/ha/pdb.yaml
+++ b/config/ha/pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: kubeslice-controller-pdb
+  namespace: kubeslice-controller
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      control-plane: controller-manager


### PR DESCRIPTION


<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs() - The PR contains Documentation ONLY changes. 
- feat() - The PR contains new feature/enhancements.
- fix() - The PR contains a bug fix.
- chore() - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test() - Development changes related to tests.
- perf() - Changes related to performance improvements.

Example Title: 
feat(): New field addition for Cluster CRD 
-->

## Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Adds a config/ha/ kustomize overlay that renders a two-replica HA deployment
of the controller without modifying the default single-replica base.

Changes:
- config/ha/kustomization.yaml - bases off ../default, includes PDB, applies patch
- config/ha/manager_ha_patch.yaml - sets replicas=2, adds podAntiAffinity
  (preferredDuringScheduling, topologyKey: kubernetes.io/hostname)
- config/ha/pdb.yaml - PodDisruptionBudget with minAvailable: 1

The default base (config/manager) is untouched - no regression to existing deployments.
This is a prerequisite for the e2e HA test suite (#299) which needs a working
multi-replica deployment to test failover scenarios.

Fixes #314 

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->
- [x] kustomize build config/manager renders unchanged single-replica deployment
- [x] kustomize build config/ha renders Deployment with replicas=2,
      podAntiAffinity, and PodDisruptionBudget

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note
```