### PR TITLE
service: isolate gateway labels per object during reconciliation

### DIFF
--- a/service/worker_slice_gateway_service.go
+++ b/service/worker_slice_gateway_service.go
@@ -595,8 +595,12 @@ func (s *WorkerSliceGatewayService) BuildNetworkAddresses(sliceSubnet, sourceClu
 func (s *WorkerSliceGatewayService) buildMinimumGateway(sourceCluster, destinationCluster *controllerv1alpha1.Cluster,
 	sliceName, namespace, gatewayHostType, gatewayConnType, gatewayProtocol string, labels map[string]string, gatewayNumber int,
 	gatewaySubnet, localVpnAddress, remoteGatewayName, remoteGatewaySubnet, remoteVpnAddress, localGatewayName string) *v1alpha1.WorkerSliceGateway {
-	labels["worker-cluster"] = sourceCluster.Name
-	labels["remote-cluster"] = destinationCluster.Name
+	gatewayLabels := make(map[string]string, len(labels)+2)
+	for key, value := range labels {
+		gatewayLabels[key] = value
+	}
+	gatewayLabels["worker-cluster"] = sourceCluster.Name
+	gatewayLabels["remote-cluster"] = destinationCluster.Name
 	labels["kubeslice-manager"] = "controller"
 	labels["project-namespace"] = namespace
 	labels["original-slice-name"] = sliceName
@@ -615,7 +619,7 @@ func (s *WorkerSliceGatewayService) buildMinimumGateway(sourceCluster, destinati
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf(gatewayName, sliceName, sourceCluster.Name, destinationCluster.Name),
 			Namespace: namespace,
-			Labels:    labels,
+			Labels:    gatewayLabels,
 		},
 		Spec: v1alpha1.WorkerSliceGatewaySpec{
 			SliceName: sliceName,

--- a/service/worker_slice_gateway_service_test.go
+++ b/service/worker_slice_gateway_service_test.go
@@ -66,6 +66,7 @@ var WorkerSliceGatewayTestbed = map[string]func(*testing.T){
 	"TestCreateMinimumWorkerSliceGateways_IfNotExists":           testCreateMinimumWorkerSliceGatewaysNotExists,
 	"TestDeleteWorkerSliceGatewaysByLabel_IfExists":              testDeleteWorkerSliceGatewaysByLabelExists,
 	"TestNodeIpReconciliationOfWorkerSliceGateways_IfExists":     testNodeIpReconciliationOfWorkerSliceGatewaysExists,
+	"TestBuildMinimumGateway_LabelsAreIsolatedPerGateway":        testBuildMinimumGatewayLabelsAreIsolatedPerGateway,
 }
 
 func testWorkerSliceGatewayReconciliationSuccess(t *testing.T) {
@@ -551,7 +552,6 @@ func testNodeIpReconciliationOfWorkerSliceGatewaysExists(t *testing.T) {
 			Annotations:                nil,
 			OwnerReferences:            nil,
 			Finalizers:                 nil,
-			ClusterName:                "",
 			ManagedFields:              nil,
 		},
 		Spec:   controllerv1alpha1.ClusterSpec{},
@@ -561,6 +561,38 @@ func testNodeIpReconciliationOfWorkerSliceGatewaysExists(t *testing.T) {
 	require.NoError(t, nil)
 	require.Nil(t, err)
 	clientMock.AssertExpectations(t)
+}
+
+func testBuildMinimumGatewayLabelsAreIsolatedPerGateway(t *testing.T) {
+	service := WorkerSliceGatewayService{}
+	ownerLabels := map[string]string{
+		"kubebuilder.k8s.io/owner": "slice-owner",
+	}
+	sourceCluster := &controllerv1alpha1.Cluster{
+		ObjectMeta: k8sapimachinery.ObjectMeta{Name: "cluster-a"},
+	}
+	destinationCluster := &controllerv1alpha1.Cluster{
+		ObjectMeta: k8sapimachinery.ObjectMeta{Name: "cluster-b"},
+	}
+
+	serverGateway := service.buildMinimumGateway(
+		sourceCluster, destinationCluster, "slice", "ns", serverGateway, "LoadBalancer", "UDP",
+		ownerLabels, 1, "10.1.0.0/24", "10.1.255.1", "slice-cluster-b-cluster-a", "10.2.0.0/24", "10.1.255.2", "slice-cluster-a-cluster-b",
+	)
+	clientGateway := service.buildMinimumGateway(
+		destinationCluster, sourceCluster, "slice", "ns", clientGateway, "LoadBalancer", "UDP",
+		ownerLabels, 1, "10.2.0.0/24", "10.2.255.1", "slice-cluster-a-cluster-b", "10.1.0.0/24", "10.2.255.2", "slice-cluster-b-cluster-a",
+	)
+
+	require.Equal(t, "cluster-a", serverGateway.Labels["worker-cluster"])
+	require.Equal(t, "cluster-b", serverGateway.Labels["remote-cluster"])
+	require.Equal(t, "cluster-b", clientGateway.Labels["worker-cluster"])
+	require.Equal(t, "cluster-a", clientGateway.Labels["remote-cluster"])
+
+	_, workerClusterLabelPresent := ownerLabels["worker-cluster"]
+	_, remoteClusterLabelPresent := ownerLabels["remote-cluster"]
+	require.False(t, workerClusterLabelPresent)
+	require.False(t, remoteClusterLabelPresent)
 }
 
 func setupWorkerSliceGatewayTest(name string, namespace string) (*mocks.ISecretService, *mocks.IWorkerSliceConfigService, *mocks.IJobService, WorkerSliceGatewayService, ctrl.Request, *utilMock.Client, *workerv1alpha1.WorkerSliceGateway, context.Context, *metricMock.IMetricRecorder) {


### PR DESCRIPTION
## Description

Fixes hidden shared-state mutation during full-mesh gateway reconciliation by isolating gateway label maps per generated object.

Currently, `WorkerSliceGatewayService` creates full-mesh gateway pairs for every cluster combination during SliceConfig reconciliation. While building gateway resources, the base labels map was being mutated in-place and reused across gateway objects.

Because Go maps are reference types, this can introduce unintended label aliasing and hidden mutable shared state across generated topology objects.

### Changes

* Copy owner labels per gateway object in `buildMinimumGateway`
* Apply directional labels (`worker-cluster`, `remote-cluster`) on isolated copies
* Assign object-local label maps to `ObjectMeta.Labels`
* Add regression coverage validating label isolation behavior

### Why this matters

This change improves reconciliation safety and topology object correctness without changing external API behavior or full-mesh semantics.

It also reduces hidden coupling in gateway generation paths and makes future topology abstraction work safer as partial-mesh / hub-and-spoke support evolves.

Fixes #

---

## How Has This Been Tested?

Validated using targeted gateway service test execution.

### Added regression test

* `TestBuildMinimumGateway_LabelsAreIsolatedPerGateway`

### Verified behavior

* directional labels remain correct for both gateway directions
* original owner label map remains unchanged
* gateway objects do not share mutated label state

### Test command

```bash
ALLURE_RESULTS_PATH=/tmp/allure-results go test worker_slice_gateway_service.go worker_slice_gateway_service_test.go worker_slice_config_service.go job_service.go secret_service.go kube_slice_resource_names.go service_helper.go -run "TestWorkerSliceGatewaySuite/TestBuildMinimumGateway_LabelsAreIsolatedPerGateway" -count=1
```

---

## Checklist

* [x] The title of the PR states what changed
* [x] I have performed a self-review of my own code
* [x] I have added the required unit test cases
* [x] This PR does not introduce breaking API changes

---

## Does this PR introduce a breaking change for other components like worker-operator?

No.

This PR only hardens internal gateway reconciliation behavior by isolating per-object label state. It does not modify APIs, CRDs, topology semantics, or worker-operator contracts.
