### PR TITLE
  fix(vpn-key-rotation): recalculate certificate expiry when rotation interval changes

### DIFF
--- a/service/slice_config_service.go
+++ b/service/slice_config_service.go
@@ -211,7 +211,6 @@ func (s *SliceConfigService) ReconcileSliceConfig(ctx context.Context, req ctrl.
 	logger.Infof("sliceConfig %v reconciled", req.NamespacedName)
 
 	// Step 6: Create VPNKeyRotation CR
-	// TODO(rahul): handle change in rotation interval
 	if err := s.vpn.CreateMinimalVpnKeyRotationConfig(ctx, sliceConfig.Name, sliceConfig.Namespace, sliceConfig.Spec.RotationInterval); err != nil {
 		// register an event
 		util.RecordEvent(ctx, eventRecorder, sliceConfig, nil, events.EventVPNKeyRotationConfigCreationFailed)

--- a/service/vpn_key_rotation_service.go
+++ b/service/vpn_key_rotation_service.go
@@ -186,6 +186,10 @@ func (v *VpnKeyRotationService) ReconcileVpnKeyRotation(ctx context.Context, req
 	}
 	if !reflect.DeepEqual(copyVpnConfig.Spec.RotationInterval, s.Spec.RotationInterval) {
 		copyVpnConfig.Spec.RotationInterval = s.Spec.RotationInterval
+		if copyVpnConfig.Spec.CertificateCreationTime != nil {
+			newExpiry := metav1.NewTime(copyVpnConfig.Spec.CertificateCreationTime.AddDate(0, 0, s.Spec.RotationInterval))
+			copyVpnConfig.Spec.CertificateExpiryTime = &newExpiry
+		}
 		toUpdate = true
 	}
 	if !reflect.DeepEqual(copyVpnConfig.Spec.SliceName, s.Name) {

--- a/service/vpn_key_rotation_service_test.go
+++ b/service/vpn_key_rotation_service_test.go
@@ -1363,3 +1363,55 @@ func runReconcileVpnKeyRotation(t *testing.T, tc reconcileVpnKeyRotationTestCase
 	require.Equal(t, tc.expectedResponse, gotResp)
 
 }
+
+func Test_ReconcileVpnKeyRotationIntervalChange(t *testing.T) {
+	ctx, clientMock, vpn, _, _ := setupTestCase()
+
+	creationTime := metav1.NewTime(time.Date(2021, 6, 16, 20, 34, 58, 651387237, time.UTC))
+	oldExpiry := metav1.NewTime(creationTime.AddDate(0, 0, 90))
+
+	clientMock.
+		On("Get", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Run(func(args mock.Arguments) {
+		v := args.Get(2).(*controllerv1alpha1.VpnKeyRotation)
+		v.ObjectMeta = metav1.ObjectMeta{Name: "test-slice", Namespace: "test-ns"}
+		v.Spec = controllerv1alpha1.VpnKeyRotationSpec{
+			SliceName:               "test-slice",
+			RotationInterval:        90,
+			ClusterGatewayMapping:   map[string][]string{},
+			CertificateCreationTime: &creationTime,
+			CertificateExpiryTime:   &oldExpiry,
+		}
+	}).Once()
+
+	clientMock.
+		On("Get", mock.Anything, mock.Anything, mock.Anything).
+		Return(nil).Run(func(args mock.Arguments) {
+		s := args.Get(2).(*controllerv1alpha1.SliceConfig)
+		s.ObjectMeta = metav1.ObjectMeta{Name: "test-slice", Namespace: "test-ns"}
+		s.Spec = controllerv1alpha1.SliceConfigSpec{
+			RotationInterval: 30,
+		}
+	}).Once()
+
+	var capturedVpn controllerv1alpha1.VpnKeyRotation
+	clientMock.
+		On("Update", mock.Anything, mock.Anything).
+		Return(nil).Run(func(args mock.Arguments) {
+		capturedVpn = *args.Get(1).(*controllerv1alpha1.VpnKeyRotation)
+	}).Once()
+
+	clientMock.On("Create", mock.Anything, mock.AnythingOfType("*v1.Event")).Return(nil).Maybe()
+
+	result, err := vpn.ReconcileVpnKeyRotation(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: "test-ns", Name: "test-slice"},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, ctrl.Result{Requeue: true}, result)
+	require.Equal(t, 30, capturedVpn.Spec.RotationInterval)
+	expectedExpiry := metav1.NewTime(creationTime.AddDate(0, 0, 30))
+	require.Equal(t, expectedExpiry.UTC(), capturedVpn.Spec.CertificateExpiryTime.UTC())
+
+	clientMock.AssertExpectations(t)
+}


### PR DESCRIPTION
# Description

When `SliceConfig.Spec.RotationInterval` changes, `ReconcileVpnKeyRotation` was syncing the new interval to `VpnKeyRotation.Spec.RotationInterval` but leaving  `CertificateExpiryTime` unchanged. Certificates continued to expire on the old schedule, meaning reducing the rotation interval in response to a security incident had no immediate effect. The fix adds three lines inside the existing interval-change block in `service/vpn_key_rotation_service.go:187-193`: when `CertificateCreationTime` is set, `CertificateExpiryTime` is recalculated as `CertificateCreationTime + newInterval`. If the resulting expiry is already in the  past, the downstream `reconcileVpnKeyRotationConfig` call will detect it and trigger immediate rotation. Also removed the `// TODO(rahul): handle change in  rotation interval` comment in `slice_config_service.go` that flagged this gap.

  Fixes #351 

  ## How Has This Been Tested?

  - Added `Test_ReconcileVpnKeyRotationIntervalChange` in `service/vpn_key_rotation_service_test.go`: mocks VpnKeyRotation with RotationInterval=90 and a known CertificateCreationTime, SliceConfig with RotationInterval=30, captures the Update call, and asserts CertificateExpiryTime is recalculated to  `CertificateCreationTime + 30 days`.
  - `make test && make unit-test` passes locally.

  ## Checklist:

  * [x] The title of the PR states what changed and the related issues number (used for the release note).
  * [x] Does this PR requires documentation updates? — No.
  * [x] I've updated documentation as required by this PR.
  * [x] I have performed a self-review of my own code.
  * [x] I have commented my code, particularly in hard-to-understand areas. — N/A.
  * [x] I have tested it for all user roles. — N/A.
  * [x] I have added all the required unit test cases.

  ## Does this PR introduce a breaking change for other components like worker-operator?

  No

  ```release-note
  Fixed: reducing SliceConfig rotationInterval now immediately recalculates VpnKeyRotation certificate expiry, triggering rotation sooner instead of waiting for the old expiry.
