### PR TITLE
test(): correct mock client type and remove deprecated ClusterName field in tests

### DIFF
--- a/service/access_control_service_test.go
+++ b/service/access_control_service_test.go
@@ -19,9 +19,10 @@ package service
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/kubeslice/kubeslice-controller/metrics"
 	metricMock "github.com/kubeslice/kubeslice-controller/metrics/mocks"
-	"testing"
 
 	ossEvents "github.com/kubeslice/kubeslice-controller/events"
 	"github.com/kubeslice/kubeslice-controller/service/mocks"
@@ -1270,7 +1271,7 @@ func ACS_ReconcileWorkerClusterServiceAccountAndRoleBindings(t *testing.T) {
 	mMock.AssertExpectations(t)
 }
 
-func prepareACSTestContext(ctx context.Context, client util.Client,
+func prepareACSTestContext(ctx context.Context, client *utilMock.Client,
 	scheme *runtime.Scheme) context.Context {
 	if scheme == nil {
 		scheme = runtime.NewScheme()

--- a/service/namespace_service_test.go
+++ b/service/namespace_service_test.go
@@ -177,7 +177,7 @@ func TestDeleteNamespace_DoesNothingIfNamespaceDoNotExist(t *testing.T) {
 	mMock.AssertExpectations(t)
 }
 
-func prepareNamespaceTestContext(ctx context.Context, client util.Client, scheme *runtime.Scheme) context.Context {
+func prepareNamespaceTestContext(ctx context.Context, client *utilMock.Client, scheme *runtime.Scheme) context.Context {
 	eventRecorder := events.NewEventRecorder(client, scheme, ossEvents.EventsMap, events.EventRecorderOptions{
 		Version:   "v1alpha1",
 		Cluster:   util.ClusterController,

--- a/service/project_service_test.go
+++ b/service/project_service_test.go
@@ -276,7 +276,7 @@ func setupProjectTest(name string, namespace string) (*mocks.INamespaceService, 
 	return nsServiceMock, acsServicemOCK, projectService, requestObj, clientMock, project, ctx, clusterServiceMock, sliceConfigServiceMock, serviceExportConfigServiceMock, sliceQoSConfigServiceMock, mMock
 }
 
-func prepareProjectTestContext(ctx context.Context, client util.Client,
+func prepareProjectTestContext(ctx context.Context, client *utilMock.Client,
 	scheme *runtime.Scheme) context.Context {
 	eventRecorder := events.NewEventRecorder(client, scheme, ossEvents.EventsMap, events.EventRecorderOptions{
 		Version:   "v1alpha1",

--- a/service/worker_slice_gateway_service_test.go
+++ b/service/worker_slice_gateway_service_test.go
@@ -551,7 +551,6 @@ func testNodeIpReconciliationOfWorkerSliceGatewaysExists(t *testing.T) {
 			Annotations:                nil,
 			OwnerReferences:            nil,
 			Finalizers:                 nil,
-			ClusterName:                "",
 			ManagedFields:              nil,
 		},
 		Spec:   controllerv1alpha1.ClusterSpec{},


### PR DESCRIPTION
# Description

Fixes build failures in test files caused by incorrect mock client type usage and deprecated Kubernetes API fields.

### Changes

* Replaced `util.Client` with `*utilMock.Client` in test helper functions , required for testify mocks to work correctly
* Removed deprecated `ClusterName` field from `ObjectMeta` struct literals.

Fixes #

## How Has This Been Tested?

* [x] Ran `make unit-test`
* [x] Verified that test packages compile successfully
* [x] Confirmed the previous build failures are resolved

## Checklist

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?

No.

```release-note 
```