### PR TITLE
  improvement(service): replace duplicate checkForProjectNamespace methods with util.CheckForProjectNamespace

### DIFF
--- a/service/cluster_service.go
+++ b/service/cluster_service.go
@@ -72,7 +72,7 @@ func (c *ClusterService) ReconcileCluster(ctx context.Context, req ctrl.Request)
 	found, err = util.GetResourceIfExist(ctx, client.ObjectKey{
 		Name: req.Namespace,
 	}, projectNs)
-	if !found || !c.checkForProjectNamespace(projectNs) {
+	if !found || !util.CheckForProjectNamespace(projectNs) {
 		logger.Infof("Created Cluster %v is not in project namespace. Returning from reconciliation loop.", req.NamespacedName)
 		return ctrl.Result{}, nil
 	}
@@ -331,11 +331,6 @@ func (c *ClusterService) cleanUpClusterResources(ctx context.Context, req ctrl.R
 		return result, reconErr
 	}
 	return ctrl.Result{}, nil
-}
-
-// checkForProjectNamespace is function to check the project if the namespace is in proper format
-func (c *ClusterService) checkForProjectNamespace(namespace *corev1.Namespace) bool {
-	return namespace.Labels[util.LabelName] == fmt.Sprintf(util.LabelValue, "Project", namespace.Name)
 }
 
 // DeleteClusters is function to delete the clusters

--- a/service/slice_config_service.go
+++ b/service/slice_config_service.go
@@ -128,7 +128,7 @@ func (s *SliceConfigService) ReconcileSliceConfig(ctx context.Context, req ctrl.
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	if !found || !s.checkForProjectNamespace(nsResource) {
+	if !found || !util.CheckForProjectNamespace(nsResource) {
 		logger.Infof("Created SliceConfig %v is not in project namespace. Returning from reconciliation loop.", req.NamespacedName)
 		return ctrl.Result{}, nil
 	}
@@ -239,11 +239,6 @@ func (s *SliceConfigService) ReconcileSliceConfig(ctx context.Context, req ctrl.
 	}
 
 	return ctrl.Result{}, nil
-}
-
-// checkForProjectNamespace is a function to check the namespace is in proper format
-func (s *SliceConfigService) checkForProjectNamespace(namespace *corev1.Namespace) bool {
-	return namespace.Labels[util.LabelName] == fmt.Sprintf(util.LabelValue, "Project", namespace.Name)
 }
 
 // cleanUpSliceConfigResources is a function to delete the slice config resources

--- a/service/slice_qos_config_service.go
+++ b/service/slice_qos_config_service.go
@@ -18,7 +18,6 @@ package service
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/kubeslice/kubeslice-controller/metrics"
@@ -110,7 +109,7 @@ func (q *SliceQoSConfigService) ReconcileSliceQoSConfig(ctx context.Context, req
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	if !found || !q.checkForProjectNamespace(nsResource) {
+	if !found || !util.CheckForProjectNamespace(nsResource) {
 		logger.Infof("Created QoS Profile %v is not in project namespace. Returning from reconciliation loop.", req.NamespacedName)
 		return ctrl.Result{}, nil
 	}
@@ -121,11 +120,6 @@ func (q *SliceQoSConfigService) ReconcileSliceQoSConfig(ctx context.Context, req
 	}
 
 	return ctrl.Result{}, nil
-}
-
-// checkForProjectNamespace is a function to check the namespace is in proper format
-func (q *SliceQoSConfigService) checkForProjectNamespace(namespace *corev1.Namespace) bool {
-	return namespace.Labels[util.LabelName] == fmt.Sprintf(util.LabelValue, "Project", namespace.Name)
 }
 
 // updateWorkerSliceConfigs is a function to trigger reconciliation of worker slice config whenever there is a change in qos profile


### PR DESCRIPTION
 # Description

Three service structs (`ClusterService`, `SliceConfigService`, `SliceQoSConfigService`) each defined a private `checkForProjectNamespace(*corev1.Namespace)  bool` method with an identical body. The same check already exists as the public `util.CheckForProjectNamespace` in `util/reconciliation_utility.go`. All three   private methods were removed and their single call sites updated to call `util.CheckForProjectNamespace` directly. The `fmt` import in  `slice_qos_config_service.go` was also removed as it was only used by the deleted method. Net change: −19 lines, no behaviour change.

  Fixes #384 

  ## How Has This Been Tested?

Removed `checkForProjectNamespace` from `cluster_service.go:337–339`, `slice_config_service.go:245–247`, and `slice_qos_config_service.go:127–129`. Updated call   sites at `cluster_service.go:75`, `slice_config_service.go:131`, and `slice_qos_config_service.go:113` to call `util.CheckForProjectNamespace`. Removed unused   `fmt` import from `slice_qos_config_service.go`. `go build ./...` passes. Pre-existing `make vet` failure (`undefined: util.Client` in  `access_control_service_test.go`) exists on master before this branch and is unrelated to this change.

  ## Checklist:

  * [x] The title of the PR states what changed and the related issues number (used for the release note).
  * [ ] Does this PR requires documentation updates? — No.
  * [x] I have performed a self-review of my own code.
  * [x] I have commented my code, particularly in hard-to-understand areas. — N/A.
  * [X] I have tested it for all user roles. — N/A.
  * [ ] I have added all the required unit test cases.

  ## Does this PR introduce a breaking change for other components like worker-operator?

  No

  ```release-note
  Remove duplicate checkForProjectNamespace private methods from ClusterService, SliceConfigService, and SliceQoSConfigService; use shared  util.CheckForProjectNamespace instead