### PR TITLE
fix(util): prevent empty label value in GetOwnerLabel for 126-char resource names

### DIFF
--- a/util/reconciliation_utility.go
+++ b/util/reconciliation_utility.go
@@ -242,7 +242,9 @@ func GetOwnerLabel(completeResourceName string) map[string]string {
 			lenCompleteResourceName = lenCompleteResourceName - 63
 			j = 63 * (i + 1)
 		}
-		label[LabelManagedBy+"-"+fmt.Sprint(i)] = completeResourceName[j:]
+		if j < len(completeResourceName) {
+			label[LabelManagedBy+"-"+fmt.Sprint(i)] = completeResourceName[j:]
+		}
 	} else {
 		label[LabelManagedBy] = completeResourceName
 	}

--- a/util/reconciliation_utility_test.go
+++ b/util/reconciliation_utility_test.go
@@ -1,0 +1,72 @@
+package util
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetOwnerLabel(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]string
+	}{
+		{
+			name:  "name shorter than 63 chars fits in one label",
+			input: strings.Repeat("a", 50),
+			expected: map[string]string{
+				LabelResourceOwner: LabelValueResourceOwner,
+				LabelManagedBy:     strings.Repeat("a", 50),
+			},
+		},
+		{
+			name:  "name exactly 63 chars fits in one label",
+			input: strings.Repeat("a", 63),
+			expected: map[string]string{
+				LabelResourceOwner: LabelValueResourceOwner,
+				LabelManagedBy:     strings.Repeat("a", 63),
+			},
+		},
+		{
+			name:  "name 64 chars splits across two labels",
+			input: strings.Repeat("a", 63) + "b",
+			expected: map[string]string{
+				LabelResourceOwner:    LabelValueResourceOwner,
+				LabelManagedBy:        strings.Repeat("a", 63),
+				LabelManagedBy + "-1": "b",
+			},
+		},
+		{
+			// 126 = 2 × 63: post-loop would produce an empty-value label without the fix
+			name:  "name exactly 126 chars produces exactly two name labels with no empty value",
+			input: strings.Repeat("a", 63) + strings.Repeat("b", 63),
+			expected: map[string]string{
+				LabelResourceOwner:    LabelValueResourceOwner,
+				LabelManagedBy:        strings.Repeat("a", 63),
+				LabelManagedBy + "-1": strings.Repeat("b", 63),
+			},
+		},
+		{
+			name:  "name 127 chars splits across three labels",
+			input: strings.Repeat("a", 63) + strings.Repeat("b", 63) + "c",
+			expected: map[string]string{
+				LabelResourceOwner:    LabelValueResourceOwner,
+				LabelManagedBy:        strings.Repeat("a", 63),
+				LabelManagedBy + "-1": strings.Repeat("b", 63),
+				LabelManagedBy + "-2": "c",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := GetOwnerLabel(tc.input)
+			assert.Equal(t, tc.expected, result)
+			for k, v := range result {
+				assert.NotEmpty(t, v, "label key %q has empty value", k)
+			}
+		})
+	}
+}


### PR DESCRIPTION
 # Description

  `util.GetOwnerLabel` splits resource names longer than 63 characters across multiple label keys using manual index arithmetic. A post-loop assignment at line   245 ran unconditionally after the inner `break`, assigning `completeResourceName[j:]` to a new label key even when `j == len(completeResourceName)` — which  happens whenever the input length is an exact multiple of 63 (126, 189, 252, …). This produced a label key with an empty string value. Kubernetes accepts empty  label values, so the resource was created without error, but any downstream label selector that expected the full split name would silently fail to match. The fix is a single guard: `if j < len(completeResourceName)`. This PR also adds the first test file in the `util/` package, with five table-driven cases covering   all splitting branches including the edge case.

  Fixes #386 

  ## How Has This Been Tested?

  Created `util/reconciliation_utility_test.go` with `TestGetOwnerLabel` covering: name ≤ 63 chars, name = 63 chars, name = 64 chars (one overflow), name = 126   
  chars (the edge case — previously produced a third label key with empty value), and name = 127 chars (three labels, all non-empty). All five subtests pass with 
  `go test ./util/... -v -run TestGetOwnerLabel`. `go build ./...` passes.
  
  ### Before fix
  
<img width="1477" height="1005" alt="Screenshot 2026-05-17 201208" src="https://github.com/user-attachments/assets/72b9acf2-4c83-4827-b79e-3f38957325ad" />

  
  ### After fix
  
<img width="1134" height="370" alt="Screenshot 2026-05-17 201313" src="https://github.com/user-attachments/assets/cc469504-7252-4691-9ae6-23f3e4b1e9aa" />

  ## Checklist:

  * [x] The title of the PR states what changed and the related issues number (used for the release note).
  * [ ] Does this PR requires documentation updates? — No.
  * [x] I have performed a self-review of my own code.
  * [x] I have commented my code, particularly in hard-to-understand areas. — N/A.
  * [x] I have tested it for all user roles. — N/A.
  * [x] I have added all the required unit test cases.

  ## Does this PR introduce a breaking change for other components like worker-operator?

  No — the fix only affects resource names whose byte length is an exact multiple of 63. Previously those names produced a spurious empty-value label that would    never match any selector; after the fix they do not. Any selector already working correctly is unaffected.

  ```release-note
  Fix util.GetOwnerLabel to not emit an empty-value label key when the resource name length is an exact multiple of 63
