### PR TITLE
test(worker-slice-gateway): full-mesh pair enumeration helper (#355)

### DIFF
--- a/service/worker_slice_gateway_fullmesh_creation_test.go
+++ b/service/worker_slice_gateway_fullmesh_creation_test.go
@@ -1,0 +1,119 @@
+/*
+ * 	Copyright (c) 2022 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package service
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	controllerv1alpha1 "github.com/kubeslice/kubeslice-controller/apis/controller/v1alpha1"
+	workerv1alpha1 "github.com/kubeslice/kubeslice-controller/apis/worker/v1alpha1"
+	"github.com/kubeslice/kubeslice-controller/metrics"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	k8sError "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestCreateMinimumWorkerSliceGateways_fullMeshPairCount verifies that reconciling
+// a slice with n member clusters triggers one cert job per unordered cluster pair
+// (C(n,2)), i.e. the current full-mesh behaviour locked before topology modes.
+// kubeslice-controller#355
+func TestCreateMinimumWorkerSliceGateways_fullMeshPairCount(t *testing.T) {
+	t.Setenv("KUBESLICE_CONTROLLER_MANAGER_NAMESPACE", "kubeslice-controller")
+
+	cases := []struct {
+		nClusters int
+		wantPairs int
+	}{
+		{nClusters: 3, wantPairs: 3},
+		{nClusters: 4, wantPairs: 6},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(fmt.Sprintf("n_%d", tc.nClusters), func(t *testing.T) {
+			ns := "test-namespace"
+			sliceName := "test-slice"
+
+			clusterNames := make([]string, tc.nClusters)
+			clusterMap := make(map[string]int, tc.nClusters)
+			for i := 0; i < tc.nClusters; i++ {
+				name := fmt.Sprintf("cluster-%d", i+1)
+				clusterNames[i] = name
+				clusterMap[name] = i + 1
+			}
+
+			label := map[string]string{
+				"original-slice-name": sliceName,
+			}
+
+			_, _, jobMock, svc, _, clientMock, _, ctx, mMock := setupWorkerSliceGatewayTest("gw", ns)
+
+			clientMock.On("List", ctx, mock.Anything, mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+				list := args.Get(1).(*workerv1alpha1.WorkerSliceGatewayList)
+				list.Items = nil
+			}).Once()
+
+			clusterObj := &controllerv1alpha1.Cluster{}
+			clientMock.On("Get", ctx, mock.AnythingOfType("types.NamespacedName"), clusterObj).Return(nil).Run(func(args mock.Arguments) {
+				key := args.Get(1).(types.NamespacedName)
+				c := args.Get(2).(*controllerv1alpha1.Cluster)
+				c.Name = key.Name
+				c.Namespace = key.Namespace
+			}).Times(tc.nClusters)
+
+			notFound := k8sError.NewNotFound(schema.GroupResource{Group: "", Resource: "WorkerSliceGateway"}, "missing")
+			gatewayObj := &workerv1alpha1.WorkerSliceGateway{}
+			clientMock.On("Get", ctx, mock.AnythingOfType("types.NamespacedName"), gatewayObj).
+				Return(notFound).Maybe()
+
+			var gatewayCreates int32
+			clientMock.On("Create", ctx, mock.MatchedBy(func(obj client.Object) bool {
+				_, ok := obj.(*workerv1alpha1.WorkerSliceGateway)
+				if ok {
+					atomic.AddInt32(&gatewayCreates, 1)
+				}
+				return ok
+			})).Return(nil).Times(2 * tc.wantPairs)
+
+			clientMock.On("Create", ctx, mock.AnythingOfType("*v1.Event")).Return(nil).Maybe()
+			clientMock.On("Update", ctx, mock.Anything).Return(nil).Maybe()
+
+			sliceConfig := &controllerv1alpha1.SliceConfig{}
+			clientMock.On("Get", ctx, mock.AnythingOfType("types.NamespacedName"), sliceConfig).Return(nil).Run(func(args mock.Arguments) {
+				cfg := args.Get(2).(*controllerv1alpha1.SliceConfig)
+				cfg.Spec.SliceGatewayProvider = &controllerv1alpha1.WorkerSliceGatewayProvider{
+					SliceGatewayType: controllerv1alpha1.SliceGatewayTypeOpenVPN,
+					SliceCaType:      "Local",
+				}
+			}).Times(tc.wantPairs)
+
+			jobMock.On("CreateJob", ctx, mock.Anything, JobImage, mock.Anything).
+				Return(ctrl.Result{}, nil).Times(tc.wantPairs)
+
+			mMock.On("WithProject", mock.AnythingOfType("string")).Return(&metrics.MetricRecorder{}).Maybe()
+			mMock.On("RecordCounterMetric", mock.Anything, mock.Anything).Return().Maybe()
+
+			_, err := svc.CreateMinimumWorkerSliceGateways(ctx, sliceName, clusterNames, ns, label, clusterMap,
+				"10.10.10.0/16", "/16", nil)
+			require.NoError(t, err)
+			require.Equal(t, int32(2*tc.wantPairs), gatewayCreates,
+				"each mesh edge should create server and client WorkerSliceGateway resources")
+			jobMock.AssertNumberOfCalls(t, "CreateJob", tc.wantPairs)
+			jobMock.AssertExpectations(t)
+		})
+	}
+}

--- a/service/worker_slice_gateway_pair_enumeration_test.go
+++ b/service/worker_slice_gateway_pair_enumeration_test.go
@@ -1,0 +1,49 @@
+/*
+ * 	Copyright (c) 2022 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package service
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestFullMeshClusterPairIndices guards the full-mesh edge walk used by
+// createMinimumGatewaysIfNotExists (see #355): correct count, no duplicates,
+// stable i<j ordering so hub-and-spoke work can compare against this baseline.
+func TestFullMeshClusterPairIndices(t *testing.T) {
+	for n := 0; n <= 8; n++ {
+		n := n
+		t.Run(fmt.Sprintf("n_%d", n), func(t *testing.T) {
+			t.Parallel()
+			pairs := fullMeshClusterPairIndices(n)
+			wantLen := 0
+			if n >= 2 {
+				wantLen = n * (n - 1) / 2
+			}
+			if wantLen == 0 {
+				require.Nil(t, pairs)
+				return
+			}
+			require.Len(t, pairs, wantLen)
+
+			seen := make(map[[2]int]struct{}, wantLen)
+			for _, ij := range pairs {
+				require.Less(t, ij[0], ij[1], "every pair must use i<j ordering")
+				require.GreaterOrEqual(t, ij[0], 0)
+				require.Less(t, ij[1], n)
+				seen[ij] = struct{}{}
+			}
+			require.Len(t, seen, wantLen, "full mesh must not emit duplicate index pairs")
+		})
+	}
+}

--- a/service/worker_slice_gateway_service.go
+++ b/service/worker_slice_gateway_service.go
@@ -435,6 +435,22 @@ func (s *WorkerSliceGatewayService) cleanupObsoleteGateways(ctx context.Context,
 	return nil
 }
 
+// fullMeshClusterPairIndices returns every index pair (i, j) with i < j — one
+// pass per undirected edge of a complete graph on n vertices. For n >= 2 the
+// slice has length n*(n-1)/2; otherwise it is nil.
+func fullMeshClusterPairIndices(n int) [][2]int {
+	if n < 2 {
+		return nil
+	}
+	out := make([][2]int, 0, n*(n-1)/2)
+	for i := 0; i < n; i++ {
+		for j := i + 1; j < n; j++ {
+			out = append(out, [2]int{i, j})
+		}
+	}
+	return out
+}
+
 // createMinimumGatewaysIfNotExists is a helper function to create the gateways between worker clusters if not exists
 func (s *WorkerSliceGatewayService) createMinimumGatewaysIfNotExists(ctx context.Context, sliceName string,
 	clusterNames []string, namespace string, ownerLabel map[string]string, clusterMap map[string]int,
@@ -450,24 +466,22 @@ func (s *WorkerSliceGatewayService) createMinimumGatewaysIfNotExists(ctx context
 		}
 		clusterMapping[clusterName] = &cluster
 	}
-	for i := 0; i < noClusters; i++ {
-		for j := i + 1; j < noClusters; j++ {
-			sourceCluster, destinationCluster := clusterMapping[clusterNames[i]], clusterMapping[clusterNames[j]]
-			gatewayNumber := s.calculateGatewayNumber(clusterMap[sourceCluster.Name], clusterMap[destinationCluster.Name])
-			gatewayAddresses := s.BuildNetworkAddresses(sliceSubnet, sourceCluster.Name, destinationCluster.Name, clusterMap, clusterCidr)
-			// determine the gateway svc parameters
-			sliceGwSvcType := defaultSliceGatewayServiceType
-			gwSvcProtocol := defaultSliceGatewayServiceProtocol
-			if val, exists := sliceGwSvcTypeMap[sourceCluster.Name]; exists {
-				sliceGwSvcType = val.Type
-				gwSvcProtocol = val.Protocol
-			}
-			logger.Debugf("setting gwConType in create_minwsg %s", sliceGwSvcType)
-			logger.Debugf("setting gwProto in create_minwsg %s", gwSvcProtocol)
-			err := s.createMinimumGateWayPairIfNotExists(ctx, sourceCluster, destinationCluster, sliceName, namespace, sliceGwSvcType, gwSvcProtocol, ownerLabel, gatewayNumber, gatewayAddresses)
-			if err != nil {
-				return ctrl.Result{}, err
-			}
+	for _, ij := range fullMeshClusterPairIndices(noClusters) {
+		sourceCluster, destinationCluster := clusterMapping[clusterNames[ij[0]]], clusterMapping[clusterNames[ij[1]]]
+		gatewayNumber := s.calculateGatewayNumber(clusterMap[sourceCluster.Name], clusterMap[destinationCluster.Name])
+		gatewayAddresses := s.BuildNetworkAddresses(sliceSubnet, sourceCluster.Name, destinationCluster.Name, clusterMap, clusterCidr)
+		// determine the gateway svc parameters
+		sliceGwSvcType := defaultSliceGatewayServiceType
+		gwSvcProtocol := defaultSliceGatewayServiceProtocol
+		if val, exists := sliceGwSvcTypeMap[sourceCluster.Name]; exists {
+			sliceGwSvcType = val.Type
+			gwSvcProtocol = val.Protocol
+		}
+		logger.Debugf("setting gwConType in create_minwsg %s", sliceGwSvcType)
+		logger.Debugf("setting gwProto in create_minwsg %s", gwSvcProtocol)
+		err := s.createMinimumGateWayPairIfNotExists(ctx, sourceCluster, destinationCluster, sliceName, namespace, sliceGwSvcType, gwSvcProtocol, ownerLabel, gatewayNumber, gatewayAddresses)
+		if err != nil {
+			return ctrl.Result{}, err
 		}
 	}
 	return ctrl.Result{}, nil

--- a/service/worker_slice_gateway_service_test.go
+++ b/service/worker_slice_gateway_service_test.go
@@ -551,7 +551,6 @@ func testNodeIpReconciliationOfWorkerSliceGatewaysExists(t *testing.T) {
 			Annotations:                nil,
 			OwnerReferences:            nil,
 			Finalizers:                 nil,
-			ClusterName:                "",
 			ManagedFields:              nil,
 		},
 		Spec:   controllerv1alpha1.ClusterSpec{},

--- a/util/client_alias.go
+++ b/util/client_alias.go
@@ -1,0 +1,13 @@
+/*
+ * 	Copyright (c) 2022 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ */
+
+package util
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Client is an alias for controller-runtime's client interface, used by tests
+// and helpers that historically referred to util.Client.
+type Client = client.Client


### PR DESCRIPTION
Fixes #355

## Summary

`CreateMinimumWorkerSliceGateways` today walks every unordered cluster pair (full mesh) via nested `i` / `j>i` loops in `createMinimumGatewaysIfNotExists`. Existing unit tests only covered **two** clusters, so regressions for `n > 2` would not show up before hub-and-spoke / partial mesh work (#300 / #306).

This PR:
- Pulls the pair walk into `fullMeshClusterPairIndices` (same ordering as before: `i < j`, length `n*(n-1)/2`).
- Adds `TestFullMeshClusterPairIndices` for `n = 0..8` (count, `i<j`, no duplicate pairs).
- Adds `TestCreateMinimumWorkerSliceGateways_fullMeshPairCount` for **n = 3** (3 pairs) and **n = 4** (6 pairs), using the same mock style as the existing gateway tests — asserts `C(n,2)` cert jobs and `WorkerSliceGateway` creates.

Small build/test fixes included so `./service` tests compile on current deps:
- `util.Client` alias for `controller-runtime`’s `client.Client`.
- Drop invalid `ObjectMeta.ClusterName` from `worker_slice_gateway_service_test.go`.

No API, webhook, or worker-operator changes.

## How Has This Been Tested?

```bash
go test ./service -run "TestFullMeshClusterPairIndices|TestCreateMinimumWorkerSliceGateways_fullMeshPairCount" -count=1