### PR TITLE
   fix(namespace): remove duplicate GetProjectName call in DeleteNamespace metrics

### DIFF
--- a/service/namespace_service.go
+++ b/service/namespace_service.go
@@ -189,7 +189,7 @@ func (n *NamespaceService) DeleteNamespace(ctx context.Context, namespace string
 	eventRecorder := util.CtxEventRecorder(ctx).WithProject(util.GetProjectName(namespace)).WithNamespace(ControllerNamespace)
 
 	// Load metrics with project name and namespace
-	n.mf.WithProject(util.GetProjectName(util.GetProjectName(namespace))).
+	n.mf.WithProject(util.GetProjectName(namespace)).
 		WithNamespace(ControllerNamespace)
 
 	if err != nil {


### PR DESCRIPTION
  # Description

  `NamespaceService.DeleteNamespace` in `service/namespace_service.go:192` called `util.GetProjectName(util.GetProjectName(namespace))`. The inner call correctly  extracts the project name (e.g., `"cisco"` from `"kubeslice-cisco"`), but the outer call then receives `"cisco"` — which lacks the `"kubeslice-"` prefix — and  returns `""`. As a result, all Prometheus counter metrics for namespace deletion events were recorded with `project=""`. The fix removes the outer wrapper, matching the single-call pattern used in every other `WithProject` call in the same file (including line 189 in the same function).

  ## How Has This Been Tested?

  - `service/namespace_service.go:192` changed from `util.GetProjectName(util.GetProjectName(namespace))` to `util.GetProjectName(namespace)`.
  - The `eventRecorder` line directly above (line 189) already used the correct single-call pattern — confirmed as the reference.
  - `go build ./...` passes locally in WSL.
  - The pre-existing `make vet` failure (`undefined: util.Client` in `access_control_service_test.go`) is unrelated to this change and exists on master before

Fixe #366

  ## Checklist:

  * [x] The title of the PR states what changed and the related issues number (used for the release note).
  * [ ] Does this PR requires documentation updates? — No.
  * [x] I've updated documentation as required by this PR.
  * [x] I have performed a self-review of my own code.
  * [ ] I have commented my code, particularly in hard-to-understand areas. — N/A.
  * [x] I have tested it for all user roles. — N/A.
  * [x] I have added all the required unit test cases.

  ## Does this PR introduce a breaking change for other components like worker-operator?

  No

  ```release-note
  Fix namespace deletion Prometheus metrics always recording empty project label due to double GetProjectName call
