### PR TITLE
improvement(util): wrap Retry last error with %w for error chain pres…

### DIFF
--- a/util/common.go
+++ b/util/common.go
@@ -217,7 +217,7 @@ func Retry(ctx context.Context, backoffLimit int, sleep time.Duration, f func() 
 		}
 	}
 	elapsed := time.Since(start)
-	return fmt.Errorf("retry failed after %d attempts (took %d seconds), last error: %s", backoffLimit, int(elapsed.Seconds()), err)
+	return fmt.Errorf("retry failed after %d attempts (took %d seconds), last error: %w", backoffLimit, int(elapsed.Seconds()), err)
 }
 
 // Set Difference: A - B


### PR DESCRIPTION
# Description

  `util.Retry` in `util/common.go` (line 220) used `%s` as the verb when wrapping the last error in the final `fmt.Errorf` call. This converts the error to a   plain string, permanently discarding its type. Any caller using `errors.Is` or `errors.As` on a `util.Retry` return value would always get `false`, making it    impossible to inspect or match the underlying cause. Changing `%s` to `%w` makes the error chain available to callers without any behaviour change at runtime.  

  Fixes #380 

  ## How Has This Been Tested?

  `util/common.go` line 220 changed from `%s` to `%w`. `go build ./...` passes. The pre-existing `make vet` and `make unit-test` failures (`undefined:
  util.Client`, `unknown field ClusterName`) exist on master before this branch and are unrelated to this change.

  ## Checklist:

  * [x] The title of the PR states what changed and the related issues number (used for the release note).
  * [ ] Does this PR requires documentation updates? — No.
  * [x] I have performed a self-review of my own code.
  * [x] I have commented my code, particularly in hard-to-understand areas.
  * [x] I have tested it for all user roles.
  * [ ] I have added all the required unit test cases.

