### PR TITLE
Fix: VPN cert rotation re-fires duplicate jobs after controller restart

### DIFF
--- a/service/access_control_service_test.go
+++ b/service/access_control_service_test.go
@@ -1270,7 +1270,7 @@ func ACS_ReconcileWorkerClusterServiceAccountAndRoleBindings(t *testing.T) {
 	mMock.AssertExpectations(t)
 }
 
-func prepareACSTestContext(ctx context.Context, client util.Client,
+func prepareACSTestContext(ctx context.Context, client *utilMock.Client,
 	scheme *runtime.Scheme) context.Context {
 	if scheme == nil {
 		scheme = runtime.NewScheme()

--- a/service/job_service.go
+++ b/service/job_service.go
@@ -63,7 +63,8 @@ func (j *JobService) CreateJob(ctx context.Context, namespace string, jobImage s
 			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
-				"SLICE_NAME": environment["SLICE_NAME"],
+				"SLICE_NAME":     environment["SLICE_NAME"],
+				"ROTATION_COUNT": environment["ROTATION_COUNT"],
 			},
 		},
 		Spec: batchv1.JobSpec{

--- a/service/namespace_service_test.go
+++ b/service/namespace_service_test.go
@@ -177,7 +177,7 @@ func TestDeleteNamespace_DoesNothingIfNamespaceDoNotExist(t *testing.T) {
 	mMock.AssertExpectations(t)
 }
 
-func prepareNamespaceTestContext(ctx context.Context, client util.Client, scheme *runtime.Scheme) context.Context {
+func prepareNamespaceTestContext(ctx context.Context, client *utilMock.Client, scheme *runtime.Scheme) context.Context {
 	eventRecorder := events.NewEventRecorder(client, scheme, ossEvents.EventsMap, events.EventRecorderOptions{
 		Version:   "v1alpha1",
 		Cluster:   util.ClusterController,

--- a/service/project_service_test.go
+++ b/service/project_service_test.go
@@ -276,7 +276,7 @@ func setupProjectTest(name string, namespace string) (*mocks.INamespaceService, 
 	return nsServiceMock, acsServicemOCK, projectService, requestObj, clientMock, project, ctx, clusterServiceMock, sliceConfigServiceMock, serviceExportConfigServiceMock, sliceQoSConfigServiceMock, mMock
 }
 
-func prepareProjectTestContext(ctx context.Context, client util.Client,
+func prepareProjectTestContext(ctx context.Context, client *utilMock.Client,
 	scheme *runtime.Scheme) context.Context {
 	eventRecorder := events.NewEventRecorder(client, scheme, ossEvents.EventsMap, events.EventRecorderOptions{
 		Version:   "v1alpha1",

--- a/service/vpn_key_rotation_service.go
+++ b/service/vpn_key_rotation_service.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"sync/atomic"
+	"strconv"
 	"time"
 
 	controllerv1alpha1 "github.com/kubeslice/kubeslice-controller/apis/controller/v1alpha1"
@@ -43,9 +43,8 @@ type IVpnKeyRotationService interface {
 }
 
 type VpnKeyRotationService struct {
-	wsgs                  IWorkerSliceGatewayService
-	wscs                  IWorkerSliceConfigService
-	jobCreationInProgress atomic.Bool
+	wsgs IWorkerSliceGatewayService
+	wscs IWorkerSliceConfigService
 }
 
 // JobStatus represents the status of a job.
@@ -266,24 +265,32 @@ func (v *VpnKeyRotationService) reconcileVpnKeyRotationConfig(ctx context.Contex
 
 	} else {
 		if now.After(copyVpnConfig.Spec.CertificateExpiryTime.Time) {
-			if !v.jobCreationInProgress.Load() {
+			// Check Kubernetes state first to avoid duplicating jobs after a controller restart.
+			// Jobs are labelled with SLICE_NAME and ROTATION_COUNT so we can identify
+			// whether the current rotation cycle has already been triggered.
+			hasJobs, err := v.hasJobsForCurrentRotation(ctx, copyVpnConfig.Spec.SliceName, copyVpnConfig.Spec.RotationCount)
+			if err != nil {
+				return ctrl.Result{}, nil, err
+			}
+			if !hasJobs {
+				// No jobs for the current rotation cycle — trigger them now.
 				if err := v.triggerJobsForCertCreation(ctx, copyVpnConfig, s); err != nil {
 					logger.Error("error creating new certs", err)
 					// register an event
 					util.RecordEvent(ctx, eventRecorder, copyVpnConfig, nil, events.EventCertificateJobCreationFailed)
 					return ctrl.Result{}, nil, err
 				}
-				v.jobCreationInProgress.Store(true)
 				logger.Debugf("jobs triggered for creating new certs for slice %s", s.Name)
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil, nil
 			}
-			// verify jobs are completed
+			// Jobs already exist for this rotation cycle (possibly from before a restart).
+			// Verify their completion status.
 			status, err := v.verifyAllJobsAreCompleted(ctx, copyVpnConfig.Spec.SliceName)
 			if err != nil {
 				return ctrl.Result{}, nil, err
 			}
 			logger.Debugf("certs job status for sliceconfig %s = %s ", s.Name, status.String())
-			// requeue after 1 minute if job is still running
+			// requeue after 30 seconds if job is still running
 			if status == JobStatusRunning {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil, nil
 			}
@@ -292,9 +299,8 @@ func (v *VpnKeyRotationService) reconcileVpnKeyRotationConfig(ctx context.Contex
 				util.RecordEvent(ctx, eventRecorder, copyVpnConfig, nil, events.EventCertificateJobFailed)
 				return ctrl.Result{}, nil, nil
 			}
-			if status == JobNotCreated {
-				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil, nil
-			}
+			// status == JobStatusComplete: all jobs for this rotation cycle finished successfully.
+			// Update timestamps and increment rotation count to conclude this cycle.
 			copyVpnConfig.Spec.CertificateCreationTime = &now
 			expiryTS := metav1.NewTime(now.AddDate(0, 0, copyVpnConfig.Spec.RotationInterval).Add(-1 * time.Hour))
 			copyVpnConfig.Spec.CertificateExpiryTime = &expiryTS
@@ -302,8 +308,6 @@ func (v *VpnKeyRotationService) reconcileVpnKeyRotationConfig(ctx context.Contex
 			if err := util.UpdateResource(ctx, copyVpnConfig); err != nil {
 				return ctrl.Result{}, nil, err
 			}
-			// restore the variable jobCreationInProgress to false
-			v.jobCreationInProgress.Store(false)
 			//register an event
 			util.RecordEvent(ctx, eventRecorder, copyVpnConfig, nil, events.EventVPNKeyRotationStart)
 		}
@@ -353,8 +357,15 @@ func (v *VpnKeyRotationService) triggerJobsForCertCreation(ctx context.Context, 
 				return err
 			}
 			clusterMap := v.wscs.ComputeClusterMap(s.Spec.Clusters, workerSliceConfigs)
-			// contruct gw address
+			// construct gw address
 			gatewayAddresses := v.wsgs.BuildNetworkAddresses(s.Spec.SliceSubnet, gateway.Spec.LocalGatewayConfig.ClusterName, gateway.Spec.RemoteGatewayConfig.ClusterName, clusterMap, clusterCidr)
+			// Inject ROTATION_COUNT into the gateway context so the cert job carries the label.
+			// GenerateCerts will pass this through to CreateJob via the environment map,
+			// allowing hasJobsForCurrentRotation to find the jobs after a controller restart.
+			gateway := gateway
+			gateway.Annotations = mergeAnnotations(gateway.Annotations, map[string]string{
+				"rotation-count": strconv.Itoa(vpnKeyRotationConfig.Spec.RotationCount),
+			})
 			// call GenerateCerts()
 			if err := v.wsgs.GenerateCerts(ctx, s.Name, s.Namespace, gateway.Spec.GatewayProtocol, &gateway, cl, gatewayAddresses); err != nil {
 				return err
@@ -362,6 +373,17 @@ func (v *VpnKeyRotationService) triggerJobsForCertCreation(ctx context.Context, 
 		}
 	}
 	return nil
+}
+
+// mergeAnnotations merges src into dst, returning dst.
+func mergeAnnotations(dst, src map[string]string) map[string]string {
+	if dst == nil {
+		dst = make(map[string]string, len(src))
+	}
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
 }
 
 func (v *VpnKeyRotationService) listWorkerSliceGateways(ctx context.Context, labels map[string]string) (*workerv1alpha1.WorkerSliceGatewayList, error) {
@@ -401,6 +423,25 @@ func (v *VpnKeyRotationService) listClientPairGateway(wl *workerv1alpha1.WorkerS
 		}
 	}
 	return nil, fmt.Errorf("cannot find gateway %s", clientGatewayName)
+}
+
+// hasJobsForCurrentRotation returns true if any cert-rotation jobs for the given slice
+// and rotation cycle already exist in Kubernetes. This is used as the authoritative,
+// restart-safe check to prevent duplicate job creation: if jobs are present (even after
+// a controller restart), the reconciler resumes waiting for completion instead of
+// firing a second batch of jobs.
+func (v *VpnKeyRotationService) hasJobsForCurrentRotation(ctx context.Context, sliceName string, rotationCount int) (bool, error) {
+	jobs := batchv1.JobList{}
+	listOpts := []client.ListOption{
+		client.MatchingLabels(map[string]string{
+			"SLICE_NAME":     sliceName,
+			"ROTATION_COUNT": strconv.Itoa(rotationCount),
+		}),
+	}
+	if err := util.ListResources(ctx, &jobs, listOpts...); err != nil {
+		return false, err
+	}
+	return len(jobs.Items) > 0, nil
 }
 
 // verifyAllJobsAreCompleted checks if all the jobs are in complete state

--- a/service/vpn_key_rotation_service_test.go
+++ b/service/vpn_key_rotation_service_test.go
@@ -488,111 +488,122 @@ func runReconcileVpnKeyRotationConfig(t *testing.T, tc *reconcileVpnKeyRotationC
 		return tc.now
 	})
 	defer patch.Unpatch()
-	// NOTE: Monkey pathcing sometimes requires the inlining to be disabled
+	// NOTE: Monkey patching sometimes requires the inlining to be disabled
 	// use go test -gcflags=-l
-	// setup Expectations
-	gwList := &workerv1alpha1.WorkerSliceGatewayList{}
-	clientMock.
-		On("List", mock.Anything, gwList, mock.Anything).
-		Return(nil).Run(func(args mock.Arguments) {
-		w := args.Get(1).(*workerv1alpha1.WorkerSliceGatewayList)
-		w.Items = append(w.Items,
-			workerv1alpha1.WorkerSliceGateway{
-				Spec: workerv1alpha1.WorkerSliceGatewaySpec{
-					GatewayHostType: "Server",
-					RemoteGatewayConfig: workerv1alpha1.SliceGatewayConfig{
-						GatewayName: "test-slice-worker-2-worker-1",
-					},
-				},
-			},
-			workerv1alpha1.WorkerSliceGateway{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-slice-worker-2-worker-1",
-				},
-				Spec: workerv1alpha1.WorkerSliceGatewaySpec{
-					GatewayHostType: "Client",
-					RemoteGatewayConfig: workerv1alpha1.SliceGatewayConfig{
-						GatewayName: "test-slice-worker-1-worker-2",
-					},
-				},
-			})
-	}).Times(1)
 
-	jobList := &batchv1.JobList{}
+	// Both test cases exercise the first-time path (timestamps nil) OR the expiry path.
+	// For the "should update CertCreation TS" case (timestamps zero), the flow is:
+	//   verifyAllJobsAreCompleted(List) → complete → update timestamps.
+	// For the "should requeue after firing new jobs" case (certs expired, now > expiryTS):
+	//   hasJobsForCurrentRotation(List) → empty → triggerJobsForCertCreation(List gateways, GenerateCerts...) → requeue.
+	isCertExpiredCase := tc.arg1.Spec.CertificateCreationTime != nil && tc.arg1.Spec.CertificateExpiryTime != nil
 
-	clientMock.
-		On("List", mock.Anything, jobList, mock.Anything).
-		Return(nil).Run(func(args mock.Arguments) {
-		w := args.Get(1).(*batchv1.JobList)
-		w.Items = append(w.Items,
-			batchv1.Job{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "job-1",
-					Labels: map[string]string{
-						"SLICE_NAME": "test-slice",
+	if !isCertExpiredCase {
+		// First-time path: verifyAllJobsAreCompleted is called → jobs complete → update timestamps.
+		jobList := &batchv1.JobList{}
+		clientMock.
+			On("List", mock.Anything, jobList, mock.Anything).
+			Return(nil).Run(func(args mock.Arguments) {
+			w := args.Get(1).(*batchv1.JobList)
+			w.Items = append(w.Items,
+				batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "job-1",
+						Labels: map[string]string{
+							"SLICE_NAME": "test-slice",
+						},
 					},
-				},
-				Status: batchv1.JobStatus{
-					Conditions: []batchv1.JobCondition{
-						{
-							Type:   batchv1.JobComplete,
-							Status: corev1.ConditionTrue,
+					Status: batchv1.JobStatus{
+						Conditions: []batchv1.JobCondition{
+							{
+								Type:   batchv1.JobComplete,
+								Status: corev1.ConditionTrue,
+							},
 						},
 					},
 				},
-			},
-			batchv1.Job{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "job-2",
-					Labels: map[string]string{
-						"SLICE_NAME": "test-slice",
+				batchv1.Job{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "job-2",
+						Labels: map[string]string{
+							"SLICE_NAME": "test-slice",
+						},
 					},
-				},
-				Status: batchv1.JobStatus{
-					Conditions: []batchv1.JobCondition{
-						{
-							Type:   batchv1.JobComplete,
-							Status: corev1.ConditionTrue,
+					Status: batchv1.JobStatus{
+						Conditions: []batchv1.JobCondition{
+							{
+								Type:   batchv1.JobComplete,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				})
+		}).Once()
+
+		clientMock.On("Create", ctx, mock.AnythingOfType("*v1.Event")).Return(nil).Once()
+		clientMock.
+			On("Update", tc.updateArg1, tc.updateArg2).Return(tc.updateRet1).Once()
+	} else {
+		// Expiry path: hasJobsForCurrentRotation → empty list → triggerJobsForCertCreation.
+		// First List call is for hasJobsForCurrentRotation (returns empty → no existing jobs).
+		jobList := &batchv1.JobList{}
+		clientMock.
+			On("List", mock.Anything, jobList, mock.Anything).
+			Return(nil).Run(func(args mock.Arguments) {
+			// Return empty list: no jobs for the current rotation count.
+			_ = args.Get(1).(*batchv1.JobList)
+		}).Once()
+
+		// Second List call is for triggerJobsForCertCreation (gateway list).
+		gwList := &workerv1alpha1.WorkerSliceGatewayList{}
+		clientMock.
+			On("List", mock.Anything, gwList, mock.Anything).
+			Return(nil).Run(func(args mock.Arguments) {
+			w := args.Get(1).(*workerv1alpha1.WorkerSliceGatewayList)
+			w.Items = append(w.Items,
+				workerv1alpha1.WorkerSliceGateway{
+					Spec: workerv1alpha1.WorkerSliceGatewaySpec{
+						GatewayHostType: "Server",
+						RemoteGatewayConfig: workerv1alpha1.SliceGatewayConfig{
+							GatewayName: "test-slice-worker-2-worker-1",
 						},
 					},
 				},
-			})
-	}).Times(2)
+				workerv1alpha1.WorkerSliceGateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-slice-worker-2-worker-1",
+					},
+					Spec: workerv1alpha1.WorkerSliceGatewaySpec{
+						GatewayHostType: "Client",
+						RemoteGatewayConfig: workerv1alpha1.SliceGatewayConfig{
+							GatewayName: "test-slice-worker-1-worker-2",
+						},
+					},
+				})
+		}).Times(1)
 
-	clientMock.On("Create", ctx, mock.AnythingOfType("*v1.Event")).Return(nil).Once()
-
-	workerSliceConfigs := workerv1alpha1.WorkerSliceConfigList{
-		Items: []workerv1alpha1.WorkerSliceConfig{
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-slice-config-1",
+		workerSliceConfigs := workerv1alpha1.WorkerSliceConfigList{
+			Items: []workerv1alpha1.WorkerSliceConfig{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-slice-config-1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-slice-config-2",
+					},
 				},
 			},
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "test-slice-config-2",
-				},
-			},
-		},
+		}
+
+		ws.On("ListWorkerSliceConfigs", mock.Anything, mock.Anything, mock.Anything).Return(workerSliceConfigs.Items, nil).Once()
+		ws.On("ComputeClusterMap", mock.Anything, mock.Anything).Return(map[string]int{"cluster-1": 1, "cluster-2": 2}).Once()
+
+		gwAddress := util.WorkerSliceGatewayNetworkAddresses{}
+		wg.On("BuildNetworkAddresses", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(gwAddress).Once()
+		wg.On("GenerateCerts", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 	}
-
-	ws.On("ListWorkerSliceConfigs", mock.Anything, mock.Anything, mock.Anything).Return(workerSliceConfigs.Items, nil).Once()
-
-	clusterMap := map[string]int{
-		"cluster-1": 1,
-		"cluster-2": 2,
-	}
-
-	ws.On("ComputeClusterMap", mock.Anything, mock.Anything).Return(clusterMap).Once()
-
-	gwAddress := util.WorkerSliceGatewayNetworkAddresses{}
-
-	wg.On("BuildNetworkAddresses", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(gwAddress).Once()
-
-	wg.On("GenerateCerts", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-
-	clientMock.
-		On("Update", tc.updateArg1, tc.updateArg2).Return(tc.updateRet1).Once()
 
 	reconcileResult, gotResp, gotErr := vpn.reconcileVpnKeyRotationConfig(ctx, tc.arg1, tc.arg2)
 	require.Equal(t, gotErr, tc.expectedErr)
@@ -600,6 +611,266 @@ func runReconcileVpnKeyRotationConfig(t *testing.T, tc *reconcileVpnKeyRotationC
 	require.Equal(t, tc.expectedResp, gotResp)
 	require.Equal(t, tc.reconcileResult, reconcileResult)
 }
+
+// ---------------------------------------------------------------------------
+// Tests for hasJobsForCurrentRotation
+// ---------------------------------------------------------------------------
+
+func Test_hasJobsForCurrentRotation(t *testing.T) {
+	t.Run("returns false when no jobs exist for rotation count", func(t *testing.T) {
+		ctx, clientMock, vpn, _, _ := setupTestCase()
+		clientMock.
+			On("List", mock.Anything, mock.Anything, mock.Anything).
+			Return(nil).Once()
+
+		got, err := vpn.hasJobsForCurrentRotation(ctx, "test-slice", 1)
+		require.NoError(t, err)
+		require.False(t, got)
+		clientMock.AssertExpectations(t)
+	})
+
+	t.Run("returns true when jobs exist for rotation count", func(t *testing.T) {
+		ctx, clientMock, vpn, _, _ := setupTestCase()
+		clientMock.
+			On("List", mock.Anything, mock.Anything, mock.Anything).
+			Return(nil).Run(func(args mock.Arguments) {
+			w := args.Get(1).(*batchv1.JobList)
+			w.Items = append(w.Items, batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "open-cert-abc12345",
+					Labels: map[string]string{
+						"SLICE_NAME":     "test-slice",
+						"ROTATION_COUNT": "1",
+					},
+				},
+			})
+		}).Once()
+
+		got, err := vpn.hasJobsForCurrentRotation(ctx, "test-slice", 1)
+		require.NoError(t, err)
+		require.True(t, got)
+		clientMock.AssertExpectations(t)
+	})
+
+	t.Run("returns error when list fails", func(t *testing.T) {
+		ctx, clientMock, vpn, _, _ := setupTestCase()
+		clientMock.
+			On("List", mock.Anything, mock.Anything, mock.Anything).
+			Return(errors.New("list failed")).Once()
+
+		got, err := vpn.hasJobsForCurrentRotation(ctx, "test-slice", 1)
+		require.Error(t, err)
+		require.False(t, got)
+		clientMock.AssertExpectations(t)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Idempotent reconcile tests — simulates controller restart scenarios
+// ---------------------------------------------------------------------------
+
+// Test_IdempotentReconcileAfterRestart verifies that when the controller restarts
+// mid-rotation (certs expired, jobs already exist for the current rotation count),
+// the reconciler does NOT fire duplicate jobs — it resumes waiting for completion.
+func Test_IdempotentReconcileAfterRestart(t *testing.T) {
+	ts := metav1.NewTime(time.Date(2021, 6, 16, 20, 34, 58, 651387237, time.UTC))
+	expiryTs := metav1.NewTime(ts.AddDate(0, 0, 30).Add(-1 * time.Hour))
+	// "now" is past expiry
+	pastExpiry := metav1.NewTime(expiryTs.Add(2 * time.Hour))
+
+	patch := monkey.Patch(metav1.Now, func() metav1.Time { return pastExpiry })
+	defer patch.Unpatch()
+
+	ctx, clientMock, vpn, wg, _ := setupTestCase()
+
+	vpnCfg := &controllerv1alpha1.VpnKeyRotation{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-slice", Namespace: "test-ns"},
+		Spec: controllerv1alpha1.VpnKeyRotationSpec{
+			SliceName:               "test-slice",
+			RotationInterval:        30,
+			RotationCount:           2,
+			CertificateCreationTime: &ts,
+			CertificateExpiryTime:   &expiryTs,
+		},
+	}
+	sliceCfg := &controllerv1alpha1.SliceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-slice", Namespace: "test-ns"},
+	}
+
+	// hasJobsForCurrentRotation → jobs already exist for rotationCount=2 (pre-restart jobs)
+	clientMock.
+		On("List", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Run(func(args mock.Arguments) {
+		w := args.Get(1).(*batchv1.JobList)
+		w.Items = append(w.Items, batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "open-cert-abc12345",
+				Labels: map[string]string{
+					"SLICE_NAME":     "test-slice",
+					"ROTATION_COUNT": "2",
+				},
+			},
+			Status: batchv1.JobStatus{Active: 1},
+		})
+	}).Once()
+
+	// verifyAllJobsAreCompleted → still running
+	clientMock.
+		On("List", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Run(func(args mock.Arguments) {
+		w := args.Get(1).(*batchv1.JobList)
+		w.Items = append(w.Items, batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "open-cert-abc12345",
+				Labels: map[string]string{"SLICE_NAME": "test-slice"},
+			},
+			Status: batchv1.JobStatus{Active: 1},
+		})
+	}).Once()
+
+	// GenerateCerts must NOT be called — confirm no duplicate jobs
+	wg.AssertNotCalled(t, "GenerateCerts")
+
+	result, resp, err := vpn.reconcileVpnKeyRotationConfig(ctx, vpnCfg, sliceCfg)
+
+	require.NoError(t, err)
+	require.Nil(t, resp)
+	require.Equal(t, 30*time.Second, result.RequeueAfter)
+	clientMock.AssertExpectations(t)
+}
+
+// Test_ExistingRunningJobsOnRestart verifies that when jobs for the current rotation
+// are running (detected after restart), the reconciler returns RequeueAfter without
+// creating new jobs.
+func Test_ExistingRunningJobsOnRestart(t *testing.T) {
+	ts := metav1.NewTime(time.Date(2021, 6, 16, 20, 34, 58, 0, time.UTC))
+	expiryTs := metav1.NewTime(ts.AddDate(0, 0, 30).Add(-1 * time.Hour))
+	pastExpiry := metav1.NewTime(expiryTs.Add(time.Hour))
+
+	patch := monkey.Patch(metav1.Now, func() metav1.Time { return pastExpiry })
+	defer patch.Unpatch()
+
+	ctx, clientMock, vpn, wg, _ := setupTestCase()
+
+	vpnCfg := &controllerv1alpha1.VpnKeyRotation{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-slice", Namespace: "ns"},
+		Spec: controllerv1alpha1.VpnKeyRotationSpec{
+			SliceName:               "my-slice",
+			RotationInterval:        30,
+			RotationCount:           3,
+			CertificateCreationTime: &ts,
+			CertificateExpiryTime:   &expiryTs,
+		},
+	}
+	sliceCfg := &controllerv1alpha1.SliceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-slice", Namespace: "ns"},
+	}
+
+	// hasJobsForCurrentRotation → jobs exist
+	clientMock.
+		On("List", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Run(func(args mock.Arguments) {
+		w := args.Get(1).(*batchv1.JobList)
+		w.Items = append(w.Items, batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"SLICE_NAME": "my-slice", "ROTATION_COUNT": "3"},
+			},
+			Status: batchv1.JobStatus{Active: 1},
+		})
+	}).Once()
+
+	// verifyAllJobsAreCompleted → still running
+	clientMock.
+		On("List", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Run(func(args mock.Arguments) {
+		w := args.Get(1).(*batchv1.JobList)
+		w.Items = append(w.Items, batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"SLICE_NAME": "my-slice"},
+			},
+			Status: batchv1.JobStatus{Active: 1},
+		})
+	}).Once()
+
+	wg.AssertNotCalled(t, "GenerateCerts")
+
+	result, resp, err := vpn.reconcileVpnKeyRotationConfig(ctx, vpnCfg, sliceCfg)
+
+	require.NoError(t, err)
+	require.Nil(t, resp)
+	require.Equal(t, 30*time.Second, result.RequeueAfter)
+	clientMock.AssertExpectations(t)
+}
+
+// Test_NoDuplicateJobsOnConcurrentReconcile verifies that a second reconcile
+// execution (e.g. caused by a requeue firing while the first is still running)
+// does not create a second batch of cert jobs when jobs for the current rotation
+// count already exist.
+func Test_NoDuplicateJobsOnConcurrentReconcile(t *testing.T) {
+	ts := metav1.NewTime(time.Date(2021, 6, 16, 20, 34, 58, 0, time.UTC))
+	expiryTs := metav1.NewTime(ts.AddDate(0, 0, 30).Add(-1 * time.Hour))
+	pastExpiry := metav1.NewTime(expiryTs.Add(time.Hour))
+
+	patch := monkey.Patch(metav1.Now, func() metav1.Time { return pastExpiry })
+	defer patch.Unpatch()
+
+	ctx, clientMock, vpn, wg, _ := setupTestCase()
+
+	vpnCfg := &controllerv1alpha1.VpnKeyRotation{
+		ObjectMeta: metav1.ObjectMeta{Name: "slice-a", Namespace: "ns"},
+		Spec: controllerv1alpha1.VpnKeyRotationSpec{
+			SliceName:               "slice-a",
+			RotationInterval:        30,
+			RotationCount:           1,
+			CertificateCreationTime: &ts,
+			CertificateExpiryTime:   &expiryTs,
+		},
+	}
+	sliceCfg := &controllerv1alpha1.SliceConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: "slice-a", Namespace: "ns"},
+	}
+
+	// Simulate: jobs already created by the first reconcile call (same RotationCount=1).
+	existingJob := batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "open-cert-existing",
+			Labels: map[string]string{"SLICE_NAME": "slice-a", "ROTATION_COUNT": "1"},
+		},
+		Status: batchv1.JobStatus{Active: 1},
+	}
+
+	// hasJobsForCurrentRotation → returns existing job → must NOT trigger again
+	clientMock.
+		On("List", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Run(func(args mock.Arguments) {
+		w := args.Get(1).(*batchv1.JobList)
+		w.Items = append(w.Items, existingJob)
+	}).Once()
+
+	// verifyAllJobsAreCompleted → still running
+	clientMock.
+		On("List", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Run(func(args mock.Arguments) {
+		w := args.Get(1).(*batchv1.JobList)
+		w.Items = append(w.Items, batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"SLICE_NAME": "slice-a"},
+			},
+			Status: batchv1.JobStatus{Active: 1},
+		})
+	}).Once()
+
+	// GenerateCerts / triggerJobsForCertCreation must NOT be called
+	wg.AssertNotCalled(t, "GenerateCerts")
+
+	result, resp, err := vpn.reconcileVpnKeyRotationConfig(ctx, vpnCfg, sliceCfg)
+
+	require.NoError(t, err)
+	require.Nil(t, resp)
+	require.Equal(t, 30*time.Second, result.RequeueAfter)
+	clientMock.AssertExpectations(t)
+}
+
 
 type listClientPairGatewayTesCase struct {
 	name         string

--- a/service/worker_slice_gateway_service.go
+++ b/service/worker_slice_gateway_service.go
@@ -688,6 +688,13 @@ func (s *WorkerSliceGatewayService) GenerateCerts(ctx context.Context, sliceName
 	} else {
 		environment["VPN_CIPHER"] = sliceConfig.Spec.VPNConfig.Cipher
 	}
+	// Propagate the rotation count annotation (set by VpnKeyRotationService) into the
+	// job environment so the Job carries a ROTATION_COUNT label. This allows the
+	// reconciler to detect existing jobs for the current rotation cycle after a restart,
+	// preventing duplicate cert job creation.
+	if rc, ok := serverGateway.Annotations["rotation-count"]; ok {
+		environment["ROTATION_COUNT"] = rc
+	}
 
 	jobNamespace = os.Getenv("KUBESLICE_CONTROLLER_MANAGER_NAMESPACE")
 	util.CtxLogger(ctx).Info("jobNamespace", jobNamespace) //todo:remove

--- a/service/worker_slice_gateway_service_test.go
+++ b/service/worker_slice_gateway_service_test.go
@@ -551,7 +551,6 @@ func testNodeIpReconciliationOfWorkerSliceGatewaysExists(t *testing.T) {
 			Annotations:                nil,
 			OwnerReferences:            nil,
 			Finalizers:                 nil,
-			ClusterName:                "",
 			ManagedFields:              nil,
 		},
 		Spec:   controllerv1alpha1.ClusterSpec{},


### PR DESCRIPTION
## 🐛 

Fixes #320

---

### 📜 Problem

`VpnKeyRotationService` used an in-memory `atomic.Bool` (`jobCreationInProgress`) to prevent duplicate cert rotation jobs. After a controller restart this flag resets to `false`, causing `triggerJobsForCertCreation` to fire again for the same rotation cycle.

Because job names use random UUIDs, Kubernetes does not detect a conflict — a second full set of cert jobs is created. Both generations write to the same gateway secret, which can leave VPN workers with mismatched certificates and break tunnels silently.

**Failure sequence:**
1. Cert expiry triggers `triggerJobsForCertCreation` → `jobCreationInProgress = true` → requeue 30s
2. Controller restarts before `CertificateExpiryTime` is updated
3. `jobCreationInProgress` resets to `false`
4. Next reconcile: certs still appear expired → `triggerJobsForCertCreation` fires again
5. Duplicate Kubernetes Jobs created, both writing to the same gateway secret

---

### ✅ Fix

Replace the volatile in-memory flag with a persistent, Kubernetes-state-based deduplication check.

#### Key changes

**`service/vpn_key_rotation_service.go`**
- Remove `jobCreationInProgress atomic.Bool` field and `sync/atomic` import entirely
- Add `hasJobsForCurrentRotation(ctx, sliceName, rotationCount)` — queries the Kubernetes API for Jobs labelled with both `SLICE_NAME` and `ROTATION_COUNT`. This is the authoritative, restart-safe check.
- Rewrite the certificate-expiry branch of `reconcileVpnKeyRotationConfig`:
