### PR TITLE
fix: return error from UpdateStatus in cluster deregistration

### DIFF
--- a/service/cluster_service.go
+++ b/service/cluster_service.go
@@ -187,7 +187,9 @@ func (c *ClusterService) ReconcileCluster(ctx context.Context, req ctrl.Request)
 					logger.Info("Waiting for worker-operator charts to uninstall")
 					// setting IsDeregisterInProgress to true to avoid requeuing
 					cluster.Status.IsDeregisterInProgress = true
-					util.UpdateStatus(ctx, cluster)
+					if err := util.UpdateStatus(ctx, cluster); err != nil {
+						return ctrl.Result{}, err
+					}
 					// Event for worker-operator chart uninstallation in progress [ClusterDeregistrationInProgress]
 					util.RecordEvent(ctx, eventRecorder, cluster, nil, events.EventClusterDeregistrationInProgress)
 					c.mf.RecordCounterMetric(metrics.KubeSliceEventsCounter,


### PR DESCRIPTION
## Description
This PR ensures that if updating a cluster's status fails during the deregistration flow (`ReconcileCluster`), the error is properly returned to the controller runtime. Previously, the `util.UpdateStatus` error was silently ignored, which masked failure states (e.g., optimistic locking conflicts) and prevented the reconciliation loop from properly requeuing the operation.



## How Has This Been Tested?
- Built the project locally using `go build ./...` to verify there are no compilation errors.
- Verified the control flow now properly passes the error back up to `ctrl.Result{}, err` as required by `controller-runtime`.

## Checklist:
- [x] The title of the PR states what changed and the related issues number (used for the release note).
- [ ] Does this PR requires documentation updates?
- [ ] I've updated documentation as required by this PR.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have tested it for all user roles.
- [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?
No.
