### PR TITLE
fix(): Missing cluster silently skips gateway creation, leaving slice with no inter-cluster   connectivity

### DIFF
--- a/service/access_control_service_test.go
+++ b/service/access_control_service_test.go
@@ -1270,7 +1270,7 @@ func ACS_ReconcileWorkerClusterServiceAccountAndRoleBindings(t *testing.T) {
 	mMock.AssertExpectations(t)
 }
 
-func prepareACSTestContext(ctx context.Context, client util.Client,
+func prepareACSTestContext(ctx context.Context, client client.Client,
 	scheme *runtime.Scheme) context.Context {
 	if scheme == nil {
 		scheme = runtime.NewScheme()

--- a/service/gw_cluster_notfound_bug_test.go
+++ b/service/gw_cluster_notfound_bug_test.go
@@ -1,0 +1,49 @@
+package service
+
+import (
+	"testing"
+
+	controllerv1alpha1 "github.com/kubeslice/kubeslice-controller/apis/controller/v1alpha1"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Test_ClusterNotFound_GatewayCreationSilentlySkipped proves the bug:
+// When a Cluster CR referenced in SliceConfig.Spec.Clusters is not found,
+// createMinimumGatewaysIfNotExists returns (ctrl.Result{}, nil) instead of an error.
+// The SliceConfig reconcile sees nil, treats reconciliation as successful, and the
+// work queue drops it — gateways are never created and the slice has no connectivity.
+func Test_ClusterNotFound_GatewayCreationSilentlySkipped(t *testing.T) {
+	_, _, _, svc, _, clientMock, _, ctx, mMock := setupWorkerSliceGatewayTest("test-slice", "test-ns")
+
+	mMock.On("WithProject", mock.Anything).Return(mMock)
+	mMock.On("WithNamespace", mock.Anything).Return(mMock)
+	mMock.On("WithSlice", mock.Anything).Return(mMock)
+
+	// Cluster CR does not exist — API server returns NotFound, which GetResourceIfExist
+	// converts to (false, nil). The bug is that the caller then returns nil to the work queue.
+	notFound := k8serrors.NewNotFound(schema.GroupResource{Group: "controller.kubeslice.io", Resource: "clusters"}, "missing-cluster")
+	clientMock.On("Get", mock.Anything, mock.Anything, mock.AnythingOfType("*v1alpha1.Cluster"), mock.Anything).
+		Return(notFound)
+
+	result, err := svc.createMinimumGatewaysIfNotExists(
+		ctx,
+		"test-slice",
+		[]string{"missing-cluster"},
+		"test-ns",
+		map[string]string{"original-slice-name": "test-slice"},
+		map[string]int{"missing-cluster": 1},
+		"192.168.0.0/16",
+		"/24",
+		map[string]*controllerv1alpha1.SliceGatewayServiceType{},
+	)
+
+	// FIX: err must be non-nil when a referenced cluster is not found,
+	// so the SliceConfig reconcile fails and the work queue requeues it.
+	require.Error(t, err,
+		"cluster not found must return an error so the SliceConfig is requeued")
+	require.Contains(t, err.Error(), "missing-cluster")
+	_ = result
+}

--- a/service/namespace_service_test.go
+++ b/service/namespace_service_test.go
@@ -177,7 +177,7 @@ func TestDeleteNamespace_DoesNothingIfNamespaceDoNotExist(t *testing.T) {
 	mMock.AssertExpectations(t)
 }
 
-func prepareNamespaceTestContext(ctx context.Context, client util.Client, scheme *runtime.Scheme) context.Context {
+func prepareNamespaceTestContext(ctx context.Context, client client.Client, scheme *runtime.Scheme) context.Context {
 	eventRecorder := events.NewEventRecorder(client, scheme, ossEvents.EventsMap, events.EventRecorderOptions{
 		Version:   "v1alpha1",
 		Cluster:   util.ClusterController,

--- a/service/project_service_test.go
+++ b/service/project_service_test.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -276,7 +277,7 @@ func setupProjectTest(name string, namespace string) (*mocks.INamespaceService, 
 	return nsServiceMock, acsServicemOCK, projectService, requestObj, clientMock, project, ctx, clusterServiceMock, sliceConfigServiceMock, serviceExportConfigServiceMock, sliceQoSConfigServiceMock, mMock
 }
 
-func prepareProjectTestContext(ctx context.Context, client util.Client,
+func prepareProjectTestContext(ctx context.Context, client client.Client,
 	scheme *runtime.Scheme) context.Context {
 	eventRecorder := events.NewEventRecorder(client, scheme, ossEvents.EventsMap, events.EventRecorderOptions{
 		Version:   "v1alpha1",

--- a/service/vpn_global_flag_bug_test.go
+++ b/service/vpn_global_flag_bug_test.go
@@ -1,0 +1,146 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	controllerv1alpha1 "github.com/kubeslice/kubeslice-controller/apis/controller/v1alpha1"
+	workerv1alpha1 "github.com/kubeslice/kubeslice-controller/apis/worker/v1alpha1"
+	ossEvents "github.com/kubeslice/kubeslice-controller/events"
+	"github.com/kubeslice/kubeslice-controller/service/mocks"
+	"github.com/kubeslice/kubeslice-controller/util"
+	utilMock "github.com/kubeslice/kubeslice-controller/util/mocks"
+	"github.com/kubeslice/kubeslice-monitoring/pkg/events"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+// Test_GlobalFlagBug_SkipsCertRotationForSecondSlice proves the bug:
+// VpnKeyRotationService.jobCreationInProgress is process-global (not per-slice).
+// When slice-A sets the flag to true, slice-B's call to triggerJobsForCertCreation
+// is skipped. If stale Jobs from slice-B's prior rotation still exist (they are never
+// deleted), verifyAllJobsAreCompleted returns JobStatusComplete, and the reconciler
+// advances slice-B's CertificateExpiryTime + RotationCount WITHOUT generating new certs.
+func Test_GlobalFlagBug_SkipsCertRotationForSecondSlice(t *testing.T) {
+	clientMock := &utilMock.Client{}
+	scheme := runtime.NewScheme()
+	utilruntime.Must(controllerv1alpha1.AddToScheme(scheme))
+	wg := &mocks.IWorkerSliceGatewayService{}
+	ws := &mocks.IWorkerSliceConfigService{}
+	eventRecorder := events.NewEventRecorder(clientMock, scheme, ossEvents.EventsMap, events.EventRecorderOptions{
+		Version:   "v1alpha1",
+		Cluster:   util.ClusterController,
+		Component: util.ComponentController,
+		Slice:     util.NotApplicable,
+	})
+	ctx := util.PrepareKubeSliceControllersRequestContext(
+		context.Background(), clientMock, scheme, "BugTest", &eventRecorder,
+	)
+
+	vpn := VpnKeyRotationService{wsgs: wg, wscs: ws}
+
+	past := metav1.NewTime(time.Now().Add(-2 * time.Hour)) // cert already expired
+
+	makeVpnCR := func(sliceName string) *controllerv1alpha1.VpnKeyRotation {
+		return &controllerv1alpha1.VpnKeyRotation{
+			ObjectMeta: metav1.ObjectMeta{Name: sliceName, Namespace: "test-ns"},
+			Spec: controllerv1alpha1.VpnKeyRotationSpec{
+				SliceName:               sliceName,
+				Clusters:                []string{"w1", "w2"},
+				RotationInterval:        30,
+				RotationCount:           1,
+				CertificateCreationTime: &past,
+				CertificateExpiryTime:   &past,
+			},
+		}
+	}
+
+	makeSliceCR := func(sliceName string) *controllerv1alpha1.SliceConfig {
+		return &controllerv1alpha1.SliceConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: sliceName, Namespace: "test-ns"},
+			Spec:       controllerv1alpha1.SliceConfigSpec{Clusters: []string{"w1", "w2"}},
+		}
+	}
+
+	// Slice-A reconcile: flag is false → triggerJobsForCertCreation runs → GenerateCerts called once.
+	clientMock.On("List", mock.Anything, mock.AnythingOfType("*v1alpha1.WorkerSliceGatewayList"), mock.Anything).
+		Return(nil).Run(func(args mock.Arguments) {
+		list := args.Get(1).(*workerv1alpha1.WorkerSliceGatewayList)
+		list.Items = []workerv1alpha1.WorkerSliceGateway{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "gw-server"},
+				Spec: workerv1alpha1.WorkerSliceGatewaySpec{
+					GatewayHostType:     "Server",
+					RemoteGatewayConfig: workerv1alpha1.SliceGatewayConfig{GatewayName: "gw-client"},
+					LocalGatewayConfig:  workerv1alpha1.SliceGatewayConfig{ClusterName: "w1"},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "gw-client"},
+				Spec: workerv1alpha1.WorkerSliceGatewaySpec{
+					GatewayHostType:    "Client",
+					LocalGatewayConfig: workerv1alpha1.SliceGatewayConfig{ClusterName: "w2"},
+				},
+			},
+		}
+	}).Once()
+	ws.On("ListWorkerSliceConfigs", mock.Anything, mock.Anything, mock.Anything).
+		Return([]workerv1alpha1.WorkerSliceConfig{}, nil).Once()
+	ws.On("ComputeClusterMap", mock.Anything, mock.Anything).
+		Return(map[string]int{"w1": 1, "w2": 2}).Once()
+	wg.On("BuildNetworkAddresses", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(util.WorkerSliceGatewayNetworkAddresses{}).Once()
+	wg.On("GenerateCerts", mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+
+	_, _, err := vpn.reconcileVpnKeyRotationConfig(ctx, makeVpnCR("slice-a"), makeSliceCR("slice-a"))
+	require.NoError(t, err)
+
+	// PRECONDITION: flag is now true because slice-A set it.
+	inProgress, _ := vpn.jobCreationInProgress.Load("test-ns/slice-a")
+	require.True(t, inProgress == true,
+		"precondition: slice-a must have set jobCreationInProgress=true")
+
+	// Slice-B reconcile: after fix, slice-b has its own independent flag (false) →
+	// triggerJobsForCertCreation runs for slice-b as well.
+	clientMock.On("List", mock.Anything, mock.AnythingOfType("*v1alpha1.WorkerSliceGatewayList"), mock.Anything).
+		Return(nil).Run(func(args mock.Arguments) {
+		list := args.Get(1).(*workerv1alpha1.WorkerSliceGatewayList)
+		list.Items = []workerv1alpha1.WorkerSliceGateway{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "gw-b-server"},
+				Spec: workerv1alpha1.WorkerSliceGatewaySpec{
+					GatewayHostType:     "Server",
+					RemoteGatewayConfig: workerv1alpha1.SliceGatewayConfig{GatewayName: "gw-b-client"},
+					LocalGatewayConfig:  workerv1alpha1.SliceGatewayConfig{ClusterName: "w1"},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "gw-b-client"},
+				Spec: workerv1alpha1.WorkerSliceGatewaySpec{
+					GatewayHostType:    "Client",
+					LocalGatewayConfig: workerv1alpha1.SliceGatewayConfig{ClusterName: "w2"},
+				},
+			},
+		}
+	}).Once()
+	ws.On("ListWorkerSliceConfigs", mock.Anything, mock.Anything, mock.Anything).
+		Return([]workerv1alpha1.WorkerSliceConfig{}, nil).Once()
+	ws.On("ComputeClusterMap", mock.Anything, mock.Anything).
+		Return(map[string]int{"w1": 1, "w2": 2}).Once()
+	wg.On("BuildNetworkAddresses", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(util.WorkerSliceGatewayNetworkAddresses{}).Once()
+	wg.On("GenerateCerts", mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	clientMock.On("Create", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	_, _, errB := vpn.reconcileVpnKeyRotationConfig(ctx, makeVpnCR("slice-b"), makeSliceCR("slice-b"))
+	require.NoError(t, errB)
+
+	// FIX ASSERTION: GenerateCerts called once for slice-a AND once for slice-b — two total.
+	wg.AssertNumberOfCalls(t, "GenerateCerts", 2)
+}

--- a/service/vpn_key_rotation_service.go
+++ b/service/vpn_key_rotation_service.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"sync/atomic"
+	"sync"
 	"time"
 
 	controllerv1alpha1 "github.com/kubeslice/kubeslice-controller/apis/controller/v1alpha1"
@@ -45,7 +45,7 @@ type IVpnKeyRotationService interface {
 type VpnKeyRotationService struct {
 	wsgs                  IWorkerSliceGatewayService
 	wscs                  IWorkerSliceConfigService
-	jobCreationInProgress atomic.Bool
+	jobCreationInProgress sync.Map
 }
 
 // JobStatus represents the status of a job.
@@ -266,14 +266,16 @@ func (v *VpnKeyRotationService) reconcileVpnKeyRotationConfig(ctx context.Contex
 
 	} else {
 		if now.After(copyVpnConfig.Spec.CertificateExpiryTime.Time) {
-			if !v.jobCreationInProgress.Load() {
+			sliceKey := s.Namespace + "/" + s.Name
+			inProgress, _ := v.jobCreationInProgress.Load(sliceKey)
+			if inProgress != true {
 				if err := v.triggerJobsForCertCreation(ctx, copyVpnConfig, s); err != nil {
 					logger.Error("error creating new certs", err)
 					// register an event
 					util.RecordEvent(ctx, eventRecorder, copyVpnConfig, nil, events.EventCertificateJobCreationFailed)
 					return ctrl.Result{}, nil, err
 				}
-				v.jobCreationInProgress.Store(true)
+				v.jobCreationInProgress.Store(sliceKey, true)
 				logger.Debugf("jobs triggered for creating new certs for slice %s", s.Name)
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, nil, nil
 			}
@@ -303,7 +305,7 @@ func (v *VpnKeyRotationService) reconcileVpnKeyRotationConfig(ctx context.Contex
 				return ctrl.Result{}, nil, err
 			}
 			// restore the variable jobCreationInProgress to false
-			v.jobCreationInProgress.Store(false)
+			v.jobCreationInProgress.Store(sliceKey, false)
 			//register an event
 			util.RecordEvent(ctx, eventRecorder, copyVpnConfig, nil, events.EventVPNKeyRotationStart)
 		}

--- a/service/vpn_key_rotation_service_test.go
+++ b/service/vpn_key_rotation_service_test.go
@@ -1363,3 +1363,4 @@ func runReconcileVpnKeyRotation(t *testing.T, tc reconcileVpnKeyRotationTestCase
 	require.Equal(t, tc.expectedResponse, gotResp)
 
 }
+

--- a/service/worker_slice_gateway_service.go
+++ b/service/worker_slice_gateway_service.go
@@ -445,8 +445,11 @@ func (s *WorkerSliceGatewayService) createMinimumGatewaysIfNotExists(ctx context
 	for _, clusterName := range clusterNames {
 		cluster := controllerv1alpha1.Cluster{}
 		found, err := util.GetResourceIfExist(ctx, client.ObjectKey{Name: clusterName, Namespace: namespace}, &cluster)
-		if !found || err != nil {
+		if err != nil {
 			return ctrl.Result{}, err
+		}
+		if !found {
+			return ctrl.Result{}, fmt.Errorf("cluster %s not found in namespace %s", clusterName, namespace)
 		}
 		clusterMapping[clusterName] = &cluster
 	}

--- a/service/worker_slice_gateway_service_test.go
+++ b/service/worker_slice_gateway_service_test.go
@@ -551,7 +551,6 @@ func testNodeIpReconciliationOfWorkerSliceGatewaysExists(t *testing.T) {
 			Annotations:                nil,
 			OwnerReferences:            nil,
 			Finalizers:                 nil,
-			ClusterName:                "",
 			ManagedFields:              nil,
 		},
 		Spec:   controllerv1alpha1.ClusterSpec{},


### PR DESCRIPTION
# Description
 `createMinimumGatewaysIfNotExists()` queries each cluster referenced in `SliceConfig.Spec.Clusters` 
  to build the gateway mesh. When a `Cluster` CR is absent, `util.GetResourceIfExist()` returns
  `(false, nil)`. The original code checked `if !found || err != nil { return ctrl.Result{}, err }` — 
  when `!found==true` and `err==nil`, this returns `nil` to the work queue.

  **Before (broken):**
  ```go
  found, err := util.GetResourceIfExist(ctx, client.ObjectKey{...}, &cluster)
  if !found || err != nil {
      return ctrl.Result{}, err  // returns nil when cluster missing
  }
```

  The SliceConfig reconcile sees nil, treats it as success, and drops from the work queue. Meanwhile, 
  the earlier CreateMinimalWorkerSliceConfig step already created WorkerSliceConfig objects for all
  clusters (it doesn't validate cluster existence). The slice is now in a ghost state: worker configs 
  exist, but the gateway mesh is never built zero cross-cluster connectivity.

```go
  After (fixed):
  if err != nil {
      return ctrl.Result{}, err
  }
  if !found {
      return ctrl.Result{}, fmt.Errorf("cluster %s not found in namespace %s", clusterName, namespace)
  }                                                                                                     
  Now a missing cluster explicitly fails the reconcile, causing the work queue to requeue with
  exponential backoff until the Cluster CR is registered.
```


## How Has This Been Tested?
 - Wrote a unit test (Test_ClusterNotFound_GatewayCreationSilentlySkipped) that mocks a missing      
  Cluster CR during gateway creation
  - Before fix: function returns nil error ghost slice confirmed
  - After fix: function returns error "cluster ... not found" -- SliceConfig will be requeued

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have tested it for all user roles.
* [x] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?
 No breaking changes. The fix makes error handling stricter only affects behavior when a referenced   Cluster is missing (previously silent, now properly requeued).
-->
```release-note

```

