### PR TITLE
fix(slice-qos-config): use correct QoSConfig event constants in DeleteSliceQoSConfig metrics

### DIFF
--- a/service/slice_qos_config_service.go
+++ b/service/slice_qos_config_service.go
@@ -175,7 +175,7 @@ func (q *SliceQoSConfigService) DeleteSliceQoSConfig(ctx context.Context, namesp
 			q.mf.RecordCounterMetric(metrics.KubeSliceEventsCounter,
 				map[string]string{
 					"action":      "deletion_failed",
-					"event":       string(events.EventSliceConfigDeletionFailed),
+					"event":       string(events.EventSliceQoSConfigDeletionFailed),
 					"object_name": sliceQoSConfig.Name,
 					"object_kind": metricKindSliceQoSConfig,
 				},
@@ -187,7 +187,7 @@ func (q *SliceQoSConfigService) DeleteSliceQoSConfig(ctx context.Context, namesp
 		q.mf.RecordCounterMetric(metrics.KubeSliceEventsCounter,
 			map[string]string{
 				"action":      "deleted",
-				"event":       string(events.EventSliceConfigDeleted),
+				"event":       string(events.EventSliceQoSConfigDeleted),
 				"object_name": sliceQoSConfig.Name,
 				"object_kind": metricKindSliceQoSConfig,
 			},


### PR DESCRIPTION
# Description

`DeleteSliceQoSConfig` in `service/slice_qos_config_service.go` was recording Prometheus counters with `events.EventSliceConfigDeletionFailed` (line 178) and `events.EventSliceConfigDeleted` (line 190)  the SliceConfig constants  instead of the QoSConfig-specific `events.EventSliceQoSConfigDeletionFailed` and `events.EventSliceQoSConfigDeleted`. The `util.RecordEvent` calls on the same lines already used the correct QoSConfig constants; only the metric counter labels were wrong. This caused all SliceQoSConfig deletion events to be counted under SliceConfig metric labels, making QoSConfig deletions invisible in QoS-specific dashboards and alerts.

Fixes #401 

## How Has This Been Tested?

- `service/slice_qos_config_service.go:178` changed from `events.EventSliceConfigDeletionFailed` to `events.EventSliceQoSConfigDeletionFailed`; line 190 changed from `events.EventSliceConfigDeleted` to `events.EventSliceQoSConfigDeleted`. Verified by diffing against master.
- `go build ./...` passes.
- `make fmt` passes with no diff.
- Pre-existing `make vet` and `make unit-test` failures are present on unmodified master and are unrelated to this change.

## Checklist:
* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates? — No.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas. — N/A.
* [x] I have tested it for all user roles. — N/A, metrics label fix.
* [x] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?

No

```release-note
Fix DeleteSliceQoSConfig recording Prometheus metrics under wrong SliceConfig event label names