### PR TITLE
  fix(ci): fix Trivy grep reading wrong stdin in scan scripts

### DIFF
--- a/.github/workflows/scripts/base-image-critical.sh
+++ b/.github/workflows/scripts/base-image-critical.sh
@@ -5,12 +5,7 @@ then
     echo "Error: base image scan result file does not exist"
     exit 1
 else
-    while read -r line; do
-      x=$(grep -o "CRITICAL: [0-9]*" | awk '{print $2}')
-#      echo "printing the founded critical line"
-#      echo "${x}"
-    done < final.txt
-#    echo "the total sum is: $x"
+    x=$(grep -o "CRITICAL: [0-9]*" final.txt | awk '{print $2}')
 fi
 
 sum=0

--- a/.github/workflows/scripts/binary-image-critical.sh
+++ b/.github/workflows/scripts/binary-image-critical.sh
@@ -5,12 +5,7 @@ then
     echo "Error: binary scan result file does not exist"
     exit 1
 else
-    while read -r line; do
-      x=$(grep -o "CRITICAL: [0-9]*" | awk '{print $2}')
-#      echo "printing the founded critical line"
-#      echo "${x}"
-    done < binary.txt
-#    echo "the total sum is: $x"
+    x=$(grep -o "CRITICAL: [0-9]*" binary.txt | awk '{print $2}')
 fi
 
 sum=0


### PR DESCRIPTION
 # Description

  Both `base-image-critical.sh` and `binary-image-critical.sh` used a `while read -r line` loop that redirected the scan file to the loop's stdin. Inside the loop, `grep -o "CRITICAL: [0-9]*"` received no file argument, so it consumed from that same shared stdin — not from `$line`, which was never passed to it. The CRITICAL summary was consumed by `read` on the first iteration; `grep` saw nothing and returned empty. `$sum` was always 0 and the security gate never triggered  regardless of actual CVE counts.

  Fixed by removing the `while read` loop entirely and passing the scan file directly to `grep` as a file argument. All matches are captured in one pass; the
  existing `for i in $x` loop sums them correctly.

  Fixes #394 

  ## How Has This Been Tested?

  - Created `/tmp/final.txt` containing `CRITICAL: 5, HIGH: 12, MEDIUM: 3, LOW: 1`
  - Old code: `base image critical value is  0` — gate does not fire (bug confirmed)
  - Fixed script: `base image critical value is  5` + `CRITICAL vulnerabilities found` + `Exit code: 1` — gate fires correctly (fix verified)


  **- The before line: OLD: base image critical value is  0 (expected 5)**
 
<img width="1444" height="98" alt="Screenshot 2026-05-24 044753" src="https://github.com/user-attachments/assets/8805065a-300a-44c7-b2f9-7be7f23811f8" />

  **- The after lines: base image critical value is  5 + CRITICAL vulnerabilities found + Exit code: 1**

<img width="1463" height="112" alt="Screenshot 2026-05-24 044816" src="https://github.com/user-attachments/assets/4fb7fc8c-9bc3-4324-853f-61658bce7f7b" />


  ## Checklist:

  * [x] The title of the PR states what changed and the related issues number (used for the release note).
  * [x] Does this PR requires documentation updates? — No.
  * [x] I've updated documentation as required by this PR.
  * [x] I have performed a self-review of my own code.
  * [x] I have commented my code, particularly in hard-to-understand areas. — N/A.
  * [x] I have tested it for all user roles. — N/A (CI script change).
  * [x] I have added all the required unit test cases.

  ## Does this PR introduce a breaking change for other components like worker-operator?

  No

  ```release-note
  Fix Trivy CRITICAL vulnerability scan always reporting 0 — grep now reads the scan file directly instead of consuming the wrong stdin