### PR TITLE
fix(cluster): return error when UpdateStatus fails during deregistration

### DIFF
--- a/service/cluster_service.go
+++ b/service/cluster_service.go
@@ -187,7 +187,9 @@ func (c *ClusterService) ReconcileCluster(ctx context.Context, req ctrl.Request)
 					logger.Info("Waiting for worker-operator charts to uninstall")
 					// setting IsDeregisterInProgress to true to avoid requeuing
 					cluster.Status.IsDeregisterInProgress = true
-					util.UpdateStatus(ctx, cluster)
+					if err := util.UpdateStatus(ctx, cluster); err != nil {
+						return ctrl.Result{}, err
+					}
 					// Event for worker-operator chart uninstallation in progress [ClusterDeregistrationInProgress]
 					util.RecordEvent(ctx, eventRecorder, cluster, nil, events.EventClusterDeregistrationInProgress)
 					c.mf.RecordCounterMetric(metrics.KubeSliceEventsCounter,

--- a/service/cluster_service_test.go
+++ b/service/cluster_service_test.go
@@ -76,6 +76,7 @@ var ClusterTestbed = map[string]func(*testing.T){
 	"TestReconcileClusterDeletionFailureAfterWorkerFailedToRemoveFinalizer": testReconcileClusterDeletionFailureAfterWorkerFailedToRemoveFinalizer,
 	"TestReconcileClusterDeletionDeregisterFailed":                          testReconcileClusterDeletionDeregisterFailed,
 	"TestReconcileClusterDeletionDeregisterSuccess":                         testReconcileClusterDeletionDeregisterSuccess,
+	"TestReconcileClusterDeletionDeregisterStatusUpdateFail":                testReconcileClusterDeletionDeregisterStatusUpdateFail,
 }
 
 func testReconcileClusterClusterNotFound(t *testing.T) {
@@ -845,6 +846,57 @@ func testReconcileClusterDeletionFailureAfterWorkerFailedToRemoveFinalizer(t *te
 	mMock.On("RecordCounterMetric", mock.Anything, mock.Anything).Return().Once()
 	_, err = clusterService.ReconcileCluster(ctx, requestObj)
 	// require.True(t, result.Requeue)
+	require.NotNil(t, err)
+	clientMock.AssertExpectations(t)
+	mMock.AssertExpectations(t)
+}
+
+func testReconcileClusterDeletionDeregisterStatusUpdateFail(t *testing.T) {
+	nsServiceMock := &mocks.INamespaceService{}
+	acsService := &mocks.IAccessControlService{}
+	mMock := &metricMock.IMetricRecorder{}
+	clusterService := ClusterService{
+		ns:  nsServiceMock,
+		acs: acsService,
+		mf:  mMock,
+	}
+
+	clusterName := types.NamespacedName{
+		Namespace: "cisco",
+		Name:      "cluster-1",
+	}
+	requestObj := ctrl.Request{
+		clusterName,
+	}
+	clientMock := &utilmock.Client{}
+	cluster := &controllerv1alpha1.Cluster{}
+	nsResource := &corev1.Namespace{}
+	scheme := runtime.NewScheme()
+	controllerv1alpha1.AddToScheme(scheme)
+	ctx := prepareTestContext(context.Background(), clientMock, scheme)
+	timeStamp := kubemachine.Now()
+	mMock.On("WithProject", mock.AnythingOfType("string")).Return(&metrics.MetricRecorder{}).Once()
+	clientMock.On("Get", ctx, requestObj.NamespacedName, cluster).Return(nil).Once().Run(func(args mock.Arguments) {
+		arg := args.Get(2).(*controllerv1alpha1.Cluster)
+		arg.ObjectMeta.DeletionTimestamp = &timeStamp
+		arg.ObjectMeta.Finalizers = []string{ClusterFinalizer, ClusterDeregisterFinalizer}
+	})
+	clientMock.On("Get", ctx, client.ObjectKey{
+		Name: requestObj.Namespace,
+	}, nsResource).Return(nil).Run(func(args mock.Arguments) {
+		arg := args.Get(2).(*corev1.Namespace)
+		if arg.Labels == nil {
+			arg.Labels = make(map[string]string)
+		}
+		arg.Labels[util.LabelName] = fmt.Sprintf(util.LabelValue, "Project", requestObj.Namespace)
+		arg.Name = "cisco"
+	})
+	clientMock.On("Get", ctx, mock.Anything, mock.Anything).Return(nil).Once()
+	statusUpdateErr := errors.New("status update failed")
+	clientMock.On("Status").Return(clientMock)
+	clientMock.On("Update", mock.Anything, mock.Anything).Return(statusUpdateErr)
+	result, err := clusterService.ReconcileCluster(ctx, requestObj)
+	require.False(t, result.Requeue)
 	require.NotNil(t, err)
 	clientMock.AssertExpectations(t)
 	mMock.AssertExpectations(t)


### PR DESCRIPTION
# Description

  In `ReconcileCluster`, when a cluster deletion is being processed and `ClusterDeregisterFinalizer` is present, the code sets
  `cluster.Status.IsDeregisterInProgress = true` and then calls `util.UpdateStatus(ctx, cluster)` without checking the returned error. A transient API failure during this status update was silently swallowed — the controller continued, fired `EventClusterDeregistrationInProgress`, and returned `RequeueAfter: 610s`regardless. On every subsequent reconciliation the same event would fire again until the status update eventually succeeded, causing redundant events to accumulate.
The fix wraps the `util.UpdateStatus` call in an error check and returns `ctrl.Result{}, err` immediately on failure, so controller-runtime requeues at exponential backoff instead of waiting 610 seconds with a stale status.

  Fixes #338 

  ## How Has This Been Tested?

  - Added `TestReconcileClusterDeletionDeregisterStatusUpdateFail` to `service/cluster_service_test.go`: sets up a cluster with `DeletionTimestamp` and both  `ClusterFinalizer` + `ClusterDeregisterFinalizer`, makes `Status().Update()` return an error, and asserts that `ReconcileCluster` returns a non-nil error with no requeue — confirming the error is now propagated.
  - Existing `TestReconcileClusterDeletionRequeueForDeregister` continues to pass, confirming the happy path is unaffected.

  ## Checklist:

  * [x] The title of the PR states what changed and the related issues number (used for the release note).
  * [x] Does this PR requires documentation updates? — No.
  * [x] I've updated documentation as required by this PR.
  * [x] I have performed a self-review of my own code.
  * [x] I have commented my code, particularly in hard-to-understand areas. — No new comments needed.
  * [x] I have tested it for all user roles. — N/A (controller internals, no user-role distinction).
  * [x] I have added all the required unit test cases.

  ## Does this PR introduce a breaking change for other components like worker-operator?

No. The only observable difference is that a transient API error now causes an immediate requeue instead of a 610-second delayed requeue with a stale status.

  ```release-note
  Fix cluster reconciler to propagate UpdateStatus error during deregistration instead of silently ignoring it.