### PR TITLE
service: avoid shared label-map mutation in worker gateway generation

### DIFF
--- a/service/worker_slice_gateway_service.go
+++ b/service/worker_slice_gateway_service.go
@@ -599,11 +599,11 @@ func (s *WorkerSliceGatewayService) buildMinimumGateway(sourceCluster, destinati
 	for key, value := range labels {
 		gatewayLabels[key] = value
 	}
+	gatewayLabels["kubeslice-manager"] = "controller"
+	gatewayLabels["project-namespace"] = namespace
+	gatewayLabels["original-slice-name"] = sliceName
 	gatewayLabels["worker-cluster"] = sourceCluster.Name
 	gatewayLabels["remote-cluster"] = destinationCluster.Name
-	labels["kubeslice-manager"] = "controller"
-	labels["project-namespace"] = namespace
-	labels["original-slice-name"] = sliceName
 	sourceClusterNodeIPs := sourceCluster.Spec.NodeIPs
 	destinationClusterNodeIPs := destinationCluster.Spec.NodeIPs
 

--- a/service/worker_slice_gateway_service.go
+++ b/service/worker_slice_gateway_service.go
@@ -595,8 +595,12 @@ func (s *WorkerSliceGatewayService) BuildNetworkAddresses(sliceSubnet, sourceClu
 func (s *WorkerSliceGatewayService) buildMinimumGateway(sourceCluster, destinationCluster *controllerv1alpha1.Cluster,
 	sliceName, namespace, gatewayHostType, gatewayConnType, gatewayProtocol string, labels map[string]string, gatewayNumber int,
 	gatewaySubnet, localVpnAddress, remoteGatewayName, remoteGatewaySubnet, remoteVpnAddress, localGatewayName string) *v1alpha1.WorkerSliceGateway {
-	labels["worker-cluster"] = sourceCluster.Name
-	labels["remote-cluster"] = destinationCluster.Name
+	gatewayLabels := make(map[string]string, len(labels)+2)
+	for key, value := range labels {
+		gatewayLabels[key] = value
+	}
+	gatewayLabels["worker-cluster"] = sourceCluster.Name
+	gatewayLabels["remote-cluster"] = destinationCluster.Name
 	labels["kubeslice-manager"] = "controller"
 	labels["project-namespace"] = namespace
 	labels["original-slice-name"] = sliceName
@@ -615,7 +619,7 @@ func (s *WorkerSliceGatewayService) buildMinimumGateway(sourceCluster, destinati
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf(gatewayName, sliceName, sourceCluster.Name, destinationCluster.Name),
 			Namespace: namespace,
-			Labels:    labels,
+			Labels:    gatewayLabels,
 		},
 		Spec: v1alpha1.WorkerSliceGatewaySpec{
 			SliceName: sliceName,

--- a/service/worker_slice_gateway_service_test.go
+++ b/service/worker_slice_gateway_service_test.go
@@ -591,8 +591,16 @@ func testBuildMinimumGatewayLabelsAreIsolatedPerGateway(t *testing.T) {
 
 	_, workerClusterLabelPresent := ownerLabels["worker-cluster"]
 	_, remoteClusterLabelPresent := ownerLabels["remote-cluster"]
+	_, managerLabelPresent := ownerLabels["kubeslice-manager"]
+	_, projectNamespaceLabelPresent := ownerLabels["project-namespace"]
+	_, originalSliceNameLabelPresent := ownerLabels["original-slice-name"]
 	require.False(t, workerClusterLabelPresent)
 	require.False(t, remoteClusterLabelPresent)
+	require.False(t, managerLabelPresent)
+	require.False(t, projectNamespaceLabelPresent)
+	require.False(t, originalSliceNameLabelPresent)
+	require.Equal(t, 1, len(ownerLabels))
+	require.Equal(t, "slice-owner", ownerLabels["kubebuilder.k8s.io/owner"])
 }
 
 func setupWorkerSliceGatewayTest(name string, namespace string) (*mocks.ISecretService, *mocks.IWorkerSliceConfigService, *mocks.IJobService, WorkerSliceGatewayService, ctrl.Request, *utilMock.Client, *workerv1alpha1.WorkerSliceGateway, context.Context, *metricMock.IMetricRecorder) {

--- a/service/worker_slice_gateway_service_test.go
+++ b/service/worker_slice_gateway_service_test.go
@@ -66,6 +66,7 @@ var WorkerSliceGatewayTestbed = map[string]func(*testing.T){
 	"TestCreateMinimumWorkerSliceGateways_IfNotExists":           testCreateMinimumWorkerSliceGatewaysNotExists,
 	"TestDeleteWorkerSliceGatewaysByLabel_IfExists":              testDeleteWorkerSliceGatewaysByLabelExists,
 	"TestNodeIpReconciliationOfWorkerSliceGateways_IfExists":     testNodeIpReconciliationOfWorkerSliceGatewaysExists,
+	"TestBuildMinimumGateway_LabelsAreIsolatedPerGateway":        testBuildMinimumGatewayLabelsAreIsolatedPerGateway,
 }
 
 func testWorkerSliceGatewayReconciliationSuccess(t *testing.T) {
@@ -551,7 +552,6 @@ func testNodeIpReconciliationOfWorkerSliceGatewaysExists(t *testing.T) {
 			Annotations:                nil,
 			OwnerReferences:            nil,
 			Finalizers:                 nil,
-			ClusterName:                "",
 			ManagedFields:              nil,
 		},
 		Spec:   controllerv1alpha1.ClusterSpec{},
@@ -561,6 +561,38 @@ func testNodeIpReconciliationOfWorkerSliceGatewaysExists(t *testing.T) {
 	require.NoError(t, nil)
 	require.Nil(t, err)
 	clientMock.AssertExpectations(t)
+}
+
+func testBuildMinimumGatewayLabelsAreIsolatedPerGateway(t *testing.T) {
+	service := WorkerSliceGatewayService{}
+	ownerLabels := map[string]string{
+		"kubebuilder.k8s.io/owner": "slice-owner",
+	}
+	sourceCluster := &controllerv1alpha1.Cluster{
+		ObjectMeta: k8sapimachinery.ObjectMeta{Name: "cluster-a"},
+	}
+	destinationCluster := &controllerv1alpha1.Cluster{
+		ObjectMeta: k8sapimachinery.ObjectMeta{Name: "cluster-b"},
+	}
+
+	serverGateway := service.buildMinimumGateway(
+		sourceCluster, destinationCluster, "slice", "ns", serverGateway, "LoadBalancer", "UDP",
+		ownerLabels, 1, "10.1.0.0/24", "10.1.255.1", "slice-cluster-b-cluster-a", "10.2.0.0/24", "10.1.255.2", "slice-cluster-a-cluster-b",
+	)
+	clientGateway := service.buildMinimumGateway(
+		destinationCluster, sourceCluster, "slice", "ns", clientGateway, "LoadBalancer", "UDP",
+		ownerLabels, 1, "10.2.0.0/24", "10.2.255.1", "slice-cluster-a-cluster-b", "10.1.0.0/24", "10.2.255.2", "slice-cluster-b-cluster-a",
+	)
+
+	require.Equal(t, "cluster-a", serverGateway.Labels["worker-cluster"])
+	require.Equal(t, "cluster-b", serverGateway.Labels["remote-cluster"])
+	require.Equal(t, "cluster-b", clientGateway.Labels["worker-cluster"])
+	require.Equal(t, "cluster-a", clientGateway.Labels["remote-cluster"])
+
+	_, workerClusterLabelPresent := ownerLabels["worker-cluster"]
+	_, remoteClusterLabelPresent := ownerLabels["remote-cluster"]
+	require.False(t, workerClusterLabelPresent)
+	require.False(t, remoteClusterLabelPresent)
 }
 
 func setupWorkerSliceGatewayTest(name string, namespace string) (*mocks.ISecretService, *mocks.IWorkerSliceConfigService, *mocks.IJobService, WorkerSliceGatewayService, ctrl.Request, *utilMock.Client, *workerv1alpha1.WorkerSliceGateway, context.Context, *metricMock.IMetricRecorder) {


### PR DESCRIPTION
## Description

This PR fixes a reconciliation-safety issue in worker gateway topology generation caused by mutation of caller-owned label maps during gateway object construction.

`buildMinimumGateway` previously copied the provided labels into a local `gatewayLabels` map, but also mutated the original input map by injecting controller/project/slice labels directly into `labels`.

Because the same label map can be reused across full-mesh gateway pair generation during SliceConfig reconciliation, this introduced hidden shared mutable state and weakened deterministic topology object synthesis.

## Changes

* Stop mutating the caller-provided `labels` map in `buildMinimumGateway`
* Apply controller/project/slice labels only to the local `gatewayLabels` copy
* Extend regression assertions validating that:

  * owner labels remain unchanged
  * no reconciliation-specific labels leak into caller-owned maps
  * original label map size/content remains intact

## Why this matters

This improves:

* reconciliation determinism
* helper purity/idempotency
* topology generation safety
* maintainability of gateway object synthesis logic

The change also reduces hidden coupling between topology intent inputs and generated gateway objects during full-mesh reconciliation workflows.

## Testing

Updated:

* `testBuildMinimumGatewayLabelsAreIsolatedPerGateway`

Additional assertions now verify:

* no mutation of caller-owned labels
* no leaked reconciliation labels
* original label content remains unchanged after generating multiple gateway objects

## Compatibility

* No API changes
* No CRD changes
* No intended topology behavior changes
* Only removes unintended side effects during gateway construction

## Architectural Context

`SliceConfig` reconciliation computes desired topology intent and generates full-mesh worker gateway objects across clusters. Helper-level mutation of shared label state breaks clean intent-to-object boundaries and can introduce inconsistent reconciliation behavior over time.

This fix restores safer object materialization semantics by ensuring gateway construction operates on isolated label copies.
