### PR TITLE
fix(deploy): add missing configmaps RBAC and replace dead gcr.io kube…

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
         - name: kube-rbac-proxy
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+          image: quay.io/brancz/kube-rbac-proxy:v0.8.0
           args:
             - "--secure-listen-address=0.0.0.0:8443"
             - "--upstream=http://127.0.0.1:8080/"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - events
   verbs:
   - create

--- a/main.go
+++ b/main.go
@@ -440,6 +440,7 @@ func initialize(services *service.Services) {
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create;update;patch;delete;escalate
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=create;get;list;watch;escalate;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;escalate;update;patch;create
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 //+kubebuilder:rbac:groups="batch",resources=jobs,verbs=get;list;watch;create;update;patch;delete
 
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings;roles;clusterroles,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
# Description

Two issues block the documented local development flow (`make deploy` per `developer_guide.md`):

1. **Missing ConfigMap RBAC**: the controller ClusterRole grants no `configmaps` access, but the Project reconciler reads the `namespace-labels-config` ConfigMap (via the cached client, which starts a cluster-wide ConfigMap informer) as its first step and aborts on failure. Result: project namespaces are never created and the manager logs fill with `configmaps is forbidden` watch errors. Added a kubebuilder RBAC marker for `configmaps` (`get/list/watch`) and regenerated `config/rbac/role.yaml`.

2. **Dead kube-rbac-proxy image**: `gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0` no longer exists (the GCR registry was shut down), so the manager pod stays in `ImagePullBackOff`. Switched to the image's current home, `quay.io/brancz/kube-rbac-proxy:v0.8.0`.

## How Has This Been Tested?

Verified in a local Kind cluster deployed with `make deploy`:

* [x] Without the RBAC rule: created a Project → its namespace is never created; `configmaps is forbidden` errors loop in the manager log.
* [x] Re-added only the RBAC rule (same pod, no restart) → pending Project reconciled and the namespace was created within seconds, confirming the missing permission is the cause.
* [x] With the `quay.io` image, the pod reaches `2/2 Running` (previously `ErrImagePull` on the `gcr.io` image).

## Checklist

* [x] The title of the PR states what changed and the related issues number.
* [ ] Does this PR require documentation updates? — No
* [x] I have performed a self-review of my own code.
* [x] I have tested it (see above).
* [ ] Unit tests — N/A (RBAC marker + deploy manifest only, no code paths changed)

## Does this PR introduce a breaking change for other components like worker-operator?

No
