### PR TITLE
feat(): POC Active/Standby HA foundation for the controller

### DIFF
--- a/docs/ha/active-standby.md
+++ b/docs/ha/active-standby.md
@@ -1,0 +1,121 @@
+# KubeSlice Controller — Active/Standby High Availability
+
+> POC for *CNCF — KubeSlice: Controller HA (Active/Standby) Support (2026 Term 2)*
+
+## Problem
+
+The KubeSlice controller currently runs as a single replica. If that pod
+crashes, is evicted, or its node fails, the entire multi-cluster control plane
+stalls: no SliceConfig reconciliation, no gateway provisioning, no VPN key
+rotation. Recovery time is bounded by pod rescheduling plus a cold cache warm-up.
+
+This POC implements the foundational layer for an **Active/Standby** topology:
+two (or more) controller replicas run concurrently; exactly one is **Active**
+and reconciles, while the others stay **Standby** — warm, observing state, and
+ready to take over within one lease period.
+
+## Design
+
+```
+                ┌───────────────────────── HAManager ─────────────────────────┐
+                │  orchestrates components, owns ControllerState, exposes      │
+                │  IsActive() / WaitForActivePromotion() / metrics             │
+                └───┬───────────────────┬───────────────────────┬─────────────┘
+                    │                   │                       │
+          ┌─────────▼────────┐ ┌────────▼─────────┐  ┌───────────▼──────────┐
+          │ LeaderElection   │ │ StateSynchronizer│  │   HealthChecker      │
+          │ coordination/v1  │ │ versioned        │  │ observes Active      │
+          │ Lease, client-go │ │ snapshots + diff │  │ lease freshness      │
+          └─────────┬────────┘ └────────┬─────────┘  └───────────┬──────────┘
+                    │                   │                        │
+                    └───────────────────┴────────────────────────┘
+                                        │
+                              Kubernetes API server
+                              (Lease + KubeSlice CRDs)
+
+   reconcilers ── wrapped by ──▶ ActiveGuard ──▶ runs only while role == Active
+```
+
+### Components
+
+| Component | Responsibility |
+|-----------|----------------|
+| **LeaderElection** | Lease-based election via `client-go/tools/leaderelection`. Releases the lease on context cancellation so failover is fast. Transitions are surfaced through callbacks. |
+| **StateSynchronizer** | Periodically collects KubeSlice CRDs into a revisioned `Snapshot` and computes the `SnapshotDiff` (added/removed/updated) vs. the prior revision. Keeps a Standby warm and gives an Active a current view immediately on promotion. |
+| **HealthChecker** | Watches the Active controller's `Lease` renewal time. Flags the Active unhealthy only after `Threshold` consecutive failures — debouncing transient API errors. The stale-lease detection is panic-safe for leases missing optional fields. |
+| **HAManager** | Wires the three components, owns `ControllerState`, drives Active↔Standby transitions, triggers an immediate resync on promotion, and exports Prometheus metrics. |
+| **ActiveGuard** | A `reconcile.Reconciler` wrapper. On a Standby it drops requests without requeue and without mutating cluster state; controller-runtime's resync re-enqueues work once the instance is promoted. |
+
+### Abstractions for testability
+
+`ResourceCollector` and `LeaseReader` are narrow interfaces. Production uses
+`NewKubeSliceCollector` (lists SliceConfig, Cluster, VpnKeyRotation,
+ServiceExportConfig) and `NewLeaseReader` (controller-runtime client). Tests
+inject in-memory implementations, so the suite exercises real synchronizer and
+health logic — not stubs — without a live API server.
+
+## Failover sequence
+
+1. Active controller dies; its lease stops being renewed.
+2. Standby `HealthChecker` observes the stale lease and flags it unhealthy.
+3. `LeaderElection` on a Standby acquires the expired lease.
+4. `HAManager` transitions to `RoleActive`, increments the transition counter,
+   runs an immediate `Sync`, and signals `WaitForActivePromotion` waiters.
+5. `ActiveGuard` now lets reconcile requests through; the next resync replays
+   outstanding work against current state.
+
+## Metrics
+
+Registered with the controller-runtime registry:
+
+| Metric | Type | Meaning |
+|--------|------|---------|
+| `kubeslice_ha_active` | gauge | 1 if this instance is Active |
+| `kubeslice_ha_leadership_transitions_total` | counter | Active/Standby transitions |
+| `kubeslice_ha_synced_resources` | gauge | resources in latest snapshot |
+| `kubeslice_ha_last_sync_timestamp_seconds` | gauge | last successful sync time |
+| `kubeslice_ha_active_healthy` | gauge | 1 if Active lease looks healthy |
+| `kubeslice_ha_reconcile_skipped_total` | counter | reconciles skipped while Standby |
+
+## Integration sketch
+
+```go
+hm, err := ha.NewHAManager(ha.HAManagerConfig{
+    Identity:   os.Getenv("POD_NAME"),
+    Namespace:  "kubeslice-controller",
+    LeaseName:  "kubeslice-controller-ha",
+    Logger:     logger,
+    KubeClient: kubeClientset, // leader election
+    Client:     mgr.GetClient(), // state collection + lease reads
+})
+if err != nil { return err }
+go hm.Start(ctx)
+
+// Gate every reconciler so only the Active instance writes.
+guarded := ha.NewActiveGuard(hm, sliceConfigReconciler, logger)
+```
+
+## Testing
+
+34 unit tests, run with `-race`:
+
+```
+go test -race ./pkg/ha/...
+ok  	github.com/kubeslice/kubeslice-controller/pkg/ha
+```
+
+Coverage highlights: snapshot diffing (add/remove/update), collector-failure
+resilience, health threshold + recovery, zero-lease-duration panic safety,
+Active/Standby transitions, promotion-triggered resync, and `ActiveGuard`
+gating.
+
+## Scope and next steps
+
+This POC delivers the HA control loop and the reconcile gate. Out of scope,
+proposed for follow-up phases:
+
+- Wiring `ActiveGuard` into every controller in `main.go`.
+- Promoting the snapshot into a true warm informer cache.
+- Worker-cluster endpoint updates on failover and in-flight reconcile handling.
+- `envtest`-based integration tests simulating real lease expiry.
+- Status conditions / events reflecting HA role on the controller's own CR.

--- a/pkg/ha/active_guard.go
+++ b/pkg/ha/active_guard.go
@@ -1,0 +1,57 @@
+/*
+ * 	Copyright (c) 2026 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// RoleProvider exposes the current HA role. *HAManager satisfies it.
+type RoleProvider interface {
+	IsActive() bool
+}
+
+// ActiveGuard wraps a reconcile.Reconciler so that reconciliation runs only
+// while this instance is Active. A Standby instance drops requests without
+// requeue, leaving cluster state untouched until it is promoted — at which
+// point controller-runtime's own resync re-enqueues the work.
+type ActiveGuard struct {
+	role     RoleProvider
+	delegate reconcile.Reconciler
+	logger   *zap.SugaredLogger
+}
+
+// NewActiveGuard wraps delegate with an Active-only gate.
+func NewActiveGuard(role RoleProvider, delegate reconcile.Reconciler, logger *zap.SugaredLogger) *ActiveGuard {
+	return &ActiveGuard{role: role, delegate: delegate, logger: logger}
+}
+
+// Reconcile delegates to the wrapped reconciler when Active; otherwise it
+// records a skip and returns an empty result.
+func (g *ActiveGuard) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	if !g.role.IsActive() {
+		metricReconcileSkipped.Inc()
+		if g.logger != nil {
+			g.logger.Debugw("skipping reconcile: instance is Standby", "request", req.String())
+		}
+		return reconcile.Result{}, nil
+	}
+	return g.delegate.Reconcile(ctx, req)
+}

--- a/pkg/ha/active_guard_test.go
+++ b/pkg/ha/active_guard_test.go
@@ -1,0 +1,77 @@
+/*
+ * 	Copyright (c) 2026 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type staticRole struct{ active bool }
+
+func (s staticRole) IsActive() bool { return s.active }
+
+type countingReconciler struct{ calls int }
+
+func (c *countingReconciler) Reconcile(context.Context, reconcile.Request) (reconcile.Result, error) {
+	c.calls++
+	return reconcile.Result{}, nil
+}
+
+func sampleRequest() reconcile.Request {
+	return reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "kubeslice", Name: "slice-a"}}
+}
+
+func TestActiveGuard_DelegatesWhenActive(t *testing.T) {
+	delegate := &countingReconciler{}
+	guard := NewActiveGuard(staticRole{active: true}, delegate, testLogger())
+
+	_, err := guard.Reconcile(context.Background(), sampleRequest())
+	assert.NoError(t, err)
+	assert.Equal(t, 1, delegate.calls)
+}
+
+func TestActiveGuard_SkipsWhenStandby(t *testing.T) {
+	delegate := &countingReconciler{}
+	guard := NewActiveGuard(staticRole{active: false}, delegate, testLogger())
+
+	res, err := guard.Reconcile(context.Background(), sampleRequest())
+	assert.NoError(t, err)
+	assert.Equal(t, reconcile.Result{}, res)
+	assert.Equal(t, 0, delegate.calls, "Standby must not mutate cluster state")
+}
+
+func TestActiveGuard_FollowsRoleChange(t *testing.T) {
+	delegate := &countingReconciler{}
+	role := &mutableRole{}
+	guard := NewActiveGuard(role, delegate, testLogger())
+
+	_, _ = guard.Reconcile(context.Background(), sampleRequest())
+	assert.Equal(t, 0, delegate.calls)
+
+	role.active = true
+	_, _ = guard.Reconcile(context.Background(), sampleRequest())
+	assert.Equal(t, 1, delegate.calls)
+}
+
+type mutableRole struct{ active bool }
+
+func (m *mutableRole) IsActive() bool { return m.active }

--- a/pkg/ha/collector.go
+++ b/pkg/ha/collector.go
@@ -1,0 +1,89 @@
+/*
+ * 	Copyright (c) 2026 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"context"
+	"fmt"
+
+	controllerv1alpha1 "github.com/kubeslice/kubeslice-controller/apis/controller/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// kubeSliceCollector lists the core KubeSlice control-plane CRDs that define
+// the desired multi-cluster state. These are the resources a promoted Standby
+// must already be aware of to continue reconciliation without regression.
+type kubeSliceCollector struct {
+	client client.Client
+}
+
+// NewKubeSliceCollector returns a ResourceCollector backed by a
+// controller-runtime client that enumerates KubeSlice control-plane CRDs.
+func NewKubeSliceCollector(c client.Client) ResourceCollector {
+	return &kubeSliceCollector{client: c}
+}
+
+// Collect lists SliceConfig, Cluster, VpnKeyRotation, and ServiceExportConfig
+// resources across all namespaces and returns their lightweight refs.
+func (k *kubeSliceCollector) Collect(ctx context.Context) ([]ResourceRef, error) {
+	var refs []ResourceRef
+
+	slices := &controllerv1alpha1.SliceConfigList{}
+	if err := k.client.List(ctx, slices); err != nil {
+		return nil, fmt.Errorf("listing SliceConfigs: %w", err)
+	}
+	for i := range slices.Items {
+		refs = append(refs, refOf("SliceConfig", &slices.Items[i].ObjectMeta))
+	}
+
+	clusters := &controllerv1alpha1.ClusterList{}
+	if err := k.client.List(ctx, clusters); err != nil {
+		return nil, fmt.Errorf("listing Clusters: %w", err)
+	}
+	for i := range clusters.Items {
+		refs = append(refs, refOf("Cluster", &clusters.Items[i].ObjectMeta))
+	}
+
+	rotations := &controllerv1alpha1.VpnKeyRotationList{}
+	if err := k.client.List(ctx, rotations); err != nil {
+		return nil, fmt.Errorf("listing VpnKeyRotations: %w", err)
+	}
+	for i := range rotations.Items {
+		refs = append(refs, refOf("VpnKeyRotation", &rotations.Items[i].ObjectMeta))
+	}
+
+	exports := &controllerv1alpha1.ServiceExportConfigList{}
+	if err := k.client.List(ctx, exports); err != nil {
+		return nil, fmt.Errorf("listing ServiceExportConfigs: %w", err)
+	}
+	for i := range exports.Items {
+		refs = append(refs, refOf("ServiceExportConfig", &exports.Items[i].ObjectMeta))
+	}
+
+	return refs, nil
+}
+
+func refOf(kind string, m *metav1.ObjectMeta) ResourceRef {
+	return ResourceRef{
+		Kind:            kind,
+		Namespace:       m.Namespace,
+		Name:            m.Name,
+		ResourceVersion: m.ResourceVersion,
+		UID:             string(m.UID),
+	}
+}

--- a/pkg/ha/ha_manager.go
+++ b/pkg/ha/ha_manager.go
@@ -1,0 +1,308 @@
+/*
+ * 	Copyright (c) 2026 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// HAManager orchestrates leader election, state synchronization, and health
+// checking to provide Active/Standby high availability for the controller.
+type HAManager struct {
+	identity string
+	logger   *zap.SugaredLogger
+
+	election ILeaderElection
+	sync     *StateSynchronizer
+	health   *HealthChecker
+
+	mu    sync.RWMutex
+	state ControllerState
+
+	promotions chan struct{}
+	cancel     context.CancelFunc
+	wg         sync.WaitGroup
+	started    bool
+}
+
+// HAManagerConfig configures an HAManager. Collector, Election, and
+// LeaseReader may be supplied to override the production implementations;
+// this is primarily used by tests.
+type HAManagerConfig struct {
+	Identity  string
+	Namespace string
+	LeaseName string
+	Logger    *zap.SugaredLogger
+
+	// KubeClient drives the default lease-based leader election.
+	KubeClient kubernetes.Interface
+	// Client drives the default state collector and lease reader.
+	Client client.Client
+
+	LeaseDuration       time.Duration
+	RenewDeadline       time.Duration
+	RetryPeriod         time.Duration
+	SyncInterval        time.Duration
+	HealthCheckInterval time.Duration
+	FailureThreshold    int
+
+	// Optional overrides.
+	Collector   ResourceCollector
+	Election    ILeaderElection
+	LeaseReader LeaseReader
+}
+
+// NewHAManager constructs an HAManager, wiring production components for any
+// dependency not explicitly overridden.
+func NewHAManager(cfg HAManagerConfig) (*HAManager, error) {
+	if cfg.Logger == nil {
+		return nil, fmt.Errorf("ha manager: logger is required")
+	}
+	if cfg.Identity == "" {
+		return nil, fmt.Errorf("ha manager: identity is required")
+	}
+	if cfg.LeaseName == "" {
+		return nil, fmt.Errorf("ha manager: lease name is required")
+	}
+	registerMetrics()
+
+	election := cfg.Election
+	if election == nil {
+		if cfg.KubeClient == nil {
+			return nil, fmt.Errorf("ha manager: KubeClient or Election is required")
+		}
+		election = NewLeaderElection(LeaderElectionConfig{
+			Client:        cfg.KubeClient,
+			Identity:      cfg.Identity,
+			Namespace:     cfg.Namespace,
+			LeaseName:     cfg.LeaseName,
+			LeaseDuration: cfg.LeaseDuration,
+			RenewDeadline: cfg.RenewDeadline,
+			RetryPeriod:   cfg.RetryPeriod,
+			Logger:        cfg.Logger,
+		})
+	}
+
+	collector := cfg.Collector
+	if collector == nil {
+		if cfg.Client == nil {
+			return nil, fmt.Errorf("ha manager: Client or Collector is required")
+		}
+		collector = NewKubeSliceCollector(cfg.Client)
+	}
+
+	leaseReader := cfg.LeaseReader
+	if leaseReader == nil {
+		if cfg.Client == nil {
+			return nil, fmt.Errorf("ha manager: Client or LeaseReader is required")
+		}
+		leaseReader = NewLeaseReader(cfg.Client)
+	}
+
+	synchronizer := NewStateSynchronizer(StateSynchronizerConfig{
+		Collector: collector,
+		Interval:  cfg.SyncInterval,
+		Logger:    cfg.Logger,
+		OnDiff: func(d SnapshotDiff) {
+			cfg.Logger.Debugw("standby state drift detected",
+				"added", len(d.Added), "removed", len(d.Removed), "updated", len(d.Updated))
+		},
+	})
+
+	healthChecker := NewHealthChecker(HealthCheckerConfig{
+		Reader:    leaseReader,
+		Namespace: cfg.Namespace,
+		LeaseName: cfg.LeaseName,
+		Interval:  cfg.HealthCheckInterval,
+		Threshold: cfg.FailureThreshold,
+		Logger:    cfg.Logger,
+	})
+
+	hm := &HAManager{
+		identity:   cfg.Identity,
+		logger:     cfg.Logger,
+		election:   election,
+		sync:       synchronizer,
+		health:     healthChecker,
+		promotions: make(chan struct{}, 1),
+		state: ControllerState{
+			Role:           RoleStandby,
+			Identity:       cfg.Identity,
+			TransitionTime: time.Now(),
+		},
+	}
+	metricActive.Set(0)
+	return hm, nil
+}
+
+// Start launches leader election, state synchronization, and health checking.
+// It returns immediately; the components run until Stop is called or the
+// supplied context is cancelled.
+func (hm *HAManager) Start(ctx context.Context) error {
+	hm.mu.Lock()
+	if hm.started {
+		hm.mu.Unlock()
+		return fmt.Errorf("ha manager: already started")
+	}
+	hm.started = true
+	runCtx, cancel := context.WithCancel(ctx)
+	hm.cancel = cancel
+	hm.mu.Unlock()
+
+	hm.election.SetCallbacks(hm.handleLeadershipAcquired, hm.handleLeadershipLost)
+
+	hm.logger.Infow("starting HA manager", "identity", hm.identity)
+	hm.run(runCtx, hm.sync.Run)
+	hm.run(runCtx, hm.health.Run)
+	hm.run(runCtx, hm.election.Run)
+	hm.run(runCtx, hm.publishMetrics)
+	return nil
+}
+
+// run starts fn in a tracked goroutine.
+func (hm *HAManager) run(ctx context.Context, fn func(context.Context) error) {
+	hm.wg.Add(1)
+	go func() {
+		defer hm.wg.Done()
+		if err := fn(ctx); err != nil && err != context.Canceled {
+			hm.logger.Debugw("HA component exited", "error", err)
+		}
+	}()
+}
+
+// Stop signals all components to terminate and waits for them to finish.
+func (hm *HAManager) Stop() {
+	hm.mu.Lock()
+	cancel := hm.cancel
+	started := hm.started
+	hm.mu.Unlock()
+
+	if !started || cancel == nil {
+		return
+	}
+	hm.logger.Info("stopping HA manager")
+	cancel()
+	hm.wg.Wait()
+	hm.logger.Info("HA manager stopped")
+}
+
+func (hm *HAManager) handleLeadershipAcquired(ctx context.Context) {
+	hm.mu.Lock()
+	hm.state.Role = RoleActive
+	hm.state.IsLeader = true
+	hm.state.LeaderIdentity = hm.identity
+	hm.state.Transitions++
+	hm.state.TransitionTime = time.Now()
+	hm.mu.Unlock()
+
+	metricActive.Set(1)
+	metricTransitions.Inc()
+	hm.logger.Infow("promoted to Active", "identity", hm.identity)
+
+	// Refresh state immediately so the new Active reconciles from a current
+	// view rather than the last periodic snapshot.
+	if _, err := hm.sync.Sync(ctx); err != nil {
+		hm.logger.Warnw("post-promotion sync failed", "error", err)
+	}
+
+	select {
+	case hm.promotions <- struct{}{}:
+	default:
+	}
+}
+
+func (hm *HAManager) handleLeadershipLost() {
+	hm.mu.Lock()
+	hm.state.Role = RoleStandby
+	hm.state.IsLeader = false
+	hm.state.Transitions++
+	hm.state.TransitionTime = time.Now()
+	hm.mu.Unlock()
+
+	metricActive.Set(0)
+	metricTransitions.Inc()
+	hm.logger.Infow("demoted to Standby", "identity", hm.identity)
+}
+
+// publishMetrics periodically exports synchronizer and health gauges.
+func (hm *HAManager) publishMetrics(ctx context.Context) error {
+	ticker := time.NewTicker(10 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			snap := hm.sync.Snapshot()
+			metricSyncedResources.Set(float64(snap.Count()))
+			if !snap.Timestamp.IsZero() {
+				metricLastSync.Set(float64(snap.Timestamp.Unix()))
+			}
+			metricActiveHealthy.Set(boolToFloat(hm.health.IsHealthy()))
+		}
+	}
+}
+
+// GetCurrentState returns a snapshot of this instance's HA state.
+func (hm *HAManager) GetCurrentState() ControllerState {
+	hm.mu.RLock()
+	defer hm.mu.RUnlock()
+	return hm.state
+}
+
+// IsActive reports whether this instance is currently the Active controller.
+func (hm *HAManager) IsActive() bool {
+	hm.mu.RLock()
+	defer hm.mu.RUnlock()
+	return hm.state.Role == RoleActive
+}
+
+// IsStandby reports whether this instance is currently a Standby controller.
+func (hm *HAManager) IsStandby() bool {
+	return !hm.IsActive()
+}
+
+// HealthStatus returns the observed health of the Active controller's lease.
+func (hm *HAManager) HealthStatus() HealthStatus {
+	return hm.health.Status()
+}
+
+// StateSnapshot returns the most recent synchronized state snapshot.
+func (hm *HAManager) StateSnapshot() Snapshot {
+	return hm.sync.Snapshot()
+}
+
+// WaitForActivePromotion blocks until this instance is promoted to Active or
+// ctx is cancelled.
+func (hm *HAManager) WaitForActivePromotion(ctx context.Context) error {
+	if hm.IsActive() {
+		return nil
+	}
+	select {
+	case <-hm.promotions:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/pkg/ha/ha_manager_test.go
+++ b/pkg/ha/ha_manager_test.go
@@ -1,0 +1,176 @@
+/*
+ * 	Copyright (c) 2026 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestManager(t *testing.T) (*HAManager, *fakeElection, *memCollector) {
+	t.Helper()
+	election := &fakeElection{}
+	collector := &memCollector{}
+	collector.set(ref("SliceConfig", "slice-a", "1"))
+	lease := &memLeaseReader{}
+	lease.set(freshLease())
+
+	hm, err := NewHAManager(HAManagerConfig{
+		Identity:            "controller-0",
+		Namespace:           "kubeslice-controller",
+		LeaseName:           "kubeslice-controller-ha",
+		Logger:              testLogger(),
+		Election:            election,
+		Collector:           collector,
+		LeaseReader:         lease,
+		SyncInterval:        time.Hour,
+		HealthCheckInterval: time.Hour,
+	})
+	require.NoError(t, err)
+	return hm, election, collector
+}
+
+func TestNewHAManager_RequiresMandatoryFields(t *testing.T) {
+	_, err := NewHAManager(HAManagerConfig{LeaseName: "x", Identity: "y"})
+	assert.Error(t, err, "logger required")
+
+	_, err = NewHAManager(HAManagerConfig{Logger: testLogger(), LeaseName: "x"})
+	assert.Error(t, err, "identity required")
+
+	_, err = NewHAManager(HAManagerConfig{Logger: testLogger(), Identity: "y"})
+	assert.Error(t, err, "lease name required")
+}
+
+func TestHAManager_InitialRoleIsStandby(t *testing.T) {
+	hm, _, _ := newTestManager(t)
+	assert.True(t, hm.IsStandby())
+	assert.False(t, hm.IsActive())
+	assert.Equal(t, RoleStandby, hm.GetCurrentState().Role)
+}
+
+func TestHAManager_PromotionTransitionsToActive(t *testing.T) {
+	hm, election, _ := newTestManager(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, hm.Start(ctx))
+	defer hm.Stop()
+
+	election.promote()
+
+	assert.True(t, hm.IsActive())
+	st := hm.GetCurrentState()
+	assert.Equal(t, RoleActive, st.Role)
+	assert.True(t, st.IsLeader)
+	assert.Equal(t, 1, st.Transitions)
+}
+
+func TestHAManager_DemotionTransitionsToStandby(t *testing.T) {
+	hm, election, _ := newTestManager(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, hm.Start(ctx))
+	defer hm.Stop()
+
+	election.promote()
+	require.True(t, hm.IsActive())
+	election.demote()
+
+	assert.True(t, hm.IsStandby())
+	st := hm.GetCurrentState()
+	assert.Equal(t, RoleStandby, st.Role)
+	assert.False(t, st.IsLeader)
+	assert.Equal(t, 2, st.Transitions)
+}
+
+func TestHAManager_PromotionTriggersImmediateSync(t *testing.T) {
+	hm, election, collector := newTestManager(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, hm.Start(ctx))
+	defer hm.Stop()
+
+	require.NoError(t, hm.sync.WaitForSync(ctx))
+	before := hm.sync.SyncCount()
+
+	collector.set(ref("SliceConfig", "slice-a", "1"), ref("Cluster", "worker-1", "1"))
+	election.promote()
+
+	// The post-promotion sync must have run and picked up the new resource.
+	assert.Greater(t, hm.sync.SyncCount(), before)
+	assert.Equal(t, 2, hm.StateSnapshot().Count())
+}
+
+func TestHAManager_WaitForActivePromotionUnblocksOnPromotion(t *testing.T) {
+	hm, election, _ := newTestManager(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, hm.Start(ctx))
+	defer hm.Stop()
+
+	result := make(chan error, 1)
+	go func() {
+		waitCtx, waitCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer waitCancel()
+		result <- hm.WaitForActivePromotion(waitCtx)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	election.promote()
+
+	select {
+	case err := <-result:
+		assert.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("WaitForActivePromotion did not unblock")
+	}
+}
+
+func TestHAManager_WaitForActivePromotionRespectsContext(t *testing.T) {
+	hm, _, _ := newTestManager(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	assert.ErrorIs(t, hm.WaitForActivePromotion(ctx), context.DeadlineExceeded)
+}
+
+func TestHAManager_DoubleStartIsRejected(t *testing.T) {
+	hm, _, _ := newTestManager(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, hm.Start(ctx))
+	defer hm.Stop()
+
+	assert.Error(t, hm.Start(ctx))
+}
+
+func TestHAManager_StopIsIdempotent(t *testing.T) {
+	hm, _, _ := newTestManager(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, hm.Start(ctx))
+
+	hm.Stop()
+	assert.NotPanics(t, hm.Stop)
+}
+
+func TestHAManager_HealthStatusIsExposed(t *testing.T) {
+	hm, _, _ := newTestManager(t)
+	assert.True(t, hm.HealthStatus().IsHealthy)
+}

--- a/pkg/ha/health_checker.go
+++ b/pkg/ha/health_checker.go
@@ -1,0 +1,202 @@
+/*
+ * 	Copyright (c) 2026 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	apitypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// HealthChecker monitors the Active controller's lease and reports whether the
+// Active instance appears alive. A Standby uses this signal to anticipate a
+// failover before it formally wins the election.
+type HealthChecker struct {
+	reader    LeaseReader
+	namespace string
+	leaseName string
+	interval  time.Duration
+	threshold int
+	logger    *zap.SugaredLogger
+
+	mu     sync.RWMutex
+	status HealthStatus
+}
+
+// HealthCheckerConfig configures a HealthChecker.
+type HealthCheckerConfig struct {
+	Reader    LeaseReader
+	Namespace string
+	LeaseName string
+	Interval  time.Duration
+	// Threshold is the number of consecutive failed checks before the Active
+	// controller is reported unhealthy.
+	Threshold int
+	Logger    *zap.SugaredLogger
+}
+
+// NewHealthChecker builds a HealthChecker with defaults applied.
+func NewHealthChecker(cfg HealthCheckerConfig) *HealthChecker {
+	if cfg.Interval <= 0 {
+		cfg.Interval = 5 * time.Second
+	}
+	if cfg.Threshold <= 0 {
+		cfg.Threshold = 3
+	}
+	return &HealthChecker{
+		reader:    cfg.Reader,
+		namespace: cfg.Namespace,
+		leaseName: cfg.LeaseName,
+		interval:  cfg.Interval,
+		threshold: cfg.Threshold,
+		logger:    cfg.Logger,
+		status: HealthStatus{
+			IsHealthy: true,
+			LastCheck: time.Now(),
+		},
+	}
+}
+
+// Run performs an immediate health check, then rechecks on the configured
+// interval until ctx is cancelled.
+func (hc *HealthChecker) Run(ctx context.Context) error {
+	hc.check(ctx)
+
+	ticker := time.NewTicker(hc.interval)
+	defer ticker.Stop()
+	hc.logger.Infow("health checker started", "interval", hc.interval, "threshold", hc.threshold)
+
+	for {
+		select {
+		case <-ctx.Done():
+			hc.logger.Info("health checker stopped")
+			return ctx.Err()
+		case <-ticker.C:
+			hc.check(ctx)
+		}
+	}
+}
+
+// check performs a single evaluation of the lease and updates health state.
+func (hc *HealthChecker) check(ctx context.Context) HealthStatus {
+	now := time.Now()
+
+	lease, err := hc.reader.GetLease(ctx, hc.namespace, hc.leaseName)
+	if err != nil {
+		return hc.record(false, fmt.Errorf("reading lease: %w", err), "", 0, now)
+	}
+	if lease.HolderIdentity == "" || lease.RenewTime.IsZero() {
+		return hc.record(false, errors.New("lease has no holder or renew time"), lease.HolderIdentity, 0, now)
+	}
+
+	leaseDuration := time.Duration(lease.LeaseDurationSeconds) * time.Second
+	if leaseDuration <= 0 {
+		leaseDuration = hc.interval * time.Duration(hc.threshold)
+	}
+	age := now.Sub(lease.RenewTime)
+	if age > leaseDuration {
+		err := fmt.Errorf("lease stale: not renewed for %s (limit %s)",
+			age.Round(time.Second), leaseDuration)
+		return hc.record(false, err, lease.HolderIdentity, age, now)
+	}
+	return hc.record(true, nil, lease.HolderIdentity, age, now)
+}
+
+// record folds a single check result into the running health status. A single
+// failed check does not flip health; the threshold of consecutive failures
+// must be met, which debounces transient API hiccups.
+func (hc *HealthChecker) record(ok bool, checkErr error, holder string, age time.Duration, now time.Time) HealthStatus {
+	hc.mu.Lock()
+	defer hc.mu.Unlock()
+
+	hc.status.LastCheck = now
+	hc.status.ObservedHolder = holder
+	hc.status.LeaseAge = age
+	hc.status.LastError = checkErr
+
+	if ok {
+		hc.status.ConsecutiveFailures = 0
+		if !hc.status.IsHealthy {
+			hc.status.IsHealthy = true
+			hc.status.LastTransition = now
+			hc.logger.Infow("active controller recovered", "holder", holder)
+		}
+		return hc.status
+	}
+
+	hc.status.ConsecutiveFailures++
+	hc.logger.Warnw("active controller health check failed",
+		"failures", hc.status.ConsecutiveFailures, "error", checkErr)
+	if hc.status.IsHealthy && hc.status.ConsecutiveFailures >= hc.threshold {
+		hc.status.IsHealthy = false
+		hc.status.LastTransition = now
+		hc.logger.Errorw("active controller marked unhealthy",
+			"failures", hc.status.ConsecutiveFailures)
+	}
+	return hc.status
+}
+
+// IsHealthy reports whether the Active controller is currently healthy.
+func (hc *HealthChecker) IsHealthy() bool {
+	hc.mu.RLock()
+	defer hc.mu.RUnlock()
+	return hc.status.IsHealthy
+}
+
+// Status returns the detailed health status.
+func (hc *HealthChecker) Status() HealthStatus {
+	hc.mu.RLock()
+	defer hc.mu.RUnlock()
+	return hc.status
+}
+
+// crLeaseReader is the production LeaseReader backed by a controller-runtime
+// client. It safely handles the optional fields of a coordination/v1 Lease.
+type crLeaseReader struct {
+	client client.Client
+}
+
+// NewLeaseReader returns a LeaseReader that reads a coordination/v1 Lease via
+// the supplied controller-runtime client.
+func NewLeaseReader(c client.Client) LeaseReader {
+	return &crLeaseReader{client: c}
+}
+
+func (r *crLeaseReader) GetLease(ctx context.Context, namespace, name string) (*LeaseInfo, error) {
+	lease := &coordinationv1.Lease{}
+	if err := r.client.Get(ctx, apitypes.NamespacedName{Namespace: namespace, Name: name}, lease); err != nil {
+		return nil, err
+	}
+	info := &LeaseInfo{}
+	if lease.Spec.HolderIdentity != nil {
+		info.HolderIdentity = *lease.Spec.HolderIdentity
+	}
+	if lease.Spec.RenewTime != nil {
+		info.RenewTime = lease.Spec.RenewTime.Time
+	}
+	if lease.Spec.LeaseDurationSeconds != nil {
+		info.LeaseDurationSeconds = *lease.Spec.LeaseDurationSeconds
+	}
+	return info, nil
+}

--- a/pkg/ha/health_checker_test.go
+++ b/pkg/ha/health_checker_test.go
@@ -1,0 +1,137 @@
+/*
+ * 	Copyright (c) 2026 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestHealthChecker(r LeaseReader, threshold int) *HealthChecker {
+	return NewHealthChecker(HealthCheckerConfig{
+		Reader:    r,
+		Namespace: "kubeslice-controller",
+		LeaseName: "kubeslice-controller-ha",
+		Interval:  time.Hour,
+		Threshold: threshold,
+		Logger:    testLogger(),
+	})
+}
+
+func freshLease() *LeaseInfo {
+	return &LeaseInfo{HolderIdentity: "controller-0", RenewTime: time.Now(), LeaseDurationSeconds: 15}
+}
+
+func staleLease() *LeaseInfo {
+	return &LeaseInfo{HolderIdentity: "controller-0", RenewTime: time.Now().Add(-2 * time.Minute), LeaseDurationSeconds: 15}
+}
+
+func TestHealth_FreshLeaseIsHealthy(t *testing.T) {
+	r := &memLeaseReader{}
+	r.set(freshLease())
+	hc := newTestHealthChecker(r, 3)
+
+	st := hc.check(context.Background())
+	assert.True(t, st.IsHealthy)
+	assert.Equal(t, 0, st.ConsecutiveFailures)
+	assert.Equal(t, "controller-0", st.ObservedHolder)
+}
+
+func TestHealth_StaleLeaseTripsAfterThreshold(t *testing.T) {
+	r := &memLeaseReader{}
+	r.set(staleLease())
+	hc := newTestHealthChecker(r, 3)
+
+	hc.check(context.Background())
+	assert.True(t, hc.IsHealthy(), "should stay healthy below threshold")
+	hc.check(context.Background())
+	assert.True(t, hc.IsHealthy(), "should stay healthy below threshold")
+
+	st := hc.check(context.Background())
+	assert.False(t, st.IsHealthy, "should be unhealthy at threshold")
+	assert.Equal(t, 3, st.ConsecutiveFailures)
+}
+
+func TestHealth_RecoversAfterRenewal(t *testing.T) {
+	r := &memLeaseReader{}
+	r.set(staleLease())
+	hc := newTestHealthChecker(r, 2)
+
+	hc.check(context.Background())
+	hc.check(context.Background())
+	assert.False(t, hc.IsHealthy())
+
+	r.set(freshLease())
+	st := hc.check(context.Background())
+	assert.True(t, st.IsHealthy)
+	assert.Equal(t, 0, st.ConsecutiveFailures)
+}
+
+func TestHealth_ReadErrorCountsAsFailure(t *testing.T) {
+	r := &memLeaseReader{}
+	r.setErr(errors.New("connection refused"))
+	hc := newTestHealthChecker(r, 1)
+
+	st := hc.check(context.Background())
+	assert.False(t, st.IsHealthy)
+	assert.Error(t, st.LastError)
+}
+
+func TestHealth_LeaseWithoutHolderIsUnhealthy(t *testing.T) {
+	r := &memLeaseReader{}
+	r.set(&LeaseInfo{RenewTime: time.Now(), LeaseDurationSeconds: 15})
+	hc := newTestHealthChecker(r, 1)
+
+	assert.False(t, hc.check(context.Background()).IsHealthy)
+}
+
+func TestHealth_ZeroLeaseDurationDoesNotPanic(t *testing.T) {
+	r := &memLeaseReader{}
+	// LeaseDurationSeconds intentionally zero — must not panic and must fall
+	// back to a derived limit.
+	r.set(&LeaseInfo{HolderIdentity: "controller-0", RenewTime: time.Now()})
+	hc := newTestHealthChecker(r, 3)
+
+	assert.NotPanics(t, func() { hc.check(context.Background()) })
+	assert.True(t, hc.IsHealthy())
+}
+
+func TestHealth_RunStopsOnContextCancel(t *testing.T) {
+	r := &memLeaseReader{}
+	r.set(freshLease())
+	hc := NewHealthChecker(HealthCheckerConfig{
+		Reader: r, Interval: 10 * time.Millisecond, Threshold: 3, Logger: testLogger(),
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		_ = hc.Run(ctx)
+		close(done)
+	}()
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after context cancellation")
+	}
+}

--- a/pkg/ha/helpers_test.go
+++ b/pkg/ha/helpers_test.go
@@ -1,0 +1,150 @@
+/*
+ * 	Copyright (c) 2026 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"go.uber.org/zap"
+)
+
+func testLogger() *zap.SugaredLogger {
+	return zap.NewNop().Sugar()
+}
+
+func ref(kind, name, rv string) ResourceRef {
+	return ResourceRef{Kind: kind, Namespace: "kubeslice", Name: name, ResourceVersion: rv, UID: kind + "-" + name}
+}
+
+// memCollector is an in-memory ResourceCollector whose contents tests mutate.
+type memCollector struct {
+	mu   sync.Mutex
+	refs []ResourceRef
+	err  error
+}
+
+func (m *memCollector) set(refs ...ResourceRef) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.refs = refs
+}
+
+func (m *memCollector) setErr(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.err = err
+}
+
+func (m *memCollector) Collect(_ context.Context) ([]ResourceRef, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.err != nil {
+		return nil, m.err
+	}
+	out := make([]ResourceRef, len(m.refs))
+	copy(out, m.refs)
+	return out, nil
+}
+
+// memLeaseReader is an in-memory LeaseReader.
+type memLeaseReader struct {
+	mu    sync.Mutex
+	lease *LeaseInfo
+	err   error
+}
+
+func (m *memLeaseReader) set(lease *LeaseInfo) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.lease, m.err = lease, nil
+}
+
+func (m *memLeaseReader) setErr(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.err = err
+}
+
+func (m *memLeaseReader) GetLease(_ context.Context, _, _ string) (*LeaseInfo, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.err != nil {
+		return nil, m.err
+	}
+	if m.lease == nil {
+		return nil, errors.New("lease not found")
+	}
+	cp := *m.lease
+	return &cp, nil
+}
+
+// fakeElection is an ILeaderElection whose leadership transitions tests drive
+// explicitly via promote and demote.
+type fakeElection struct {
+	mu         sync.Mutex
+	leader     bool
+	onAcquired func(context.Context)
+	onLost     func()
+}
+
+func (f *fakeElection) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (f *fakeElection) IsLeader() bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.leader
+}
+
+func (f *fakeElection) LeaderIdentity() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.leader {
+		return "self"
+	}
+	return ""
+}
+
+func (f *fakeElection) SetCallbacks(onAcquired func(context.Context), onLost func()) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.onAcquired, f.onLost = onAcquired, onLost
+}
+
+func (f *fakeElection) promote() {
+	f.mu.Lock()
+	f.leader = true
+	cb := f.onAcquired
+	f.mu.Unlock()
+	if cb != nil {
+		cb(context.Background())
+	}
+}
+
+func (f *fakeElection) demote() {
+	f.mu.Lock()
+	f.leader = false
+	cb := f.onLost
+	f.mu.Unlock()
+	if cb != nil {
+		cb()
+	}
+}

--- a/pkg/ha/leader_election.go
+++ b/pkg/ha/leader_election.go
@@ -1,0 +1,179 @@
+/*
+ * 	Copyright (c) 2026 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+// LeaderElection drives a Kubernetes Lease-based leader election. It is the
+// production implementation of ILeaderElection.
+type LeaderElection struct {
+	client        kubernetes.Interface
+	identity      string
+	namespace     string
+	leaseName     string
+	leaseDuration time.Duration
+	renewDeadline time.Duration
+	retryPeriod   time.Duration
+	logger        *zap.SugaredLogger
+
+	mu             sync.RWMutex
+	isLeader       bool
+	leaderIdentity string
+	onAcquired     func(ctx context.Context)
+	onLost         func()
+}
+
+// LeaderElectionConfig configures a LeaderElection. Zero-valued durations are
+// replaced with safe defaults.
+type LeaderElectionConfig struct {
+	Client        kubernetes.Interface
+	Identity      string
+	Namespace     string
+	LeaseName     string
+	LeaseDuration time.Duration
+	RenewDeadline time.Duration
+	RetryPeriod   time.Duration
+	Logger        *zap.SugaredLogger
+}
+
+// NewLeaderElection builds a LeaderElection, applying defaults for any unset
+// timing parameters.
+func NewLeaderElection(cfg LeaderElectionConfig) *LeaderElection {
+	if cfg.LeaseDuration <= 0 {
+		cfg.LeaseDuration = 15 * time.Second
+	}
+	if cfg.RenewDeadline <= 0 {
+		cfg.RenewDeadline = 10 * time.Second
+	}
+	if cfg.RetryPeriod <= 0 {
+		cfg.RetryPeriod = 2 * time.Second
+	}
+	return &LeaderElection{
+		client:        cfg.Client,
+		identity:      cfg.Identity,
+		namespace:     cfg.Namespace,
+		leaseName:     cfg.LeaseName,
+		leaseDuration: cfg.LeaseDuration,
+		renewDeadline: cfg.RenewDeadline,
+		retryPeriod:   cfg.RetryPeriod,
+		logger:        cfg.Logger,
+	}
+}
+
+// SetCallbacks registers the transition hooks invoked when leadership is
+// acquired or lost. It must be called before Run.
+func (le *LeaderElection) SetCallbacks(onAcquired func(ctx context.Context), onLost func()) {
+	le.mu.Lock()
+	defer le.mu.Unlock()
+	le.onAcquired = onAcquired
+	le.onLost = onLost
+}
+
+// Run blocks, contending for leadership until ctx is cancelled. On context
+// cancellation the lease is released so a Standby can take over promptly.
+func (le *LeaderElection) Run(ctx context.Context) error {
+	if le.client == nil {
+		return fmt.Errorf("leader election: kubernetes client is required")
+	}
+
+	lock := &resourcelock.LeaseLock{
+		LeaseMeta: metav1.ObjectMeta{Name: le.leaseName, Namespace: le.namespace},
+		Client:    le.client.CoordinationV1(),
+		LockConfig: resourcelock.ResourceLockConfig{
+			Identity: le.identity,
+		},
+	}
+
+	elector, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
+		Lock:            lock,
+		ReleaseOnCancel: true,
+		LeaseDuration:   le.leaseDuration,
+		RenewDeadline:   le.renewDeadline,
+		RetryPeriod:     le.retryPeriod,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: le.handleStartedLeading,
+			OnStoppedLeading: le.handleStoppedLeading,
+			OnNewLeader:      le.handleNewLeader,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("creating leader elector: %w", err)
+	}
+
+	le.logger.Infow("starting leader election", "lease", le.namespace+"/"+le.leaseName, "identity", le.identity)
+	elector.Run(ctx)
+	return ctx.Err()
+}
+
+func (le *LeaderElection) handleStartedLeading(ctx context.Context) {
+	le.mu.Lock()
+	le.isLeader = true
+	le.leaderIdentity = le.identity
+	onAcquired := le.onAcquired
+	le.mu.Unlock()
+
+	le.logger.Infow("acquired leadership", "identity", le.identity)
+	if onAcquired != nil {
+		onAcquired(ctx)
+	}
+}
+
+func (le *LeaderElection) handleStoppedLeading() {
+	le.mu.Lock()
+	le.isLeader = false
+	onLost := le.onLost
+	le.mu.Unlock()
+
+	le.logger.Infow("lost leadership", "identity", le.identity)
+	if onLost != nil {
+		onLost()
+	}
+}
+
+func (le *LeaderElection) handleNewLeader(identity string) {
+	le.mu.Lock()
+	le.leaderIdentity = identity
+	le.mu.Unlock()
+	if identity != le.identity {
+		le.logger.Infow("observed new leader", "leader", identity)
+	}
+}
+
+// IsLeader reports whether this instance currently holds the lease.
+func (le *LeaderElection) IsLeader() bool {
+	le.mu.RLock()
+	defer le.mu.RUnlock()
+	return le.isLeader
+}
+
+// LeaderIdentity returns the identity of the last observed leader.
+func (le *LeaderElection) LeaderIdentity() string {
+	le.mu.RLock()
+	defer le.mu.RUnlock()
+	return le.leaderIdentity
+}

--- a/pkg/ha/leader_election_test.go
+++ b/pkg/ha/leader_election_test.go
@@ -1,0 +1,92 @@
+/*
+ * 	Copyright (c) 2026 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewLeaderElection_AppliesTimingDefaults(t *testing.T) {
+	le := NewLeaderElection(LeaderElectionConfig{
+		Identity:  "controller-0",
+		LeaseName: "ha-lease",
+		Logger:    testLogger(),
+	})
+	assert.Equal(t, 15*time.Second, le.leaseDuration)
+	assert.Equal(t, 10*time.Second, le.renewDeadline)
+	assert.Equal(t, 2*time.Second, le.retryPeriod)
+}
+
+func TestNewLeaderElection_KeepsExplicitTimings(t *testing.T) {
+	le := NewLeaderElection(LeaderElectionConfig{
+		Identity:      "controller-0",
+		LeaseName:     "ha-lease",
+		LeaseDuration: 30 * time.Second,
+		RenewDeadline: 20 * time.Second,
+		RetryPeriod:   5 * time.Second,
+		Logger:        testLogger(),
+	})
+	assert.Equal(t, 30*time.Second, le.leaseDuration)
+	assert.Equal(t, 20*time.Second, le.renewDeadline)
+	assert.Equal(t, 5*time.Second, le.retryPeriod)
+}
+
+func TestLeaderElection_InitialStateIsNotLeader(t *testing.T) {
+	le := NewLeaderElection(LeaderElectionConfig{Identity: "controller-0", LeaseName: "ha-lease", Logger: testLogger()})
+	assert.False(t, le.IsLeader())
+	assert.Empty(t, le.LeaderIdentity())
+}
+
+func TestLeaderElection_RunRequiresClient(t *testing.T) {
+	le := NewLeaderElection(LeaderElectionConfig{Identity: "controller-0", LeaseName: "ha-lease", Logger: testLogger()})
+	err := le.Run(context.Background())
+	assert.Error(t, err)
+}
+
+func TestLeaderElection_AcquireCallbackFiresAndSetsLeader(t *testing.T) {
+	le := NewLeaderElection(LeaderElectionConfig{Identity: "controller-0", LeaseName: "ha-lease", Logger: testLogger()})
+
+	acquired := false
+	le.SetCallbacks(func(context.Context) { acquired = true }, nil)
+	le.handleStartedLeading(context.Background())
+
+	assert.True(t, acquired)
+	assert.True(t, le.IsLeader())
+	assert.Equal(t, "controller-0", le.LeaderIdentity())
+}
+
+func TestLeaderElection_LostCallbackFiresAndClearsLeader(t *testing.T) {
+	le := NewLeaderElection(LeaderElectionConfig{Identity: "controller-0", LeaseName: "ha-lease", Logger: testLogger()})
+
+	lost := false
+	le.SetCallbacks(nil, func() { lost = true })
+	le.handleStartedLeading(context.Background())
+	le.handleStoppedLeading()
+
+	assert.True(t, lost)
+	assert.False(t, le.IsLeader())
+}
+
+func TestLeaderElection_NewLeaderUpdatesObservedIdentity(t *testing.T) {
+	le := NewLeaderElection(LeaderElectionConfig{Identity: "controller-0", LeaseName: "ha-lease", Logger: testLogger()})
+	le.handleNewLeader("controller-1")
+	assert.Equal(t, "controller-1", le.LeaderIdentity())
+}

--- a/pkg/ha/metrics.go
+++ b/pkg/ha/metrics.go
@@ -1,0 +1,75 @@
+/*
+ * 	Copyright (c) 2026 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	metricsOnce sync.Once
+
+	metricActive = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "kubeslice_ha_active",
+		Help: "1 if this controller instance is the Active leader, else 0.",
+	})
+	metricTransitions = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "kubeslice_ha_leadership_transitions_total",
+		Help: "Total number of Active/Standby leadership transitions.",
+	})
+	metricSyncedResources = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "kubeslice_ha_synced_resources",
+		Help: "Number of KubeSlice resources in the latest state snapshot.",
+	})
+	metricLastSync = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "kubeslice_ha_last_sync_timestamp_seconds",
+		Help: "Unix timestamp of the last successful state synchronization.",
+	})
+	metricActiveHealthy = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "kubeslice_ha_active_healthy",
+		Help: "1 if the Active controller lease is observed healthy, else 0.",
+	})
+	metricReconcileSkipped = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "kubeslice_ha_reconcile_skipped_total",
+		Help: "Total reconcile requests skipped because this instance is Standby.",
+	})
+)
+
+// registerMetrics registers the HA metrics with the controller-runtime
+// registry exactly once, so repeated HA manager construction is safe.
+func registerMetrics() {
+	metricsOnce.Do(func() {
+		metrics.Registry.MustRegister(
+			metricActive,
+			metricTransitions,
+			metricSyncedResources,
+			metricLastSync,
+			metricActiveHealthy,
+			metricReconcileSkipped,
+		)
+	})
+}
+
+func boolToFloat(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/pkg/ha/state_synchronizer.go
+++ b/pkg/ha/state_synchronizer.go
@@ -1,0 +1,191 @@
+/*
+ * 	Copyright (c) 2026 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// StateSynchronizer keeps a Standby controller warm by periodically collecting
+// the set of KubeSlice resources, building a revisioned snapshot, and
+// computing the drift since the previous snapshot. On promotion the manager
+// triggers an immediate sync so the new Active starts from a current view.
+type StateSynchronizer struct {
+	collector ResourceCollector
+	interval  time.Duration
+	logger    *zap.SugaredLogger
+
+	mu        sync.RWMutex
+	snapshot  Snapshot
+	synced    bool
+	syncCount uint64
+	lastError error
+
+	syncedOnce chan struct{}
+	closeOnce  sync.Once
+	onDiff     func(SnapshotDiff)
+}
+
+// StateSynchronizerConfig configures a StateSynchronizer.
+type StateSynchronizerConfig struct {
+	Collector ResourceCollector
+	Interval  time.Duration
+	Logger    *zap.SugaredLogger
+	// OnDiff, if set, is invoked with every non-empty diff. Used for metrics
+	// and event recording.
+	OnDiff func(SnapshotDiff)
+}
+
+// NewStateSynchronizer builds a StateSynchronizer.
+func NewStateSynchronizer(cfg StateSynchronizerConfig) *StateSynchronizer {
+	if cfg.Interval <= 0 {
+		cfg.Interval = 30 * time.Second
+	}
+	return &StateSynchronizer{
+		collector:  cfg.Collector,
+		interval:   cfg.Interval,
+		logger:     cfg.Logger,
+		onDiff:     cfg.OnDiff,
+		snapshot:   Snapshot{Resources: map[string]ResourceRef{}},
+		syncedOnce: make(chan struct{}),
+	}
+}
+
+// Run performs an immediate sync, then resyncs on the configured interval
+// until ctx is cancelled.
+func (ss *StateSynchronizer) Run(ctx context.Context) error {
+	if _, err := ss.Sync(ctx); err != nil {
+		ss.logger.Warnw("initial state sync failed", "error", err)
+	}
+
+	ticker := time.NewTicker(ss.interval)
+	defer ticker.Stop()
+	ss.logger.Infow("state synchronizer started", "interval", ss.interval)
+
+	for {
+		select {
+		case <-ctx.Done():
+			ss.logger.Info("state synchronizer stopped")
+			return ctx.Err()
+		case <-ticker.C:
+			if _, err := ss.Sync(ctx); err != nil {
+				ss.logger.Warnw("state sync failed", "error", err)
+			}
+		}
+	}
+}
+
+// Sync collects current state, swaps in a new snapshot, and returns the diff
+// against the previous snapshot.
+func (ss *StateSynchronizer) Sync(ctx context.Context) (SnapshotDiff, error) {
+	refs, err := ss.collector.Collect(ctx)
+	if err != nil {
+		ss.mu.Lock()
+		ss.lastError = err
+		ss.mu.Unlock()
+		return SnapshotDiff{}, err
+	}
+
+	next := Snapshot{
+		Timestamp: time.Now(),
+		Resources: make(map[string]ResourceRef, len(refs)),
+	}
+	for _, r := range refs {
+		next.Resources[r.key()] = r
+	}
+
+	ss.mu.Lock()
+	prev := ss.snapshot
+	next.Revision = prev.Revision + 1
+	diff := diffSnapshots(prev, next)
+	ss.snapshot = next
+	ss.syncCount++
+	ss.lastError = nil
+	firstSync := !ss.synced
+	ss.synced = true
+	ss.mu.Unlock()
+
+	if firstSync {
+		ss.closeOnce.Do(func() { close(ss.syncedOnce) })
+	}
+	if !diff.Empty() {
+		ss.logger.Infow("state snapshot updated",
+			"revision", next.Revision, "resources", next.Count(),
+			"added", len(diff.Added), "removed", len(diff.Removed), "updated", len(diff.Updated))
+		if ss.onDiff != nil {
+			ss.onDiff(diff)
+		}
+	}
+	return diff, nil
+}
+
+// Snapshot returns the most recent state snapshot.
+func (ss *StateSynchronizer) Snapshot() Snapshot {
+	ss.mu.RLock()
+	defer ss.mu.RUnlock()
+	return ss.snapshot
+}
+
+// IsSynced reports whether at least one successful sync has completed.
+func (ss *StateSynchronizer) IsSynced() bool {
+	ss.mu.RLock()
+	defer ss.mu.RUnlock()
+	return ss.synced
+}
+
+// SyncCount returns the number of successful syncs performed.
+func (ss *StateSynchronizer) SyncCount() uint64 {
+	ss.mu.RLock()
+	defer ss.mu.RUnlock()
+	return ss.syncCount
+}
+
+// WaitForSync blocks until the first successful sync completes or ctx is done.
+func (ss *StateSynchronizer) WaitForSync(ctx context.Context) error {
+	select {
+	case <-ss.syncedOnce:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// diffSnapshots computes additions, removals, and resourceVersion updates
+// between two snapshots.
+func diffSnapshots(prev, next Snapshot) SnapshotDiff {
+	var diff SnapshotDiff
+	for k, n := range next.Resources {
+		p, ok := prev.Resources[k]
+		if !ok {
+			diff.Added = append(diff.Added, n)
+			continue
+		}
+		if p.ResourceVersion != n.ResourceVersion || p.UID != n.UID {
+			diff.Updated = append(diff.Updated, n)
+		}
+	}
+	for k, p := range prev.Resources {
+		if _, ok := next.Resources[k]; !ok {
+			diff.Removed = append(diff.Removed, p)
+		}
+	}
+	return diff
+}

--- a/pkg/ha/state_synchronizer_test.go
+++ b/pkg/ha/state_synchronizer_test.go
@@ -1,0 +1,142 @@
+/*
+ * 	Copyright (c) 2026 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestSynchronizer(c ResourceCollector) *StateSynchronizer {
+	return NewStateSynchronizer(StateSynchronizerConfig{
+		Collector: c,
+		Interval:  time.Hour,
+		Logger:    testLogger(),
+	})
+}
+
+func TestSync_FirstSyncReportsAllResourcesAdded(t *testing.T) {
+	col := &memCollector{}
+	col.set(ref("SliceConfig", "slice-a", "1"), ref("Cluster", "worker-1", "1"))
+	ss := newTestSynchronizer(col)
+
+	diff, err := ss.Sync(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, diff.Added, 2)
+	assert.Empty(t, diff.Removed)
+	assert.Empty(t, diff.Updated)
+	assert.True(t, ss.IsSynced())
+	assert.Equal(t, uint64(1), ss.Snapshot().Revision)
+	assert.Equal(t, 2, ss.Snapshot().Count())
+}
+
+func TestSync_DetectsAddRemoveAndUpdate(t *testing.T) {
+	col := &memCollector{}
+	col.set(ref("SliceConfig", "slice-a", "1"), ref("Cluster", "worker-1", "1"))
+	ss := newTestSynchronizer(col)
+
+	_, err := ss.Sync(context.Background())
+	require.NoError(t, err)
+
+	// slice-a updated (new resourceVersion), worker-1 removed, slice-b added.
+	col.set(ref("SliceConfig", "slice-a", "2"), ref("SliceConfig", "slice-b", "1"))
+	diff, err := ss.Sync(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, diff.Added, 1)
+	assert.Equal(t, "slice-b", diff.Added[0].Name)
+	require.Len(t, diff.Removed, 1)
+	assert.Equal(t, "worker-1", diff.Removed[0].Name)
+	require.Len(t, diff.Updated, 1)
+	assert.Equal(t, "slice-a", diff.Updated[0].Name)
+	assert.Equal(t, uint64(2), ss.Snapshot().Revision)
+}
+
+func TestSync_NoChangeProducesEmptyDiff(t *testing.T) {
+	col := &memCollector{}
+	col.set(ref("SliceConfig", "slice-a", "7"))
+	ss := newTestSynchronizer(col)
+
+	_, err := ss.Sync(context.Background())
+	require.NoError(t, err)
+	diff, err := ss.Sync(context.Background())
+	require.NoError(t, err)
+	assert.True(t, diff.Empty())
+	assert.Equal(t, uint64(2), ss.SyncCount())
+}
+
+func TestSync_CollectorErrorPreservesLastSnapshot(t *testing.T) {
+	col := &memCollector{}
+	col.set(ref("SliceConfig", "slice-a", "1"))
+	ss := newTestSynchronizer(col)
+	_, err := ss.Sync(context.Background())
+	require.NoError(t, err)
+
+	col.setErr(errors.New("api server unreachable"))
+	_, err = ss.Sync(context.Background())
+	require.Error(t, err)
+	// The last good snapshot must survive a failed collection.
+	assert.Equal(t, 1, ss.Snapshot().Count())
+	assert.Equal(t, uint64(1), ss.Snapshot().Revision)
+}
+
+func TestWaitForSync_UnblocksAfterFirstSync(t *testing.T) {
+	col := &memCollector{}
+	col.set(ref("Cluster", "worker-1", "1"))
+	ss := newTestSynchronizer(col)
+
+	go func() {
+		_, _ = ss.Sync(context.Background())
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	assert.NoError(t, ss.WaitForSync(ctx))
+}
+
+func TestWaitForSync_RespectsContextCancellation(t *testing.T) {
+	ss := newTestSynchronizer(&memCollector{})
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	assert.ErrorIs(t, ss.WaitForSync(ctx), context.Canceled)
+}
+
+func TestRun_StopsOnContextCancel(t *testing.T) {
+	col := &memCollector{}
+	col.set(ref("Cluster", "worker-1", "1"))
+	ss := newTestSynchronizer(col)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		_ = ss.Run(ctx)
+		close(done)
+	}()
+
+	require.NoError(t, ss.WaitForSync(context.Background()))
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after context cancellation")
+	}
+}

--- a/pkg/ha/types.go
+++ b/pkg/ha/types.go
@@ -1,0 +1,121 @@
+/*
+ * 	Copyright (c) 2026 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+// Package ha provides Active/Standby high-availability primitives for the
+// KubeSlice controller: lease-based leader election, a versioned state
+// synchronizer that keeps a Standby instance warm, lease health monitoring,
+// and an HA manager that orchestrates failover. The ActiveGuard reconcile
+// wrapper ensures only the Active instance mutates cluster state.
+package ha
+
+import (
+	"context"
+	"time"
+)
+
+// ControllerRole is the HA role currently held by this controller instance.
+type ControllerRole string
+
+const (
+	RoleActive  ControllerRole = "Active"
+	RoleStandby ControllerRole = "Standby"
+)
+
+// ControllerState is a point-in-time snapshot of this instance's HA state.
+type ControllerState struct {
+	Role           ControllerRole
+	Identity       string
+	IsLeader       bool
+	LeaderIdentity string
+	Transitions    int
+	TransitionTime time.Time
+}
+
+// HealthStatus describes the observed health of the Active controller's lease.
+type HealthStatus struct {
+	IsHealthy           bool
+	LastCheck           time.Time
+	LastTransition      time.Time
+	ConsecutiveFailures int
+	ObservedHolder      string
+	LeaseAge            time.Duration
+	LastError           error
+}
+
+// ResourceRef is a lightweight identity of a KubeSlice resource. The Standby
+// instance tracks refs (not full bodies) so it can detect drift and warm its
+// cache cheaply, then reconcile authoritatively once promoted.
+type ResourceRef struct {
+	Kind            string
+	Namespace       string
+	Name            string
+	ResourceVersion string
+	UID             string
+}
+
+func (r ResourceRef) key() string {
+	return r.Kind + "/" + r.Namespace + "/" + r.Name
+}
+
+// ResourceCollector enumerates the resources that constitute the controller's
+// authoritative state. The production implementation lists KubeSlice CRDs;
+// tests supply an in-memory implementation.
+type ResourceCollector interface {
+	Collect(ctx context.Context) ([]ResourceRef, error)
+}
+
+// Snapshot is an immutable, revisioned view of collected state.
+type Snapshot struct {
+	Revision  uint64
+	Timestamp time.Time
+	Resources map[string]ResourceRef
+}
+
+// Count returns the number of resources in the snapshot.
+func (s Snapshot) Count() int { return len(s.Resources) }
+
+// SnapshotDiff is the delta between two consecutive snapshots.
+type SnapshotDiff struct {
+	Added   []ResourceRef
+	Removed []ResourceRef
+	Updated []ResourceRef
+}
+
+// Empty reports whether the diff carries no changes.
+func (d SnapshotDiff) Empty() bool {
+	return len(d.Added)+len(d.Removed)+len(d.Updated) == 0
+}
+
+// LeaseInfo is the subset of a coordination/v1 Lease the HA package needs.
+type LeaseInfo struct {
+	HolderIdentity       string
+	RenewTime            time.Time
+	LeaseDurationSeconds int32
+}
+
+// LeaseReader reads the leader-election Lease. Abstracted so the health
+// checker can be exercised without a live API server.
+type LeaseReader interface {
+	GetLease(ctx context.Context, namespace, name string) (*LeaseInfo, error)
+}
+
+// ILeaderElection is the leader-election contract consumed by the HA manager.
+type ILeaderElection interface {
+	Run(ctx context.Context) error
+	IsLeader() bool
+	LeaderIdentity() string
+	SetCallbacks(onAcquired func(ctx context.Context), onLost func())
+}


### PR DESCRIPTION
# Description
  The KubeSlice controller currently runs as a single replica, if that pod crashes, is evicted, or   
  its node fails, the entire multi-cluster control plane stalls (no SliceConfig reconciliation, no
  gateway provisioning, no VPN key rotation) until the pod is rescheduled and its cache warms up cold.
  
  This PR introduces the foundational layer for an Active/Standby topology, where multiple controller 
  replicas run concurrently: exactly one is Active and reconciles, while the others stay Standby
  warm, observing state, and ready to take over within one lease period.
  
  New package pkg/ha:

  - LeaderElection :-  coordination/v1 Lease-based election via client-go; releases the lease on context   cancellation for fast failover; callback-driven transitions.
  - StateSynchronizer :-  periodically collects KubeSlice CRDs into a revisioned Snapshot and computes
  the add/remove/update SnapshotDiff vs. the prior revision, keeping a Standby warm.
  - HealthChecker :-  monitors the Active controller's lease renewal; flags it unhealthy only after a
  configurable threshold of consecutive failures (debounces transient API errors); panic-safe for     
  leases missing optional fields.
  - HAManager :- orchestrates the three components, owns ControllerState, drives Active↔Standby
  transitions, triggers an immediate resync on promotion, and exports Prometheus metrics.
  - ActiveGuard :-  a reconcile.Reconciler wrapper that drops requests on a Standby without mutating
  cluster state; controller-runtime's resync replays the work once the instance is promoted.

  ResourceCollector / LeaseReader / ILeaderElection are narrow interfaces so the logic is fully       
  unit-testable without a live API server.

  This is a self-contained, additive POC no existing controller wiring is modified.

---

## How Has This Been Tested?
34 unit tests run under the race detector and go vet, exercising real synchronizer/health/failover  
  logic via in-memory ResourceCollector and LeaseReader implementations (no stubs).

```
  go test -race ./pkg/ha/...
  ok    github.com/kubeslice/kubeslice-controller/pkg/ha        1.201s   (34/34 pass)

  go vet ./pkg/ha/...  
```
---

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR requires documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [x] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?
 No. The change is purely additive a new pkg/ha package and documentation, with no modifications to existing controllers, CRDs, or APIs.

```release-note

```

