### PR TITLE
feat(sliceconfig): add machine-observable status conditions

### DIFF
--- a/apis/controller/v1alpha1/sliceconfig_types.go
+++ b/apis/controller/v1alpha1/sliceconfig_types.go
@@ -196,11 +196,16 @@ type KubesliceEvent struct {
 
 // SliceConfigStatus defines the observed state of SliceConfig
 type SliceConfigStatus struct {
-	KubesliceEvents []KubesliceEvent `json:"kubesliceEvents,omitempty"`
+	// Conditions represent the latest available observations of the SliceConfig's provisioning state.
+	// +listType=map
+	// +listMapKey=type
+	Conditions      []metav1.Condition `json:"conditions,omitempty"`
+	KubesliceEvents []KubesliceEvent   `json:"kubesliceEvents,omitempty"`
 }
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="READY",type=string,JSONPath=".status.conditions[?(@.type=='Ready')].status"
 
 // SliceConfig is the Schema for the sliceconfig API
 type SliceConfig struct {

--- a/service/slice_config_service.go
+++ b/service/slice_config_service.go
@@ -28,9 +28,19 @@ import (
 	"github.com/kubeslice/kubeslice-controller/events"
 	"github.com/kubeslice/kubeslice-controller/util"
 	corev1 "k8s.io/api/core/v1"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Condition type constants for SliceConfig status.
+const (
+	SliceConditionWorkerConfigsProvisioned = "WorkerConfigsProvisioned"
+	SliceConditionGatewaysProvisioned      = "GatewaysProvisioned"
+	SliceConditionVPNConfigured            = "VPNConfigured"
+	SliceConditionReady                    = "Ready"
 )
 
 type ISliceConfigService interface {
@@ -187,7 +197,28 @@ func (s *SliceConfigService) ReconcileSliceConfig(ctx context.Context, req ctrl.
 
 	if sliceConfig.Spec.OverlayNetworkDeploymentMode == v1alpha1.NONET {
 		err = s.ms.CreateMinimalWorkerSliceConfigForNoNetworkSlice(ctx, sliceConfig.Spec.Clusters, req.Namespace, ownershipLabel, sliceConfig.Name)
-		return ctrl.Result{}, err
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		apimeta.SetStatusCondition(&sliceConfig.Status.Conditions, metav1.Condition{
+			Type:               SliceConditionWorkerConfigsProvisioned,
+			Status:             metav1.ConditionTrue,
+			Reason:             "WorkerConfigsCreated",
+			Message:            "WorkerSliceConfig provisioned for all clusters",
+			ObservedGeneration: sliceConfig.Generation,
+		})
+		apimeta.SetStatusCondition(&sliceConfig.Status.Conditions, metav1.Condition{
+			Type:               SliceConditionReady,
+			Status:             metav1.ConditionTrue,
+			Reason:             "Provisioned",
+			Message:            "No-network slice provisioned",
+			ObservedGeneration: sliceConfig.Generation,
+		})
+		if statusErr := util.UpdateStatus(ctx, sliceConfig); statusErr != nil {
+			logger.Errorf("failed to update SliceConfig status conditions: %s", statusErr)
+			return ctrl.Result{}, statusErr
+		}
+		return ctrl.Result{}, nil
 	}
 
 	// Step 4: Creation of worker slice Objects and Cluster Labels
@@ -202,12 +233,26 @@ func (s *SliceConfigService) ReconcileSliceConfig(ctx context.Context, req ctrl.
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+	apimeta.SetStatusCondition(&sliceConfig.Status.Conditions, metav1.Condition{
+		Type:               SliceConditionWorkerConfigsProvisioned,
+		Status:             metav1.ConditionTrue,
+		Reason:             "WorkerConfigsCreated",
+		Message:            "WorkerSliceConfig provisioned for all clusters",
+		ObservedGeneration: sliceConfig.Generation,
+	})
 
 	// Step 5: Create gateways with minimum specification
 	_, err = s.sgs.CreateMinimumWorkerSliceGateways(ctx, sliceConfig.Name, sliceConfig.Spec.Clusters, req.Namespace, ownershipLabel, clusterMap, sliceConfig.Spec.SliceSubnet, clusterCidr, sliceGwSvcTypeMap)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
+	apimeta.SetStatusCondition(&sliceConfig.Status.Conditions, metav1.Condition{
+		Type:               SliceConditionGatewaysProvisioned,
+		Status:             metav1.ConditionTrue,
+		Reason:             "GatewayPairsCreated",
+		Message:            "WorkerSliceGateway pairs created for all cluster pairs",
+		ObservedGeneration: sliceConfig.Generation,
+	})
 	logger.Infof("sliceConfig %v reconciled", req.NamespacedName)
 
 	// Step 6: Create VPNKeyRotation CR
@@ -217,10 +262,17 @@ func (s *SliceConfigService) ReconcileSliceConfig(ctx context.Context, req ctrl.
 		util.RecordEvent(ctx, eventRecorder, sliceConfig, nil, events.EventVPNKeyRotationConfigCreationFailed)
 		return ctrl.Result{}, err
 	}
-	// Step 7: update cluster info into vpnkeyrotation Cconfig
+	// Step 7: update cluster info into vpnkeyrotation config
 	if _, err := s.vpn.ReconcileClusters(ctx, sliceConfig.Name, sliceConfig.Namespace, sliceConfig.Spec.Clusters); err != nil {
 		return ctrl.Result{}, err
 	}
+	apimeta.SetStatusCondition(&sliceConfig.Status.Conditions, metav1.Condition{
+		Type:               SliceConditionVPNConfigured,
+		Status:             metav1.ConditionTrue,
+		Reason:             "VPNKeyRotationCreated",
+		Message:            "VpnKeyRotation CR created for slice",
+		ObservedGeneration: sliceConfig.Generation,
+	})
 
 	// Step 8: Create ServiceImport Objects
 	serviceExports := &v1alpha1.ServiceExportConfigList{}
@@ -238,6 +290,17 @@ func (s *SliceConfigService) ReconcileSliceConfig(ctx context.Context, req ctrl.
 		}
 	}
 
+	apimeta.SetStatusCondition(&sliceConfig.Status.Conditions, metav1.Condition{
+		Type:               SliceConditionReady,
+		Status:             metav1.ConditionTrue,
+		Reason:             "Provisioned",
+		Message:            "Slice provisioned across all clusters",
+		ObservedGeneration: sliceConfig.Generation,
+	})
+	if statusErr := util.UpdateStatus(ctx, sliceConfig); statusErr != nil {
+		logger.Errorf("failed to update SliceConfig status conditions: %s", statusErr)
+		return ctrl.Result{}, statusErr
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/service/slice_config_service_test.go
+++ b/service/slice_config_service_test.go
@@ -78,6 +78,10 @@ var SliceConfigTestBed = map[string]func(*testing.T){
 	"SliceConfig_DeleteErrorOnDelete":                            SliceConfigDeleteErrorOnDelete,
 	"SliceConfig_ErrorOnListingServiceExport":                    SliceConfigErrorOnListingServiceExport,
 	"SliceConfig_ErrorOnCreateOrUpdateServiceImport":             SliceConfigErrorOnCreateOrUpdateServiceImport,
+	// status condition tests
+	"SliceConfig_ConditionsSetOnSuccessfulReconcile":    SliceConfigConditionsSetOnSuccessfulReconcile,
+	"SliceConfig_ConditionsSetOnNoNetSuccessfulReconcile": SliceConfigConditionsSetOnNoNetSuccessfulReconcile,
+	"SliceConfig_ReadyConditionFalseWhenGatewayFails":   SliceConfigReadyConditionFalseWhenGatewayFails,
 }
 
 func SliceConfigReconciliationCompleteHappyCase(t *testing.T) {
@@ -119,6 +123,9 @@ func SliceConfigReconciliationCompleteHappyCase(t *testing.T) {
 		}
 	}).Once()
 	workerServiceImportMock.On("CreateMinimalWorkerServiceImport", ctx, sliceConfig.Spec.Clusters, requestObj.Namespace, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	// status condition update at end of reconcile
+	clientMock.On("Status").Return(clientMock).Once()
+	clientMock.On("Update", mock.Anything, mock.Anything).Return(nil).Once()
 	result, err := sliceConfigService.ReconcileSliceConfig(ctx, requestObj)
 	expectedResult := ctrl.Result{}
 	require.NoError(t, nil)
@@ -153,6 +160,9 @@ func SliceConfigReconciliationNoNetCompleteHappyCase(t *testing.T) {
 	clientMock.On("Get", ctx, mock.Anything, mock.Anything).Return(nil)
 
 	workerSliceConfigMock.On("CreateMinimalWorkerSliceConfigForNoNetworkSlice", ctx, mock.Anything, requestObj.Namespace, mock.Anything, mock.Anything).Return(nil).Once()
+	// status condition update at end of NoNet reconcile
+	clientMock.On("Status").Return(clientMock).Once()
+	clientMock.On("Update", mock.Anything, mock.Anything).Return(nil).Once()
 
 	result, err := sliceConfigService.ReconcileSliceConfig(ctx, requestObj)
 	expectedResult := ctrl.Result{}
@@ -736,4 +746,145 @@ func setupSliceConfigTest(name string, namespace string) (*mocks.IWorkerSliceGat
 	vpn.On("ReconcileClusters", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
 	ctx := util.PrepareKubeSliceControllersRequestContext(context.Background(), clientMock, scheme, "SliceConfigServiceTest", &eventRecorder)
 	return workerSliceGatewayMock, workerSliceConfigMock, serviceExportConfigMock, workerServiceImportMock, workerSliceGatewayRecyclerMock, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock
+}
+
+// SliceConfigConditionsSetOnSuccessfulReconcile verifies that all four status conditions
+// are set to True and Ready is True after a fully successful network-slice reconcile.
+func SliceConfigConditionsSetOnSuccessfulReconcile(t *testing.T) {
+	workerSliceGatewayMock, workerSliceConfigMock, _, workerServiceImportMock, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock := setupSliceConfigTest("slice_config", "namespace")
+	mMock.On("WithProject", mock.AnythingOfType("string")).Return(&metrics.MetricRecorder{}).Once()
+	clientMock.On("Get", ctx, requestObj.NamespacedName, sliceConfig).Return(nil).Once()
+	clientMock.On("Update", ctx, mock.Anything).Return(nil).Once()
+	clientMock.On("Get", ctx, mock.Anything, mock.Anything).Return(nil).Once()
+	namespace := corev1.Namespace{}
+	clientMock.On("Get", ctx, mock.Anything, &namespace).Return(nil).Run(func(args mock.Arguments) {
+		arg := args.Get(2).(*corev1.Namespace)
+		if arg.Labels == nil {
+			arg.Labels = make(map[string]string)
+		}
+		arg.Name = requestObj.Namespace
+		arg.Labels[util.LabelName] = fmt.Sprintf(util.LabelValue, "Project", requestObj.Namespace)
+	}).Once()
+	clientMock.On("Get", ctx, mock.Anything, mock.Anything).Return(nil)
+	clusterMap := map[string]int{"cluster-1": 1, "cluster-2": 2}
+	workerSliceConfigMock.On("CreateMinimalWorkerSliceConfig", ctx, mock.Anything, requestObj.Namespace, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(clusterMap, nil).Once()
+	workerSliceGatewayMock.On("CreateMinimumWorkerSliceGateways", ctx, mock.Anything, mock.Anything, requestObj.Namespace, mock.Anything, clusterMap, mock.Anything, mock.Anything, mock.Anything).Return(ctrl.Result{}, nil).Once()
+	label := map[string]string{"original-slice-name": sliceConfig.Name}
+	serviceExportList := &controllerv1alpha1.ServiceExportConfigList{}
+	clientMock.On("List", ctx, serviceExportList, client.InNamespace(requestObj.Namespace), client.MatchingLabels(label)).Return(nil).Once()
+	workerServiceImportMock.On("CreateMinimalWorkerServiceImport", ctx, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	var capturedSliceConfig *controllerv1alpha1.SliceConfig
+	clientMock.On("Status").Return(clientMock).Once()
+	clientMock.On("Update", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		if sc, ok := args.Get(1).(*controllerv1alpha1.SliceConfig); ok {
+			capturedSliceConfig = sc
+		}
+	}).Once()
+
+	result, err := sliceConfigService.ReconcileSliceConfig(ctx, requestObj)
+	require.Nil(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+
+	require.NotNil(t, capturedSliceConfig, "UpdateStatus should have been called with the SliceConfig")
+	requireConditionTrue(t, capturedSliceConfig.Status.Conditions, SliceConditionWorkerConfigsProvisioned)
+	requireConditionTrue(t, capturedSliceConfig.Status.Conditions, SliceConditionGatewaysProvisioned)
+	requireConditionTrue(t, capturedSliceConfig.Status.Conditions, SliceConditionVPNConfigured)
+	requireConditionTrue(t, capturedSliceConfig.Status.Conditions, SliceConditionReady)
+}
+
+// SliceConfigConditionsSetOnNoNetSuccessfulReconcile verifies that WorkerConfigsProvisioned
+// and Ready are True for a no-network slice; gateway/VPN conditions are not set.
+func SliceConfigConditionsSetOnNoNetSuccessfulReconcile(t *testing.T) {
+	_, workerSliceConfigMock, _, _, _, clientMock, _, ctx, sliceConfigService, requestObj, mMock := setupSliceConfigTest("slice_config", "namespace")
+	mMock.On("WithProject", mock.AnythingOfType("string")).Return(&metrics.MetricRecorder{}).Once()
+	clientMock.On("Get", ctx, requestObj.NamespacedName, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		arg := args.Get(2).(*controllerv1alpha1.SliceConfig)
+		arg.Spec.OverlayNetworkDeploymentMode = controllerv1alpha1.NONET
+	}).Once()
+	clientMock.On("Update", ctx, mock.Anything).Return(nil).Once()
+	clientMock.On("Get", ctx, mock.Anything, mock.Anything).Return(nil).Once()
+	namespace := corev1.Namespace{}
+	clientMock.On("Get", ctx, mock.Anything, &namespace).Return(nil).Run(func(args mock.Arguments) {
+		arg := args.Get(2).(*corev1.Namespace)
+		if arg.Labels == nil {
+			arg.Labels = make(map[string]string)
+		}
+		arg.Name = requestObj.Namespace
+		arg.Labels[util.LabelName] = fmt.Sprintf(util.LabelValue, "Project", requestObj.Namespace)
+	}).Once()
+	clientMock.On("Get", ctx, mock.Anything, mock.Anything).Return(nil)
+	workerSliceConfigMock.On("CreateMinimalWorkerSliceConfigForNoNetworkSlice", ctx, mock.Anything, requestObj.Namespace, mock.Anything, mock.Anything).Return(nil).Once()
+
+	var capturedSliceConfig *controllerv1alpha1.SliceConfig
+	clientMock.On("Status").Return(clientMock).Once()
+	clientMock.On("Update", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		if sc, ok := args.Get(1).(*controllerv1alpha1.SliceConfig); ok {
+			capturedSliceConfig = sc
+		}
+	}).Once()
+
+	result, err := sliceConfigService.ReconcileSliceConfig(ctx, requestObj)
+	require.Nil(t, err)
+	require.Equal(t, ctrl.Result{}, result)
+
+	require.NotNil(t, capturedSliceConfig)
+	requireConditionTrue(t, capturedSliceConfig.Status.Conditions, SliceConditionWorkerConfigsProvisioned)
+	requireConditionTrue(t, capturedSliceConfig.Status.Conditions, SliceConditionReady)
+	// gateway and VPN conditions are not applicable for no-network slices
+	require.Nil(t, findCondition(capturedSliceConfig.Status.Conditions, SliceConditionGatewaysProvisioned))
+	require.Nil(t, findCondition(capturedSliceConfig.Status.Conditions, SliceConditionVPNConfigured))
+}
+
+// SliceConfigReadyConditionFalseWhenGatewayFails verifies that no status update is
+// performed (and Ready is never set) when gateway creation returns an error.
+func SliceConfigReadyConditionFalseWhenGatewayFails(t *testing.T) {
+	workerSliceGatewayMock, workerSliceConfigMock, _, _, _, clientMock, sliceConfig, ctx, sliceConfigService, requestObj, mMock := setupSliceConfigTest("slice_config", "namespace")
+	mMock.On("WithProject", mock.AnythingOfType("string")).Return(&metrics.MetricRecorder{}).Once()
+	clientMock.On("Get", ctx, requestObj.NamespacedName, sliceConfig).Return(nil).Once()
+	clientMock.On("Update", ctx, mock.Anything).Return(nil).Once()
+	clientMock.On("Get", ctx, mock.Anything, mock.Anything).Return(nil).Once()
+	namespace := corev1.Namespace{}
+	clientMock.On("Get", ctx, mock.Anything, &namespace).Return(nil).Run(func(args mock.Arguments) {
+		arg := args.Get(2).(*corev1.Namespace)
+		if arg.Labels == nil {
+			arg.Labels = make(map[string]string)
+		}
+		arg.Name = requestObj.Namespace
+		arg.Labels[util.LabelName] = fmt.Sprintf(util.LabelValue, "Project", requestObj.Namespace)
+	}).Once()
+	clientMock.On("Get", ctx, mock.Anything, mock.Anything).Return(nil)
+	clusterMap := map[string]int{"cluster-1": 1, "cluster-2": 2}
+	workerSliceConfigMock.On("CreateMinimalWorkerSliceConfig", ctx, mock.Anything, requestObj.Namespace, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(clusterMap, nil).Once()
+	gatewayErr := errors.New("gateway creation failed")
+	workerSliceGatewayMock.On("CreateMinimumWorkerSliceGateways", ctx, mock.Anything, mock.Anything, requestObj.Namespace, mock.Anything, clusterMap, mock.Anything, mock.Anything, mock.Anything).Return(ctrl.Result{}, gatewayErr).Once()
+
+	result, err := sliceConfigService.ReconcileSliceConfig(ctx, requestObj)
+	require.Error(t, err)
+	require.Equal(t, gatewayErr, err)
+	require.Equal(t, ctrl.Result{}, result)
+	// Status().Update() must NOT have been called — no Ready condition written on error path
+	clientMock.AssertNotCalled(t, "Status")
+	clientMock.AssertExpectations(t)
+	workerSliceConfigMock.AssertExpectations(t)
+	workerSliceGatewayMock.AssertExpectations(t)
+	mMock.AssertExpectations(t)
+}
+
+// requireConditionTrue asserts that a condition of the given type exists and is True.
+func requireConditionTrue(t *testing.T, conditions []metav1.Condition, condType string) {
+	t.Helper()
+	c := findCondition(conditions, condType)
+	require.NotNilf(t, c, "condition %q not found", condType)
+	require.Equalf(t, metav1.ConditionTrue, c.Status, "condition %q expected True, got %s", condType, c.Status)
+}
+
+// findCondition returns a pointer to the condition with the given type, or nil.
+func findCondition(conditions []metav1.Condition, condType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == condType {
+			return &conditions[i]
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

- Adds `Conditions []metav1.Condition` to `SliceConfigStatus` with `+listType=map` / `+listMapKey=type` markers for correct strategic-merge-patch behaviour.
- `ReconcileSliceConfig` sets four conditions after key provisioning steps and calls a single `util.UpdateStatus` on successful completion.
- Adds `+kubebuilder:printcolumn` for `READY` so `kubectl get sliceconfig` shows readiness inline.
- `kubesliceEvents` behaviour is unchanged; this change is fully backward compatible.

## Motivation

`SliceConfigStatus` previously exposed only `kubesliceEvents[]`, an append-style audit log with no machine-queryable readiness semantics. A fully provisioned slice and one stalled at step 3 were externally indistinguishable. This blocked `kubectl wait --for=condition=Ready`, FluxCD/ArgoCD health checks, and Helm `--wait` on slice provisioning.

## Conditions added

| Condition | Set after |
|---|---|
| `WorkerConfigsProvisioned` | Step 4 — all `WorkerSliceConfig` objects created |
| `GatewaysProvisioned` | Step 5 — all `WorkerSliceGateway` pairs created |
| `VPNConfigured` | Step 7 — `VpnKeyRotation` CR created |
| `Ready` | All three above are `True` |

For no-network slices, only `WorkerConfigsProvisioned` and `Ready` are set (gateways and VPN are not applicable).

## Test plan

- `SliceConfig_ConditionsSetOnSuccessfulReconcile` — all four conditions are `True` after a complete network-slice reconcile
- `SliceConfig_ConditionsSetOnNoNetSuccessfulReconcile` — only `WorkerConfigsProvisioned` and `Ready` are set for NoNet slices
- `SliceConfig_ReadyConditionFalseWhenGatewayFails` — `Status()` is never called when gateway creation returns an error
- All 21 existing `SliceConfigTestBed` cases updated / continue to pass

## Migration notes

`conditions` is `omitempty`; existing objects without the field remain valid. No CRD migration needed. After merging, run `make manifests && make install` to apply the updated CRD.

Fixes #368