### PR TITLE
 fix(sliceconfig): enforce QoS field mutual exclusion for NONET slices

### DIFF
--- a/apis/controller/v1alpha1/sliceconfig_types.go
+++ b/apis/controller/v1alpha1/sliceconfig_types.go
@@ -58,9 +58,9 @@ type SliceConfigSpec struct {
 	//+kubebuilder:default:=Local
 	SliceIpamType          string   `json:"sliceIpamType,omitempty"`
 	Clusters               []string `json:"clusters,omitempty"`
-	StandardQosProfileName string   `json:"standardQosProfileName,omitempty"` // FIXME: Add OneOf StandardQosProfileName vs QosProfileDetails
+	StandardQosProfileName string   `json:"standardQosProfileName,omitempty"`
 	// The custom QOS Profile Details
-	QosProfileDetails         *QOSProfile               `json:"qosProfileDetails,omitempty"` // FIXME: Add OneOf StandardQosProfileName vs QosProfileDetails
+	QosProfileDetails         *QOSProfile               `json:"qosProfileDetails,omitempty"`
 	NamespaceIsolationProfile NamespaceIsolationProfile `json:"namespaceIsolationProfile,omitempty"`
 	ExternalGatewayConfig     []ExternalGatewayConfig   `json:"externalGatewayConfig,omitempty"`
 	//+kubebuilder:validation:Minimum=2

--- a/service/slice_config_webhook_validation.go
+++ b/service/slice_config_webhook_validation.go
@@ -59,6 +59,9 @@ func ValidateSliceConfigCreate(ctx context.Context, sliceConfig *controllerv1alp
 	if err := validateMaxClusterCount(sliceConfig); err != nil {
 		return nil, apierrors.NewInvalid(schema.GroupKind{Group: apiGroupKubeSliceControllers, Kind: "SliceConfig"}, sliceConfig.Name, field.ErrorList{err})
 	}
+	if err := validateQosMutualExclusion(sliceConfig); err != nil {
+		return nil, apierrors.NewInvalid(schema.GroupKind{Group: apiGroupKubeSliceControllers, Kind: "SliceConfig"}, sliceConfig.Name, field.ErrorList{err})
+	}
 	if sliceConfig.Spec.OverlayNetworkDeploymentMode != controllerv1alpha1.NONET {
 		if err := validateSliceSubnet(sliceConfig); err != nil {
 			return nil, apierrors.NewInvalid(schema.GroupKind{Group: apiGroupKubeSliceControllers, Kind: "SliceConfig"}, sliceConfig.Name, field.ErrorList{err})
@@ -104,6 +107,9 @@ func ValidateSliceConfigUpdate(ctx context.Context, sliceConfig *controllerv1alp
 		return nil, apierrors.NewInvalid(schema.GroupKind{Group: apiGroupKubeSliceControllers, Kind: "SliceConfig"}, sliceConfig.Name, field.ErrorList{err})
 	}
 	if err := validateNamespaceIsolationProfile(sliceConfig); err != nil {
+		return nil, apierrors.NewInvalid(schema.GroupKind{Group: apiGroupKubeSliceControllers, Kind: "SliceConfig"}, sliceConfig.Name, field.ErrorList{err})
+	}
+	if err := validateQosMutualExclusion(sliceConfig); err != nil {
 		return nil, apierrors.NewInvalid(schema.GroupKind{Group: apiGroupKubeSliceControllers, Kind: "SliceConfig"}, sliceConfig.Name, field.ErrorList{err})
 	}
 	// Validate single/multi overlay network deployment mode specific fields
@@ -453,11 +459,17 @@ func preventUpdate(ctx context.Context, sc *controllerv1alpha1.SliceConfig, old 
 	return nil
 }
 
+// validateQosMutualExclusion rejects slices that have both QoS fields set simultaneously.
+// Called for all overlay network modes; validateQosProfile handles the non-NONET requirements.
+func validateQosMutualExclusion(sliceConfig *controllerv1alpha1.SliceConfig) *field.Error {
+	if sliceConfig.Spec.StandardQosProfileName != "" && sliceConfig.Spec.QosProfileDetails != nil {
+		return field.Invalid(field.NewPath("Spec").Child("StandardQosProfileName"), sliceConfig.Spec.StandardQosProfileName, "StandardQosProfileName and QosProfileDetails are mutually exclusive")
+	}
+	return nil
+}
+
 // validateQosProfile is a function to validate the Qos(quality of service)profile of slice
 func validateQosProfile(ctx context.Context, sliceConfig *controllerv1alpha1.SliceConfig) *field.Error {
-	if sliceConfig.Spec.StandardQosProfileName != "" && sliceConfig.Spec.QosProfileDetails != nil {
-		return field.Invalid(field.NewPath("Spec").Child("StandardQosProfileName"), sliceConfig.Spec.StandardQosProfileName, "StandardQosProfileName cannot be set when QosProfileDetails is set")
-	}
 	if sliceConfig.Spec.StandardQosProfileName == "" && sliceConfig.Spec.QosProfileDetails == nil {
 		return field.Invalid(field.NewPath("Spec").Child("StandardQosProfileName"), sliceConfig.Spec.StandardQosProfileName, "Either StandardQosProfileName or QosProfileDetails is required")
 	}

--- a/service/slice_config_webhook_validation_test.go
+++ b/service/slice_config_webhook_validation_test.go
@@ -107,6 +107,8 @@ var SliceConfigWebhookValidationTestBed = map[string]func(*testing.T){
 	"SliceConfigWebhookValidation_DeleteValidateSliceConfigWithServiceExportsNotEmpty":                                         DeleteValidateSliceConfigWithServiceExportsNotEmpty,
 	"SliceConfigWebhookValidation_ValidateQosProfileBothStandardQosProfileNameAndQosProfileDetailsPresent":                     ValidateQosProfileBothStandardQosProfileNameAndQosProfileDetailsPresent,
 	"SliceConfigWebhookValidation_ValidateQosProfileBothStandardQosProfileNameAndQosProfileDetailsNotPresent":                  ValidateQosProfileBothStandardQosProfileNameAndQosProfileDetailsNotPresent,
+	"SliceConfigWebhookValidation_CreateValidateSliceConfigBothQosFieldsOnNoNetSlice":                                          CreateValidateSliceConfigBothQosFieldsOnNoNetSlice,
+	"SliceConfigWebhookValidation_UpdateValidateSliceConfigBothQosFieldsOnNoNetSlice":                                          UpdateValidateSliceConfigBothQosFieldsOnNoNetSlice,
 	"SliceConfigWebhookValidation_ValidateQosProfileStandardQosProfileNameDoesNotExist":                                        ValidateQosProfileStandardQosProfileNameDoesNotExist,
 	"SliceConfigWebhookValidation_ValidateMaxCluster":                                                                          ValidateMaxCluster,
 	"SliceConfigWebhookValidation_ValidateMaxClusterForParticipatingCluster":                                                   ValidateMaxClusterForParticipatingCluster,
@@ -1847,9 +1849,9 @@ func ValidateQosProfileBothStandardQosProfileNameAndQosProfileDetailsPresent(t *
 	sliceConfig.Spec.QosProfileDetails = &controllerv1alpha1.QOSProfile{
 		QueueType: "someType",
 	}
-	err := validateQosProfile(ctx, sliceConfig)
+	err := validateQosMutualExclusion(sliceConfig)
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "StandardQosProfileName cannot be set when QosProfileDetails is set")
+	require.Contains(t, err.Error(), "StandardQosProfileName and QosProfileDetails are mutually exclusive")
 	clientMock.AssertExpectations(t)
 }
 
@@ -1860,6 +1862,47 @@ func ValidateQosProfileBothStandardQosProfileNameAndQosProfileDetailsNotPresent(
 	err := validateQosProfile(ctx, sliceConfig)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), "Either StandardQosProfileName or QosProfileDetails is required")
+	clientMock.AssertExpectations(t)
+}
+
+func CreateValidateSliceConfigBothQosFieldsOnNoNetSlice(t *testing.T) {
+	name := "slice_config"
+	namespace := "namespace"
+	clientMock, sliceConfig, ctx := setupSliceConfigWebhookValidationTest(name, namespace)
+	clientMock.On("Get", ctx, client.ObjectKey{Name: namespace}, &corev1.Namespace{}).Return(nil).Run(func(args mock.Arguments) {
+		arg := args.Get(2).(*corev1.Namespace)
+		if arg.Labels == nil {
+			arg.Labels = make(map[string]string)
+		}
+		arg.Name = namespace
+		arg.Labels[util.LabelName] = fmt.Sprintf(util.LabelValue, "Project", namespace)
+	}).Once()
+	sliceConfig.Spec.MaxClusters = 2
+	sliceConfig.Spec.OverlayNetworkDeploymentMode = controllerv1alpha1.NONET
+	sliceConfig.Spec.StandardQosProfileName = "testQos"
+	sliceConfig.Spec.QosProfileDetails = &controllerv1alpha1.QOSProfile{QueueType: "someType"}
+	_, err := ValidateSliceConfigCreate(ctx, sliceConfig)
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "mutually exclusive")
+	clientMock.AssertExpectations(t)
+}
+
+func UpdateValidateSliceConfigBothQosFieldsOnNoNetSlice(t *testing.T) {
+	name := "slice_config"
+	namespace := "namespace"
+	oldSliceConfig := &controllerv1alpha1.SliceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: controllerv1alpha1.SliceConfigSpec{
+			OverlayNetworkDeploymentMode: controllerv1alpha1.NONET,
+		},
+	}
+	clientMock, newSliceConfig, ctx := setupSliceConfigWebhookValidationTest(name, namespace)
+	newSliceConfig.Spec.OverlayNetworkDeploymentMode = controllerv1alpha1.NONET
+	newSliceConfig.Spec.StandardQosProfileName = "testQos"
+	newSliceConfig.Spec.QosProfileDetails = &controllerv1alpha1.QOSProfile{QueueType: "someType"}
+	_, err := ValidateSliceConfigUpdate(ctx, newSliceConfig, runtime.Object(oldSliceConfig))
+	require.NotNil(t, err)
+	require.Contains(t, err.Error(), "mutually exclusive")
 	clientMock.AssertExpectations(t)
 }
 


### PR DESCRIPTION
# Description

 `validateQosProfile` already had a mutual exclusion check for `StandardQosProfileName` and `QosProfileDetails`, but it was only called inside the  `OverlayNetworkDeploymentMode != NONET` guard in both `ValidateSliceConfigCreate` and `ValidateSliceConfigUpdate`. NONET slices bypassed it entirely, allowing  both fields to be set simultaneously with no validation error.

 The fix extracts the mutual exclusion check into a new `validateQosMutualExclusion` helper and calls it from both validators outside the NONET guard, so it applies to all slices regardless of network mode. The duplicate check is removed from `validateQosProfile` to avoid running it twice for non-NONET slices. The  now-resolved FIXME comments in `sliceconfig_types.go` are also removed.

  Fixes #340 

  ## How Has This Been Tested?

  - Added `CreateValidateSliceConfigBothQosFieldsOnNoNetSlice`: calls `ValidateSliceConfigCreate` with a NONET slice that has both QoS fields set, asserts the error contains "mutually exclusive".
  - Added `UpdateValidateSliceConfigBothQosFieldsOnNoNetSlice`: calls `ValidateSliceConfigUpdate` with a NONET slice that has both QoS fields set, asserts the  same.
  - Updated existing `ValidateQosProfileBothStandardQosProfileNameAndQosProfileDetailsPresent` to call `validateQosMutualExclusion` directly and match the new error message.
  - Existing tests for the non-NONET QoS path and the "neither set" case are unaffected.

  ## Checklist:

  * [x] The title of the PR states what changed and the related issues number (used for the release note).
  * [x] Does this PR requires documentation updates? — No.
  * [x] I've updated documentation as required by this PR.
  * [x] I have performed a self-review of my own code.
  * [x] I have commented my code, particularly in hard-to-understand areas. — Added one-line comment on `validateQosMutualExclusion` explaining its scope.
  * [x] I have tested it for all user roles. — N/A (webhook validation, no user-role distinction).
  * [x] I have added all the required unit test cases.

  ## Does this PR introduce a breaking change for other components like worker-operator?

  No. The only observable difference is that NONET slices with both QoS fields set are now rejected at admission, which was never a valid configuration.

  ```release-note
  Fix SliceConfig webhook to reject NONET slices with both StandardQosProfileName and QosProfileDetails set.
