### PR TITLE
fix(): Remove `; exit 0` from `unit_tests.dockerfile` to stop masking `go test` failures

### DIFF
--- a/unit_tests.dockerfile
+++ b/unit_tests.dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.19 as builder
 COPY . /build
 WORKDIR /build/service
 ENV ALLURE_RESULTS_PATH=/build
-RUN go test -gcflags=-l --coverprofile=coverage.out; exit 0
+RUN go test -gcflags=-l --coverprofile=coverage.out
 RUN mkdir -p coverage-report
 RUN go tool cover -html=coverage.out -o coverage-report/report.html
 


### PR DESCRIPTION
<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs() - The PR contains Documentation ONLY changes. 
- feat() - The PR contains new feature/enhancements.
- fix() - The PR contains a bug fix.
- chore() - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test() - Development changes related to tests.
- perf() - Changes related to performance improvements.

Example Title: 
feat(): New field addition for Cluster CRD 
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Removes `; exit 0` from the `go test` layer in `unit_tests.dockerfile`. This suffix unconditionally resets the shell exit code to `0`, causing Docker to mark the layer as `DONE` even when `go test` reports `FAIL`. As a result, any CI pipeline running `docker build` would silently pass on a broken test suite.

Fixes #336

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->
Reproduced locally using an equivalent Dockerfile pinned to `golang:1.24` .
Added a failing test to check behaviour.
- **Before fix:** `docker build` completes with exit code `0` despite `go test` printing `FAIL` and compilation errors. Subsequent layers (`mkdir`, `go tool cover`) run normally.
- **After fix:** `docker build` stops at the `go test` layer with `exit code: 1`, correctly surfacing the failure.

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

