### PR TITLE
fix(slice_config_webhook): guard nil VPNConfig in preventUpdate (#322)

### DIFF
--- a/service/slice_config_webhook_validation.go
+++ b/service/slice_config_webhook_validation.go
@@ -423,7 +423,7 @@ func preventUpdate(ctx context.Context, sc *controllerv1alpha1.SliceConfig, old 
 		return field.Invalid(field.NewPath("Spec").Child("SliceIpamType"), sc.Spec.SliceIpamType, "cannot be updated")
 	}
 	// required if slice from previous releases is upgraded
-	if sliceConfig.Spec.VPNConfig != nil {
+	if sliceConfig.Spec.VPNConfig != nil && sc.Spec.VPNConfig != nil {
 		if sliceConfig.Spec.VPNConfig.Cipher != sc.Spec.VPNConfig.Cipher {
 			return field.Invalid(field.NewPath("Spec").Child("VPNConfig").Child("Cipher"), sc.Spec.VPNConfig.Cipher, "cannot be updated")
 		}

--- a/service/slice_config_webhook_validation_test.go
+++ b/service/slice_config_webhook_validation_test.go
@@ -118,6 +118,7 @@ var SliceConfigWebhookValidationTestBed = map[string]func(*testing.T){
 	"TestValidateRotationInterval_Change_Increased":                                                                            TestValidateRotationInterval_Change_Increased,
 	"TestValidateRotationInterval_NoChange":                                                                                    TestValidateRotationInterval_NoChange,
 	"SliceConfigWebhookValidation_UpdateValidateSliceConfigUpdatingVPNCipher":                                                  UpdateValidateSliceConfigUpdatingVPNCipher,
+	"SliceConfigWebhookValidation_UpdateValidateSliceConfigVPNConfigRemovedDoesNotPanic":                                       UpdateValidateSliceConfigVPNConfigRemovedDoesNotPanic,
 	"Test_validateSlicegatewayServiceType":                                                                                     test_validateSlicegatewayServiceType,
 }
 
@@ -934,6 +935,23 @@ func UpdateValidateSliceConfigUpdatingVPNCipher(t *testing.T) {
 	require.Contains(t, err.Error(), "Spec.VPNConfig.Cipher: Invalid value:")
 	require.Contains(t, err.Error(), "cannot be updated")
 	clientMock.AssertExpectations(t)
+}
+
+func UpdateValidateSliceConfigVPNConfigRemovedDoesNotPanic(t *testing.T) {
+	// Regression test for issue #322: preventUpdate panicked when the old
+	// SliceConfig had VPNConfig set but the update request omitted it,
+	// dereferencing the new (nil) VPNConfig.Cipher.
+	oldSliceConfig := controllerv1alpha1.SliceConfig{}
+	oldSliceConfig.Spec.SliceSubnet = "192.168.1.0/16"
+	oldSliceConfig.Spec.VPNConfig = &controllerv1alpha1.VPNConfiguration{
+		Cipher: "AES-256-CBC",
+	}
+	newSliceConfig := &controllerv1alpha1.SliceConfig{}
+	newSliceConfig.Spec.SliceSubnet = "192.168.1.0/16"
+	// VPNConfig deliberately left nil on the update.
+	require.NotPanics(t, func() {
+		_ = preventUpdate(context.Background(), newSliceConfig, runtime.Object(&oldSliceConfig))
+	})
 }
 
 func UpdateValidateSliceConfigUpdatingSliceType(t *testing.T) {


### PR DESCRIPTION
Fixes #322.

`preventUpdate` in `service/slice_config_webhook_validation.go` checks `sliceConfig.Spec.VPNConfig != nil` (old object) but then dereferences `sc.Spec.VPNConfig.Cipher` (new object) unconditionally. When an update removes `VPNConfig` from a SliceConfig that previously had it, the new object's `VPNConfig` is nil and the webhook panics, crashing the controller manager.

This adds the missing `sc.Spec.VPNConfig != nil` guard, matching the `SliceGatewayProvider` pattern a few lines above.

Includes a regression test `UpdateValidateSliceConfigVPNConfigRemovedDoesNotPanic` that calls `preventUpdate` directly with the failing input and asserts it does not panic.