### PR TITLE
feat(ha): mirror worker credentials (Secrets/RBAC) to the Standby

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ COPY util/ util/
 COPY events/ events/
 COPY metrics/ metrics/
 COPY cleanup/ cleanup/
+COPY pkg/ pkg/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -a -o manager main.go

--- a/config/events/controller.yaml
+++ b/config/events/controller.yaml
@@ -539,3 +539,9 @@ events:
     type: Warning
     reportingController: controller
     message: Warning - Certificate Creation job Failed
+  - name: HAMirrorSyncFailed
+    reason: HAMirrorSyncFailed
+    action: HAMirrorSync
+    type: Warning
+    reportingController: controller
+    message: Failed to mirror a resource from the Active hub onto the Standby; the syncer will retry.

--- a/config/events/events_config_map.yaml
+++ b/config/events/events_config_map.yaml
@@ -97,3 +97,4 @@ data:
       - CertificatesRenewNow
       - IllegalVPNKeyRotationConfigDelete
       - CertificateJobFailed
+      - HAMirrorSyncFailed

--- a/config/ha/README.md
+++ b/config/ha/README.md
@@ -4,7 +4,9 @@
 identity behind a Standby's `--ha-active-kubeconfig` flag: read-only
 (`get`/`list`/`watch`) access to `Namespace` plus every resource type in
 `pkg/ha.CRDMirrorSet` (`RemoteSyncer` never writes to the Active cluster —
-only reads).
+only reads), plus the Active's own `coordination.k8s.io/v1` `Lease` —
+the same kubeconfig is also used by #294's `WatchRemoteLease` to read the
+Active's Lease directly, not just by `RemoteSyncer` to mirror CRDs.
 
 ## This is not applied by this repo's own deploy flow
 

--- a/config/ha/README.md
+++ b/config/ha/README.md
@@ -3,10 +3,11 @@
 `active-cluster-clusterrole.yaml` is a least-privilege grant for the
 identity behind a Standby's `--ha-active-kubeconfig` flag: read-only
 (`get`/`list`/`watch`) access to `Namespace` plus every resource type in
-`pkg/ha.CRDMirrorSet` (`RemoteSyncer` never writes to the Active cluster —
-only reads), plus the Active's own `coordination.k8s.io/v1` `Lease` —
-the same kubeconfig is also used by #294's `WatchRemoteLease` to read the
-Active's Lease directly, not just by `RemoteSyncer` to mirror CRDs.
+`pkg/ha.CRDMirrorSet` and `pkg/ha.CredentialMirrorSet` (`RemoteSyncer`
+never writes to the Active cluster — only reads), plus the Active's own
+`coordination.k8s.io/v1` `Lease` — the same kubeconfig is also used by
+#294's `WatchRemoteLease` to read the Active's Lease directly, not just by
+`RemoteSyncer` to mirror resources.
 
 ## This is not applied by this repo's own deploy flow
 
@@ -36,13 +37,23 @@ Nothing in this repo automates applying this to a real Active cluster —
 that's cross-cluster provisioning, out of scope for a single controller
 repo. Logged as a follow-up, not built.
 
-## Credential mirroring (a later PR)
+## Credential mirroring and the Secret-read tradeoff
 
-If/when `pkg/ha.CredentialMirrorSet` (Secrets, ServiceAccounts, Roles,
-RoleBindings — for #297's post-promotion use) is wired in, this
-`ClusterRole` will need `secrets`/`serviceaccounts`/`roles`/`rolebindings`
-appended. Worth knowing ahead of time: RBAC cannot scope `Secret` access by
-`.type`, so that addition grants read access to **every** Secret in the
-project namespaces on the Active cluster, not just the credential ones
-`RemoteSyncer` actually mirrors — a real credential-exposure tradeoff to
-weigh when that lands, not just an implementation detail.
+`pkg/ha.CredentialMirrorSet` (Secrets with the SA-token type filtered out,
+ServiceAccounts, Roles, RoleBindings — for #297's post-promotion use) is
+wired in, and this `ClusterRole` grants the reads it needs. Weigh the
+Secret rule before applying it: RBAC cannot scope `Secret` access by
+`.type` or by namespace *label*, and a `ClusterRole` +
+`ClusterRoleBinding` is cluster-wide — so the Standby's identity can read
+**every** Secret on the Active hub, not just the gateway-certificate
+Secrets `RemoteSyncer` actually mirrors. The syncer itself only *copies*
+credential objects whose namespace it also mirrors (the label-scoped
+project-namespace boundary — notably excluding the controller's own
+namespace, whose name can match the project-namespace prefix) and
+excludes SA-token Secrets from the watch entirely, but none of that
+narrows what the identity *could* read if the kubeconfig leaked —
+protect it like the credential it is. The narrower alternative — per-namespace `RoleBinding`s in each
+project namespace instead of the cluster-wide binding — works with the
+same `ClusterRole`, at the cost of maintaining those bindings as projects
+come and go (cross-cluster provisioning tooling this repo deliberately
+does not ship).

--- a/config/ha/README.md
+++ b/config/ha/README.md
@@ -1,0 +1,46 @@
+# HA cross-cluster RBAC (issue #295)
+
+`active-cluster-clusterrole.yaml` is a least-privilege grant for the
+identity behind a Standby's `--ha-active-kubeconfig` flag: read-only
+(`get`/`list`/`watch`) access to `Namespace` plus every resource type in
+`pkg/ha.CRDMirrorSet` (`RemoteSyncer` never writes to the Active cluster —
+only reads).
+
+## This is not applied by this repo's own deploy flow
+
+Nothing here is referenced by `config/rbac/kustomization.yaml` or
+`config/default/kustomization.yaml`. Those govern the RBAC a controller
+grants *itself* on the cluster it's running in. This manifest is different:
+it must be applied **on the Active hub cluster**, granting access to
+whatever identity the *Standby's* kubeconfig authenticates as — a cluster
+this repo's own kustomize overlays have no way to reach, since it's a
+separate cluster entirely.
+
+Apply it manually (or via whatever provisioning tooling manages the Active
+hub) against the Active cluster:
+
+```
+kubectl --context <active-hub-context> apply -f active-cluster-clusterrole.yaml
+```
+
+Fill in the `ClusterRoleBinding`'s `subjects` first — the correct subject
+depends on how the Standby authenticates to the Active (a `ServiceAccount`
+if dialing in-cluster, a client-cert `User` if using a flattened
+kubeconfig Secret, as the current dev demo does).
+
+## A known, deliberate gap this manifest does not close
+
+Nothing in this repo automates applying this to a real Active cluster —
+that's cross-cluster provisioning, out of scope for a single controller
+repo. Logged as a follow-up, not built.
+
+## Credential mirroring (a later PR)
+
+If/when `pkg/ha.CredentialMirrorSet` (Secrets, ServiceAccounts, Roles,
+RoleBindings — for #297's post-promotion use) is wired in, this
+`ClusterRole` will need `secrets`/`serviceaccounts`/`roles`/`rolebindings`
+appended. Worth knowing ahead of time: RBAC cannot scope `Secret` access by
+`.type`, so that addition grants read access to **every** Secret in the
+project namespaces on the Active cluster, not just the credential ones
+`RemoteSyncer` actually mirrors — a real credential-exposure tradeoff to
+weigh when that lands, not just an implementation detail.

--- a/config/ha/active-cluster-clusterrole.yaml
+++ b/config/ha/active-cluster-clusterrole.yaml
@@ -1,0 +1,65 @@
+---
+# Least-privilege grant for the identity behind the Standby's
+# --ha-active-kubeconfig, applied ON THE ACTIVE CLUSTER — not part of this
+# repo's own config/rbac (that governs the local cluster's own ClusterRole)
+# and not referenced by config/rbac/kustomization.yaml or
+# config/default/kustomization.yaml, so it is never auto-applied to the
+# Standby's own cluster, where it would be meaningless.
+#
+# See config/ha/README.md for how and where to apply this.
+#
+# Scope: read-only (get/list/watch) on Namespace plus every type in
+# pkg/ha.CRDMirrorSet. RemoteSyncer never writes to the Active cluster.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeslice-ha-standby-reader
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - controller.kubeslice.io
+    resources:
+      - projects
+      - clusters
+      - sliceconfigs
+      - serviceexportconfigs
+      - sliceqosconfigs
+      - vpnkeyrotations
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - worker.kubeslice.io
+    resources:
+      - workersliceconfigs
+      - workerslicegateways
+      - workerserviceimports
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Template only — the subject is deployment-specific (a ServiceAccount if the
+# Standby dials the Active in-cluster, a cert CN if it uses client-cert auth
+# via a flattened kubeconfig) and can't be hardcoded here. Fill in `subjects`
+# before applying.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubeslice-ha-standby-reader-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeslice-ha-standby-reader
+subjects:
+  - kind: User # or ServiceAccount — see README.md
+    name: CHANGEME
+    apiGroup: rbac.authorization.k8s.io

--- a/config/ha/active-cluster-clusterrole.yaml
+++ b/config/ha/active-cluster-clusterrole.yaml
@@ -9,12 +9,12 @@
 # See config/ha/README.md for how and where to apply this.
 #
 # Scope: read-only (get/list/watch) on Namespace plus every type in
-# pkg/ha.CRDMirrorSet, plus the Active's own HA Lease — the same
-# --ha-active-kubeconfig identity is also used by #294's WatchRemoteLease to
-# read the Active's coordination.k8s.io/v1 Lease (checkRemoteLeaseOnce),
-# not just by RemoteSyncer. Confirmed live: without this, the Standby can
-# mirror CRDs fine but permanently fails to read the Active's Lease,
-# so it can never observe staleness in the first place.
+# pkg/ha.CRDMirrorSet and pkg/ha.CredentialMirrorSet, plus the Active's own
+# HA Lease — the same --ha-active-kubeconfig identity is also used by #294's
+# WatchRemoteLease to read the Active's coordination.k8s.io/v1 Lease
+# (checkRemoteLeaseOnce), not just by RemoteSyncer. Confirmed live: without
+# this, the Standby can mirror CRDs fine but permanently fails to read the
+# Active's Lease, so it can never observe staleness in the first place.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -55,6 +55,36 @@ rules:
       - workersliceconfigs
       - workerslicegateways
       - workerserviceimports
+    verbs:
+      - get
+      - list
+      - watch
+  # Credential mirroring (pkg/ha.CredentialMirrorSet). SECURITY TRADEOFF,
+  # named rather than buried: RBAC cannot scope Secret access by .type or by
+  # namespace *label*, and a ClusterRole+ClusterRoleBinding grants reads
+  # CLUSTER-WIDE — so this rule lets the Standby's identity read every
+  # Secret on the Active hub, not just the gateway certificates RemoteSyncer
+  # actually mirrors (the syncer's own field selector and mirrored-namespace
+  # gate narrow what is COPIED, but not what this identity COULD read).
+  # Treat the --ha-active-kubeconfig credential accordingly. To narrow the
+  # grant itself, replace this rule with per-namespace RoleBindings in each
+  # kubeslice project namespace — at the cost of maintaining them as
+  # projects come and go, which is cross-cluster provisioning tooling this
+  # repo deliberately does not ship.
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - serviceaccounts
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - roles
+      - rolebindings
     verbs:
       - get
       - list

--- a/config/ha/active-cluster-clusterrole.yaml
+++ b/config/ha/active-cluster-clusterrole.yaml
@@ -9,7 +9,12 @@
 # See config/ha/README.md for how and where to apply this.
 #
 # Scope: read-only (get/list/watch) on Namespace plus every type in
-# pkg/ha.CRDMirrorSet. RemoteSyncer never writes to the Active cluster.
+# pkg/ha.CRDMirrorSet, plus the Active's own HA Lease — the same
+# --ha-active-kubeconfig identity is also used by #294's WatchRemoteLease to
+# read the Active's coordination.k8s.io/v1 Lease (checkRemoteLeaseOnce),
+# not just by RemoteSyncer. Confirmed live: without this, the Standby can
+# mirror CRDs fine but permanently fails to read the Active's Lease,
+# so it can never observe staleness in the first place.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -19,6 +24,14 @@ rules:
       - ""
     resources:
       - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
     verbs:
       - get
       - list

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -33,6 +33,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
   - serviceaccounts
   verbs:
   - create

--- a/controllers/controller/cluster_controller.go
+++ b/controllers/controller/cluster_controller.go
@@ -18,10 +18,12 @@ package controller
 
 import (
 	"context"
+
 	"github.com/kubeslice/kubeslice-monitoring/pkg/events"
 	"go.uber.org/zap"
 
 	controllerv1alpha1 "github.com/kubeslice/kubeslice-controller/apis/controller/v1alpha1"
+	"github.com/kubeslice/kubeslice-controller/pkg/ha"
 	"github.com/kubeslice/kubeslice-controller/service"
 	"github.com/kubeslice/kubeslice-controller/util"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -36,6 +38,9 @@ type ClusterReconciler struct {
 	ClusterService service.IClusterService
 	Log            *zap.SugaredLogger
 	EventRecorder  *events.EventRecorder
+	// LeaderElector gates mutating reconciles on cross-cluster leadership. It is
+	// nil-safe: a nil elector (HA not wired) behaves as standalone. See ADR #293.
+	LeaderElector *ha.ClusterLeaderElector
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -47,6 +52,12 @@ func (c *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // Reconcile is a function to reconcile the cluster , ClusterReconciler implements it
 func (c *ClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// HA write fence: only the Active hub (or a standalone controller) writes.
+	// A Standby evaluates this on every call and no-ops.
+	if c.LeaderElector != nil && !c.LeaderElector.IsLeader() {
+		c.Log.Info("standby mode, skipping reconcile")
+		return ctrl.Result{}, nil
+	}
 	kubeSliceCtx := util.PrepareKubeSliceControllersRequestContext(ctx, c.Client, c.Scheme, "ClusterController", c.EventRecorder)
 	return c.ClusterService.ReconcileCluster(kubeSliceCtx, req)
 }

--- a/controllers/controller/leader_gate_test.go
+++ b/controllers/controller/leader_gate_test.go
@@ -1,0 +1,62 @@
+/*
+ * 	Copyright (c) 2022 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/kubeslice/kubeslice-controller/pkg/ha"
+)
+
+// TestReconcile_StandbySkipsAndLogs verifies the HA write fence: a Standby
+// controller returns immediately from Reconcile without touching its service
+// (left nil here — a leaking gate would panic), and logs the skip message on
+// every call, proving IsLeader() is evaluated per invocation.
+func TestReconcile_StandbySkipsAndLogs(t *testing.T) {
+	core, logs := observer.New(zapcore.InfoLevel)
+	logger := zap.New(core).Sugar()
+
+	standby := ha.NewClusterLeaderElector(nil, nil, ha.Options{
+		Mode: ha.ModeStandby,
+		Log:  zap.NewNop().Sugar(),
+	})
+	require.False(t, standby.IsLeader(), "standby must not be leader")
+
+	r := &SliceConfigReconciler{
+		Log:           logger,
+		LeaderElector: standby,
+		// SliceConfigService is intentionally nil: the gate must return before it.
+	}
+
+	const calls = 3
+	for i := 0; i < calls; i++ {
+		res, err := r.Reconcile(context.Background(), ctrl.Request{})
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, res)
+	}
+
+	assert.Equal(t, calls, logs.FilterMessage("standby mode, skipping reconcile").Len(),
+		"expected one skip log per Reconcile call")
+}

--- a/controllers/controller/project_controller.go
+++ b/controllers/controller/project_controller.go
@@ -18,10 +18,12 @@ package controller
 
 import (
 	"context"
+
 	"github.com/kubeslice/kubeslice-monitoring/pkg/events"
 	"go.uber.org/zap"
 
 	controllerv1alpha1 "github.com/kubeslice/kubeslice-controller/apis/controller/v1alpha1"
+	"github.com/kubeslice/kubeslice-controller/pkg/ha"
 	"github.com/kubeslice/kubeslice-controller/service"
 	"github.com/kubeslice/kubeslice-controller/util"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -36,6 +38,9 @@ type ProjectReconciler struct {
 	ProjectService service.IProjectService
 	Log            *zap.SugaredLogger
 	EventRecorder  *events.EventRecorder
+	// LeaderElector gates mutating reconciles on cross-cluster leadership. It is
+	// nil-safe: a nil elector (HA not wired) behaves as standalone. See ADR #293.
+	LeaderElector *ha.ClusterLeaderElector
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -47,6 +52,12 @@ func (t *ProjectReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // Reconcile is a function to reconcile the project, ProjectReconciler implements it
 func (t *ProjectReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// HA write fence: only the Active hub (or a standalone controller) writes.
+	// A Standby evaluates this on every call and no-ops.
+	if t.LeaderElector != nil && !t.LeaderElector.IsLeader() {
+		t.Log.Info("standby mode, skipping reconcile")
+		return ctrl.Result{}, nil
+	}
 	kubeSliceCtx := util.PrepareKubeSliceControllersRequestContext(ctx, t.Client, t.Scheme, "ProjectController", t.EventRecorder)
 	return t.ProjectService.ReconcileProject(kubeSliceCtx, req)
 }

--- a/controllers/controller/serviceexportconfig_controller.go
+++ b/controllers/controller/serviceexportconfig_controller.go
@@ -18,10 +18,12 @@ package controller
 
 import (
 	"context"
+
 	"github.com/kubeslice/kubeslice-monitoring/pkg/events"
 	"go.uber.org/zap"
 
 	controllerv1alpha1 "github.com/kubeslice/kubeslice-controller/apis/controller/v1alpha1"
+	"github.com/kubeslice/kubeslice-controller/pkg/ha"
 	"github.com/kubeslice/kubeslice-controller/service"
 	"github.com/kubeslice/kubeslice-controller/util"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -36,10 +38,19 @@ type ServiceExportConfigReconciler struct {
 	ServiceExportConfigService service.IServiceExportConfigService
 	Log                        *zap.SugaredLogger
 	EventRecorder              *events.EventRecorder
+	// LeaderElector gates mutating reconciles on cross-cluster leadership. It is
+	// nil-safe: a nil elector (HA not wired) behaves as standalone. See ADR #293.
+	LeaderElector *ha.ClusterLeaderElector
 }
 
 // Reconcile is a function to reconcile the ServiceExportConfig, ServiceExportConfigReconciler implements it
 func (r *ServiceExportConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// HA write fence: only the Active hub (or a standalone controller) writes.
+	// A Standby evaluates this on every call and no-ops.
+	if r.LeaderElector != nil && !r.LeaderElector.IsLeader() {
+		r.Log.Info("standby mode, skipping reconcile")
+		return ctrl.Result{}, nil
+	}
 	kubeSliceCtx := util.PrepareKubeSliceControllersRequestContext(ctx, r.Client, r.Scheme, "ServiceExportConfigController", r.EventRecorder)
 	return r.ServiceExportConfigService.ReconcileServiceExportConfig(kubeSliceCtx, req)
 }

--- a/controllers/controller/sliceconfig_controller.go
+++ b/controllers/controller/sliceconfig_controller.go
@@ -23,6 +23,7 @@ import (
 	"go.uber.org/zap"
 
 	controllerv1alpha1 "github.com/kubeslice/kubeslice-controller/apis/controller/v1alpha1"
+	"github.com/kubeslice/kubeslice-controller/pkg/ha"
 	"github.com/kubeslice/kubeslice-controller/service"
 	"github.com/kubeslice/kubeslice-controller/util"
 
@@ -38,10 +39,19 @@ type SliceConfigReconciler struct {
 	SliceConfigService service.ISliceConfigService
 	Log                *zap.SugaredLogger
 	EventRecorder      *events.EventRecorder
+	// LeaderElector gates mutating reconciles on cross-cluster leadership. It is
+	// nil-safe: a nil elector (HA not wired) behaves as standalone. See ADR #293.
+	LeaderElector *ha.ClusterLeaderElector
 }
 
 // Reconcile is a function to reconcile the slice config, SliceConfigReconciler implements it
 func (r *SliceConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// HA write fence: only the Active hub (or a standalone controller) writes.
+	// A Standby evaluates this on every call and no-ops.
+	if r.LeaderElector != nil && !r.LeaderElector.IsLeader() {
+		r.Log.Info("standby mode, skipping reconcile")
+		return ctrl.Result{}, nil
+	}
 	kubeSliceCtx := util.PrepareKubeSliceControllersRequestContext(ctx, r.Client, r.Scheme, "SliceConfigController", r.EventRecorder)
 	return r.SliceConfigService.ReconcileSliceConfig(kubeSliceCtx, req)
 }

--- a/controllers/controller/sliceqosconfig_controller.go
+++ b/controllers/controller/sliceqosconfig_controller.go
@@ -18,6 +18,8 @@ package controller
 
 import (
 	"context"
+
+	"github.com/kubeslice/kubeslice-controller/pkg/ha"
 	"github.com/kubeslice/kubeslice-controller/service"
 	"github.com/kubeslice/kubeslice-controller/util"
 	"github.com/kubeslice/kubeslice-monitoring/pkg/events"
@@ -37,6 +39,9 @@ type SliceQoSConfigReconciler struct {
 	SliceQoSConfigService service.ISliceQoSConfigService
 	Log                   *zap.SugaredLogger
 	EventRecorder         *events.EventRecorder
+	// LeaderElector gates mutating reconciles on cross-cluster leadership. It is
+	// nil-safe: a nil elector (HA not wired) behaves as standalone. See ADR #293.
+	LeaderElector *ha.ClusterLeaderElector
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -48,6 +53,12 @@ func (r *SliceQoSConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // Reconcile is a function to reconcile the qos_profile, SliceQoSConfigReconciler implements it
 func (r *SliceQoSConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// HA write fence: only the Active hub (or a standalone controller) writes.
+	// A Standby evaluates this on every call and no-ops.
+	if r.LeaderElector != nil && !r.LeaderElector.IsLeader() {
+		r.Log.Info("standby mode, skipping reconcile")
+		return ctrl.Result{}, nil
+	}
 	kubeSliceCtx := util.PrepareKubeSliceControllersRequestContext(ctx, r.Client, r.Scheme, "SliceQoSConfigController", r.EventRecorder)
 	return r.SliceQoSConfigService.ReconcileSliceQoSConfig(kubeSliceCtx, req)
 }

--- a/controllers/controller/vpnkey_rotation_controller.go
+++ b/controllers/controller/vpnkey_rotation_controller.go
@@ -18,6 +18,8 @@ package controller
 
 import (
 	"context"
+
+	"github.com/kubeslice/kubeslice-controller/pkg/ha"
 	"github.com/kubeslice/kubeslice-controller/service"
 	"github.com/kubeslice/kubeslice-controller/util"
 	"github.com/kubeslice/kubeslice-monitoring/pkg/events"
@@ -37,6 +39,9 @@ type VpnKeyRotationReconciler struct {
 	VpnKeyRotationService service.IVpnKeyRotationService
 	Log                   *zap.SugaredLogger
 	EventRecorder         *events.EventRecorder
+	// LeaderElector gates mutating reconciles on cross-cluster leadership. It is
+	// nil-safe: a nil elector (HA not wired) behaves as standalone. See ADR #293.
+	LeaderElector *ha.ClusterLeaderElector
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -48,6 +53,12 @@ func (r *VpnKeyRotationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // Reconcile is a function to reconcile the VpnKeyRotation, VpnKeyRotationReconciler implements it
 func (r *VpnKeyRotationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// HA write fence: only the Active hub (or a standalone controller) writes.
+	// A Standby evaluates this on every call and no-ops.
+	if r.LeaderElector != nil && !r.LeaderElector.IsLeader() {
+		r.Log.Info("standby mode, skipping reconcile")
+		return ctrl.Result{}, nil
+	}
 	kubeSliceCtx := util.PrepareKubeSliceControllersRequestContext(ctx, r.Client, r.Scheme, "VpnKeyRotationController", r.EventRecorder)
 	return r.VpnKeyRotationService.ReconcileVpnKeyRotation(kubeSliceCtx, req)
 }

--- a/controllers/worker/workerserviceimport_controller.go
+++ b/controllers/worker/workerserviceimport_controller.go
@@ -18,10 +18,12 @@ package worker
 
 import (
 	"context"
+
 	"github.com/kubeslice/kubeslice-monitoring/pkg/events"
 	"go.uber.org/zap"
 
 	"github.com/kubeslice/kubeslice-controller/apis/worker/v1alpha1"
+	"github.com/kubeslice/kubeslice-controller/pkg/ha"
 	"github.com/kubeslice/kubeslice-controller/service"
 	"github.com/kubeslice/kubeslice-controller/util"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -37,10 +39,19 @@ type WorkerServiceImportReconciler struct {
 	WorkerServiceImportService service.IWorkerServiceImportService
 	Log                        *zap.SugaredLogger
 	EventRecorder              *events.EventRecorder
+	// LeaderElector gates mutating reconciles on cross-cluster leadership. It is
+	// nil-safe: a nil elector (HA not wired) behaves as standalone. See ADR #293.
+	LeaderElector *ha.ClusterLeaderElector
 }
 
 // Reconcile is a function to reconcile the workerServiceImport, WorkerServiceImportReconciler implements it
 func (r *WorkerServiceImportReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// HA write fence: only the Active hub (or a standalone controller) writes.
+	// A Standby evaluates this on every call and no-ops.
+	if r.LeaderElector != nil && !r.LeaderElector.IsLeader() {
+		r.Log.Info("standby mode, skipping reconcile")
+		return ctrl.Result{}, nil
+	}
 	kubeSliceCtx := util.PrepareKubeSliceControllersRequestContext(ctx, r.Client, r.Scheme, "WorkerServiceImportController", r.EventRecorder)
 	return r.WorkerServiceImportService.ReconcileWorkerServiceImport(kubeSliceCtx, req)
 }

--- a/controllers/worker/workersliceconfig_controller.go
+++ b/controllers/worker/workersliceconfig_controller.go
@@ -18,13 +18,14 @@ package worker
 
 import (
 	"context"
+
 	"github.com/kubeslice/kubeslice-monitoring/pkg/events"
 	"go.uber.org/zap"
 
+	workerv1alpha1 "github.com/kubeslice/kubeslice-controller/apis/worker/v1alpha1"
+	"github.com/kubeslice/kubeslice-controller/pkg/ha"
 	"github.com/kubeslice/kubeslice-controller/service"
 	"github.com/kubeslice/kubeslice-controller/util"
-
-	workerv1alpha1 "github.com/kubeslice/kubeslice-controller/apis/worker/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -38,6 +39,9 @@ type WorkerSliceConfigReconciler struct {
 	WorkerSliceService service.IWorkerSliceConfigService
 	Log                *zap.SugaredLogger
 	EventRecorder      *events.EventRecorder
+	// LeaderElector gates mutating reconciles on cross-cluster leadership. It is
+	// nil-safe: a nil elector (HA not wired) behaves as standalone. See ADR #293.
+	LeaderElector *ha.ClusterLeaderElector
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -49,6 +53,12 @@ func (c *WorkerSliceConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // Reconcile is a function to reconcilation of WorkerSliceconfig, WorkerSliceConfigReconciler implements it
 func (c *WorkerSliceConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// HA write fence: only the Active hub (or a standalone controller) writes.
+	// A Standby evaluates this on every call and no-ops.
+	if c.LeaderElector != nil && !c.LeaderElector.IsLeader() {
+		c.Log.Info("standby mode, skipping reconcile")
+		return ctrl.Result{}, nil
+	}
 	kubeSliceCtx := util.PrepareKubeSliceControllersRequestContext(ctx, c.Client, c.Scheme, "WorkerSliceConfigController", c.EventRecorder)
 	return c.WorkerSliceService.ReconcileWorkerSliceConfig(kubeSliceCtx, req)
 }

--- a/controllers/worker/workerslicegateway_controller.go
+++ b/controllers/worker/workerslicegateway_controller.go
@@ -18,10 +18,12 @@ package worker
 
 import (
 	"context"
+
 	"github.com/kubeslice/kubeslice-monitoring/pkg/events"
 	"go.uber.org/zap"
 
 	"github.com/kubeslice/kubeslice-controller/apis/worker/v1alpha1"
+	"github.com/kubeslice/kubeslice-controller/pkg/ha"
 	"github.com/kubeslice/kubeslice-controller/service"
 	"github.com/kubeslice/kubeslice-controller/util"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -37,10 +39,19 @@ type WorkerSliceGatewayReconciler struct {
 	WorkerSliceGatewayService service.IWorkerSliceGatewayService
 	Log                       *zap.SugaredLogger
 	EventRecorder             *events.EventRecorder
+	// LeaderElector gates mutating reconciles on cross-cluster leadership. It is
+	// nil-safe: a nil elector (HA not wired) behaves as standalone. See ADR #293.
+	LeaderElector *ha.ClusterLeaderElector
 }
 
 // Reconcile is a function, WorkerSliceGatewayReconciler implements it
 func (r *WorkerSliceGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// HA write fence: only the Active hub (or a standalone controller) writes.
+	// A Standby evaluates this on every call and no-ops.
+	if r.LeaderElector != nil && !r.LeaderElector.IsLeader() {
+		r.Log.Info("standby mode, skipping reconcile")
+		return ctrl.Result{}, nil
+	}
 	kubeSliceCtx := util.PrepareKubeSliceControllersRequestContext(ctx, r.Client, r.Scheme, "WorkerSliceGatewayController", r.EventRecorder)
 	return r.WorkerSliceGatewayService.ReconcileWorkerSliceGateways(kubeSliceCtx, req)
 }

--- a/events/events_generated.go
+++ b/events/events_generated.go
@@ -734,6 +734,14 @@ var EventsMap = map[events.EventName]*events.EventSchema{
 		ReportingController: "controller",
 		Message:             "Warning - Certificate Creation job Failed",
 	},
+	"HAMirrorSyncFailed": {
+		Name:                "HAMirrorSyncFailed",
+		Reason:              "HAMirrorSyncFailed",
+		Action:              "HAMirrorSync",
+		Type:                events.EventTypeWarning,
+		ReportingController: "controller",
+		Message:             "Failed to mirror a resource from the Active hub onto the Standby; the syncer will retry.",
+	},
 }
 
 var (
@@ -826,4 +834,5 @@ var (
 	EventCertificatesRenewNow                 events.EventName = "CertificatesRenewNow"
 	EventIllegalVPNKeyRotationConfigDelete    events.EventName = "IllegalVPNKeyRotationConfigDelete"
 	EventCertificateJobFailed                 events.EventName = "CertificateJobFailed"
+	EventHAMirrorSyncFailed                   events.EventName = "HAMirrorSyncFailed"
 )

--- a/main.go
+++ b/main.go
@@ -126,6 +126,7 @@ func initialize(services *service.Services) {
 	var haRetryPeriod time.Duration
 	var haPaddingSeconds time.Duration
 	var haSyncWorkers int
+	var haSyncInterval time.Duration
 
 	flag.StringVar(&rbacResourcePrefix, "rbac-resource-prefix", service.RbacResourcePrefix, "RBAC resource prefix")
 	flag.StringVar(&projectNameSpacePrefixFromCustomer, "project-namespace-prefix", service.ProjectNamespacePrefix, fmt.Sprintf("Overrides the default %s kubeslice namespace", service.ProjectNamespacePrefix))
@@ -164,6 +165,7 @@ func initialize(services *service.Services) {
 	flag.DurationVar(&haRetryPeriod, "ha-retry-period", ha.DefaultRetryPeriod, "Interval between Lease renew/watch attempts.")
 	flag.DurationVar(&haPaddingSeconds, "ha-padding-seconds", ha.DefaultPaddingSeconds, "Extra buffer a Standby waits before treating the Active Lease as stale.")
 	flag.IntVar(&haSyncWorkers, "ha-sync-workers", ha.DefaultSyncWorkers, "Number of workers draining the Standby's remote-mirror workqueue.")
+	flag.DurationVar(&haSyncInterval, "ha-sync-interval", ha.DefaultPruneInterval, "How often the Standby prunes mirrored objects that no longer exist on the Active hub.")
 
 	flag.Parse()
 
@@ -351,8 +353,9 @@ func initialize(services *service.Services) {
 	// the same remote config and local client the elector above already
 	// built rather than loading the kubeconfig twice.
 	remoteSyncer, err := ha.NewRemoteSyncer(localHAClient, remoteHACfg, scheme, haRunMode, ha.RemoteSyncerOptions{
-		Workers: haSyncWorkers,
-		Log:     controllerLog.With("name", "ha-remote-syncer"),
+		Workers:       haSyncWorkers,
+		PruneInterval: haSyncInterval,
+		Log:           controllerLog.With("name", "ha-remote-syncer"),
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to build HA remote syncer")

--- a/main.go
+++ b/main.go
@@ -22,6 +22,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
+
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -42,9 +44,12 @@ import (
 	"github.com/kubeslice/kubeslice-controller/controllers/controller"
 	"github.com/kubeslice/kubeslice-controller/controllers/worker"
 	"github.com/kubeslice/kubeslice-controller/metrics"
+	"github.com/kubeslice/kubeslice-controller/pkg/ha"
 	"github.com/kubeslice/kubeslice-controller/service"
 	"github.com/kubeslice/kubeslice-controller/util"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	//+kubebuilder:scaffold:imports
 )
@@ -110,6 +115,14 @@ func initialize(services *service.Services) {
 	var jobServiceAccount string
 	// get prometheus endpoint from environment
 	var prometheusServiceEndpoint string
+	// HA (Active/Standby cross-cluster) configuration — see ADR #293 / issue #294
+	var haMode string
+	var haIdentity string
+	var haActiveKubeconfig string
+	var haLeaseDuration time.Duration
+	var haRenewDeadline time.Duration
+	var haRetryPeriod time.Duration
+	var haPaddingSeconds time.Duration
 
 	flag.StringVar(&rbacResourcePrefix, "rbac-resource-prefix", service.RbacResourcePrefix, "RBAC resource prefix")
 	flag.StringVar(&projectNameSpacePrefixFromCustomer, "project-namespace-prefix", service.ProjectNamespacePrefix, fmt.Sprintf("Overrides the default %s kubeslice namespace", service.ProjectNamespacePrefix))
@@ -137,6 +150,15 @@ func initialize(services *service.Services) {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+
+	// Cross-cluster HA flags. --ha-mode=standalone (default) preserves today's behaviour.
+	flag.StringVar(&haMode, "ha-mode", "standalone", `Cross-cluster HA mode: "active", "standby", or "standalone" (default).`)
+	flag.StringVar(&haIdentity, "ha-identity", "", "Stable per-cluster identity recorded in the Lease (defaults to the hostname).")
+	flag.StringVar(&haActiveKubeconfig, "ha-active-kubeconfig", "", "Path to the Active hub kubeconfig; required in standby mode.")
+	flag.DurationVar(&haLeaseDuration, "ha-lease-duration", ha.DefaultLeaseDuration, "HA Lease duration.")
+	flag.DurationVar(&haRenewDeadline, "ha-renew-deadline", ha.DefaultRenewDeadline, "Deadline for the Active to renew its Lease before releasing leadership.")
+	flag.DurationVar(&haRetryPeriod, "ha-retry-period", ha.DefaultRetryPeriod, "Interval between Lease renew/watch attempts.")
+	flag.DurationVar(&haPaddingSeconds, "ha-padding-seconds", ha.DefaultPaddingSeconds, "Extra buffer a Standby waits before treating the Active Lease as stale.")
 
 	flag.Parse()
 
@@ -278,8 +300,47 @@ func initialize(services *service.Services) {
 	})
 	// setting up metrics collector
 	go metrics.StartMetricsCollector(service.MetricPort, true)
+
+	// Set up cross-cluster HA leader election (ADR #293 / issue #294). In
+	// standalone mode (the default) the elector is always the leader, so the
+	// reconciler write-fence is a no-op and behaviour is unchanged.
+	haRunMode := ha.ParseHAMode(haMode)
+	localHAClient, err := client.New(mgr.GetConfig(), client.Options{Scheme: scheme})
+	if err != nil {
+		setupLog.Error(err, "unable to build HA local client")
+		os.Exit(1)
+	}
+	var remoteHAClient client.Client
+	if haRunMode == ha.ModeStandby {
+		if haActiveKubeconfig == "" {
+			setupLog.Error(fmt.Errorf("missing --ha-active-kubeconfig"), "standby mode requires the Active hub kubeconfig")
+			os.Exit(1)
+		}
+		remoteCfg, cfgErr := clientcmd.BuildConfigFromFlags("", haActiveKubeconfig)
+		if cfgErr != nil {
+			setupLog.Error(cfgErr, "unable to load Active hub kubeconfig", "path", haActiveKubeconfig)
+			os.Exit(1)
+		}
+		remoteHAClient, cfgErr = client.New(remoteCfg, client.Options{Scheme: scheme})
+		if cfgErr != nil {
+			setupLog.Error(cfgErr, "unable to build remote client for Active hub")
+			os.Exit(1)
+		}
+	}
+	leaderElector := ha.NewClusterLeaderElector(localHAClient, remoteHAClient, ha.Options{
+		Mode:           haRunMode,
+		Identity:       haIdentity,
+		LeaseDuration:  haLeaseDuration,
+		RenewDeadline:  haRenewDeadline,
+		RetryPeriod:    haRetryPeriod,
+		PaddingSeconds: haPaddingSeconds,
+		Log:            controllerLog.With("name", "ha"),
+	})
+	setupLog.Info("high availability configured", "mode", haRunMode, "identity", leaderElector.Identity())
+
 	// initialize controller with Project Kind
 	if err = (&controller.ProjectReconciler{
+		LeaderElector:  leaderElector,
 		Client:         mgr.GetClient(),
 		Scheme:         mgr.GetScheme(),
 		Log:            controllerLog.With("name", "Project"),
@@ -291,6 +352,7 @@ func initialize(services *service.Services) {
 	}
 	// initialize controller with Cluster Kind
 	if err = (&controller.ClusterReconciler{
+		LeaderElector:  leaderElector,
 		Client:         mgr.GetClient(),
 		Scheme:         mgr.GetScheme(),
 		Log:            controllerLog.With("name", "Cluster"),
@@ -302,6 +364,7 @@ func initialize(services *service.Services) {
 	}
 	// initialize controller with SliceConfig Kind
 	if err = (&controller.SliceConfigReconciler{
+		LeaderElector:      leaderElector,
 		Client:             mgr.GetClient(),
 		Scheme:             mgr.GetScheme(),
 		Log:                controllerLog.With("name", "SliceConfig"),
@@ -313,6 +376,7 @@ func initialize(services *service.Services) {
 	}
 	// initialize controller with ServiceExportConfig Kind
 	if err = (&controller.ServiceExportConfigReconciler{
+		LeaderElector:              leaderElector,
 		Client:                     mgr.GetClient(),
 		Scheme:                     mgr.GetScheme(),
 		Log:                        controllerLog.With("name", "ServiceExportConfig"),
@@ -323,6 +387,7 @@ func initialize(services *service.Services) {
 		os.Exit(1)
 	}
 	if err = (&worker.WorkerSliceGatewayReconciler{
+		LeaderElector:             leaderElector,
 		Client:                    mgr.GetClient(),
 		Scheme:                    mgr.GetScheme(),
 		Log:                       controllerLog.With("name", "WorkerSliceGateway"),
@@ -333,6 +398,7 @@ func initialize(services *service.Services) {
 		os.Exit(1)
 	}
 	if err = (&worker.WorkerSliceConfigReconciler{
+		LeaderElector:      leaderElector,
 		Client:             mgr.GetClient(),
 		Scheme:             mgr.GetScheme(),
 		Log:                controllerLog.With("name", "WorkerSliceConfig"),
@@ -343,6 +409,7 @@ func initialize(services *service.Services) {
 		os.Exit(1)
 	}
 	if err = (&worker.WorkerServiceImportReconciler{
+		LeaderElector:              leaderElector,
 		Client:                     mgr.GetClient(),
 		Scheme:                     mgr.GetScheme(),
 		Log:                        controllerLog.With("name", "WorkerServiceImport"),
@@ -353,6 +420,7 @@ func initialize(services *service.Services) {
 		os.Exit(1)
 	}
 	if err = (&controller.SliceQoSConfigReconciler{
+		LeaderElector:         leaderElector,
 		Client:                mgr.GetClient(),
 		Scheme:                mgr.GetScheme(),
 		Log:                   controllerLog.With("name", "SliceQoSConfig"),
@@ -363,6 +431,7 @@ func initialize(services *service.Services) {
 		os.Exit(1)
 	}
 	if err = (&controller.VpnKeyRotationReconciler{
+		LeaderElector:         leaderElector,
 		Client:                mgr.GetClient(),
 		Scheme:                mgr.GetScheme(),
 		Log:                   controllerLog.With("name", "VpnKeyRotationConfig"),
@@ -419,8 +488,27 @@ func initialize(services *service.Services) {
 		os.Exit(1)
 	}
 
+	ctx := ctrl.SetupSignalHandler()
+
+	// Start the HA background loop for the configured mode. Standalone starts
+	// nothing (it is always the leader).
+	switch haRunMode {
+	case ha.ModeActive:
+		go func() {
+			if err := leaderElector.StartLeaseRenewal(ctx); err != nil {
+				setupLog.Error(err, "HA lease renewal loop exited")
+			}
+		}()
+	case ha.ModeStandby:
+		go func() {
+			if err := leaderElector.WatchRemoteLease(ctx); err != nil {
+				setupLog.Error(err, "HA remote lease watch loop exited")
+			}
+		}()
+	}
+
 	setupLog.Info("starting manager")
-	if err = mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err = mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
@@ -443,3 +531,5 @@ func initialize(services *service.Services) {
 //+kubebuilder:rbac:groups="batch",resources=jobs,verbs=get;list;watch;create;update;patch;delete
 
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings;roles;clusterroles,verbs=get;list;watch;create;update;patch;delete
+
+//+kubebuilder:rbac:groups="coordination.k8s.io",resources=leases,verbs=get;list;watch;create;update;patch;delete

--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ import (
 	"github.com/kubeslice/kubeslice-controller/service"
 	"github.com/kubeslice/kubeslice-controller/util"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -124,6 +125,7 @@ func initialize(services *service.Services) {
 	var haRenewDeadline time.Duration
 	var haRetryPeriod time.Duration
 	var haPaddingSeconds time.Duration
+	var haSyncWorkers int
 
 	flag.StringVar(&rbacResourcePrefix, "rbac-resource-prefix", service.RbacResourcePrefix, "RBAC resource prefix")
 	flag.StringVar(&projectNameSpacePrefixFromCustomer, "project-namespace-prefix", service.ProjectNamespacePrefix, fmt.Sprintf("Overrides the default %s kubeslice namespace", service.ProjectNamespacePrefix))
@@ -161,6 +163,7 @@ func initialize(services *service.Services) {
 	flag.DurationVar(&haRenewDeadline, "ha-renew-deadline", ha.DefaultRenewDeadline, "Deadline for the Active to renew its Lease before releasing leadership.")
 	flag.DurationVar(&haRetryPeriod, "ha-retry-period", ha.DefaultRetryPeriod, "Interval between Lease renew/watch attempts.")
 	flag.DurationVar(&haPaddingSeconds, "ha-padding-seconds", ha.DefaultPaddingSeconds, "Extra buffer a Standby waits before treating the Active Lease as stale.")
+	flag.IntVar(&haSyncWorkers, "ha-sync-workers", ha.DefaultSyncWorkers, "Number of workers draining the Standby's remote-mirror workqueue.")
 
 	flag.Parse()
 
@@ -313,17 +316,19 @@ func initialize(services *service.Services) {
 		os.Exit(1)
 	}
 	var remoteHAClient client.Client
+	var remoteHACfg *rest.Config
 	if haRunMode == ha.ModeStandby {
 		if haActiveKubeconfig == "" {
 			setupLog.Error(fmt.Errorf("missing --ha-active-kubeconfig"), "standby mode requires the Active hub kubeconfig")
 			os.Exit(1)
 		}
-		remoteCfg, cfgErr := clientcmd.BuildConfigFromFlags("", haActiveKubeconfig)
+		var cfgErr error
+		remoteHACfg, cfgErr = clientcmd.BuildConfigFromFlags("", haActiveKubeconfig)
 		if cfgErr != nil {
 			setupLog.Error(cfgErr, "unable to load Active hub kubeconfig", "path", haActiveKubeconfig)
 			os.Exit(1)
 		}
-		remoteHAClient, cfgErr = client.New(remoteCfg, client.Options{Scheme: scheme})
+		remoteHAClient, cfgErr = client.New(remoteHACfg, client.Options{Scheme: scheme})
 		if cfgErr != nil {
 			setupLog.Error(cfgErr, "unable to build remote client for Active hub")
 			os.Exit(1)
@@ -340,6 +345,19 @@ func initialize(services *service.Services) {
 		Log:            controllerLog.With("name", "ha"),
 	})
 	setupLog.Info("high availability configured", "mode", haRunMode, "identity", leaderElector.Identity())
+
+	// RemoteSyncer mirrors CRDMirrorSet from the Active hub onto this
+	// cluster; a no-op in any mode other than standby (issue #295). Reuses
+	// the same remote config and local client the elector above already
+	// built rather than loading the kubeconfig twice.
+	remoteSyncer, err := ha.NewRemoteSyncer(localHAClient, remoteHACfg, scheme, haRunMode, ha.RemoteSyncerOptions{
+		Workers: haSyncWorkers,
+		Log:     controllerLog.With("name", "ha-remote-syncer"),
+	})
+	if err != nil {
+		setupLog.Error(err, "unable to build HA remote syncer")
+		os.Exit(1)
+	}
 
 	// initialize controller with Project Kind
 	if err = (&controller.ProjectReconciler{
@@ -506,6 +524,11 @@ func initialize(services *service.Services) {
 		go func() {
 			if err := leaderElector.WatchRemoteLease(ctx); err != nil {
 				setupLog.Error(err, "HA remote lease watch loop exited")
+			}
+		}()
+		go func() {
+			if err := remoteSyncer.Start(ctx); err != nil {
+				setupLog.Error(err, "HA remote syncer exited")
 			}
 		}()
 	}

--- a/main.go
+++ b/main.go
@@ -355,6 +355,7 @@ func initialize(services *service.Services) {
 	remoteSyncer, err := ha.NewRemoteSyncer(localHAClient, remoteHACfg, scheme, haRunMode, ha.RemoteSyncerOptions{
 		Workers:       haSyncWorkers,
 		PruneInterval: haSyncInterval,
+		EventRecorder: eventRecorder,
 		Log:           controllerLog.With("name", "ha-remote-syncer"),
 	})
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -532,4 +532,6 @@ func initialize(services *service.Services) {
 
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings;roles;clusterroles,verbs=get;list;watch;create;update;patch;delete
 
-//+kubebuilder:rbac:groups="coordination.k8s.io",resources=leases,verbs=get;list;watch;create;update;patch;delete
+// NOTE: the HA leader-election Lease lives in the controller's own namespace and
+// reuses the existing leader-election Role's coordination.k8s.io/leases grant
+// (config/rbac/leader_election_role.yaml); no dedicated RBAC marker is needed.

--- a/main.go
+++ b/main.go
@@ -552,6 +552,7 @@ func initialize(services *service.Services) {
 
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create;update;patch;delete;escalate
+//+kubebuilder:rbac:groups="",resources=namespaces/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=create;get;list;watch;escalate;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;escalate;update;patch;create
 //+kubebuilder:rbac:groups="batch",resources=jobs,verbs=get;list;watch;create;update;patch;delete

--- a/main.go
+++ b/main.go
@@ -119,6 +119,7 @@ func initialize(services *service.Services) {
 	var haMode string
 	var haIdentity string
 	var haActiveKubeconfig string
+	var haLeaseNamespace string
 	var haLeaseDuration time.Duration
 	var haRenewDeadline time.Duration
 	var haRetryPeriod time.Duration
@@ -155,6 +156,7 @@ func initialize(services *service.Services) {
 	flag.StringVar(&haMode, "ha-mode", "standalone", `Cross-cluster HA mode: "active", "standby", or "standalone" (default).`)
 	flag.StringVar(&haIdentity, "ha-identity", "", "Stable per-cluster identity recorded in the Lease (defaults to the hostname).")
 	flag.StringVar(&haActiveKubeconfig, "ha-active-kubeconfig", "", "Path to the Active hub kubeconfig; required in standby mode.")
+	flag.StringVar(&haLeaseNamespace, "ha-lease-namespace", os.Getenv("KUBESLICE_CONTROLLER_MANAGER_NAMESPACE"), "Namespace for the HA Lease; defaults to the controller's own namespace (KUBESLICE_CONTROLLER_MANAGER_NAMESPACE), where the leader-election Role grants leases. Empty falls back to the pkg/ha default.")
 	flag.DurationVar(&haLeaseDuration, "ha-lease-duration", ha.DefaultLeaseDuration, "HA Lease duration.")
 	flag.DurationVar(&haRenewDeadline, "ha-renew-deadline", ha.DefaultRenewDeadline, "Deadline for the Active to renew its Lease before releasing leadership.")
 	flag.DurationVar(&haRetryPeriod, "ha-retry-period", ha.DefaultRetryPeriod, "Interval between Lease renew/watch attempts.")
@@ -330,6 +332,7 @@ func initialize(services *service.Services) {
 	leaderElector := ha.NewClusterLeaderElector(localHAClient, remoteHAClient, ha.Options{
 		Mode:           haRunMode,
 		Identity:       haIdentity,
+		LeaseNamespace: haLeaseNamespace,
 		LeaseDuration:  haLeaseDuration,
 		RenewDeadline:  haRenewDeadline,
 		RetryPeriod:    haRetryPeriod,

--- a/main.go
+++ b/main.go
@@ -353,6 +353,7 @@ func initialize(services *service.Services) {
 	// the same remote config and local client the elector above already
 	// built rather than loading the kubeconfig twice.
 	remoteSyncer, err := ha.NewRemoteSyncer(localHAClient, remoteHACfg, scheme, haRunMode, ha.RemoteSyncerOptions{
+		Resources:     ha.FullMirrorSet(),
 		Workers:       haSyncWorkers,
 		PruneInterval: haSyncInterval,
 		EventRecorder: eventRecorder,

--- a/pkg/ha/credential_set_test.go
+++ b/pkg/ha/credential_set_test.go
@@ -1,0 +1,253 @@
+/*
+ * 	Copyright (c) 2022 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+
+	"github.com/kubeslice/kubeslice-controller/util"
+)
+
+var (
+	nsGVK     = schema.GroupVersionKind{Version: "v1", Kind: "Namespace"}
+	secretGVK = schema.GroupVersionKind{Version: "v1", Kind: "Secret"}
+	saGVK     = schema.GroupVersionKind{Version: "v1", Kind: "ServiceAccount"}
+	roleGVK   = schema.GroupVersionKind{Group: groupRBAC, Version: "v1", Kind: "Role"}
+	rbGVK     = schema.GroupVersionKind{Group: groupRBAC, Version: "v1", Kind: "RoleBinding"}
+)
+
+// buildCredentialSyncer is buildSyncer's sibling for the credential set.
+func buildCredentialSyncer(t *testing.T, remote *stubRemote) *RemoteSyncer {
+	t.Helper()
+	byGVK := make(map[schema.GroupVersionKind]MirroredResource, len(CredentialMirrorSet))
+	for _, res := range CredentialMirrorSet {
+		byGVK[res.GVK] = res
+	}
+	return &RemoteSyncer{
+		mode:        ModeStandby,
+		localClient: fakeClient(t),
+		remoteGet:   remote.get,
+		resources:   CredentialMirrorSet,
+		byGVK:       byGVK,
+		workers:     1,
+		queue: workqueue.NewTypedRateLimitingQueue[syncKey](
+			workqueue.NewTypedItemExponentialFailureRateLimiter[syncKey](time.Millisecond, time.Second),
+		),
+		handlerRegistered: map[schema.GroupVersionKind]bool{},
+		enqueuedAt:        map[syncKey]time.Time{},
+		log:               testLog(),
+	}
+}
+
+// registerMirroredNamespace makes ns visible in the stub's Namespace view,
+// standing in for a project namespace the label-scoped remote cache mirrors.
+func registerMirroredNamespace(remote *stubRemote, ns string) {
+	key := syncKey{GVK: nsGVK, Name: ns}
+	remote.objects[key] = newTestUnstructured(nsGVK, "", ns)
+}
+
+func TestCredentialMirrorSet_ShapeAndDefenses(t *testing.T) {
+	var gvks []schema.GroupVersionKind
+	for _, res := range CredentialMirrorSet {
+		gvks = append(gvks, res.GVK)
+		assert.True(t, res.StripOwnerRefs,
+			"%s: UID-based ownerReferences never survive a cross-cluster copy, and credential objects are written by actors outside this repo — every row must strip them", res.GVK.Kind)
+		assert.True(t, res.RequireMirroredNamespace,
+			"%s: core types exist cluster-wide; every row must be gated on the mirrored-namespace boundary", res.GVK.Kind)
+	}
+	assert.ElementsMatch(t, []schema.GroupVersionKind{secretGVK, saGVK, roleGVK, rbGVK}, gvks,
+		"credential set is Secret/ServiceAccount/Role/RoleBinding only — access_control_service never creates ClusterRole/ClusterRoleBinding, despite the ADR's broader wording")
+}
+
+func TestSkipServiceAccountTokenSecret(t *testing.T) {
+	saToken := newTestUnstructured(secretGVK, "proj", "sa-token")
+	require.NoError(t, unstructured.SetNestedField(saToken.Object, string(corev1.SecretTypeServiceAccountToken), "type"))
+	assert.True(t, skipServiceAccountTokenSecret(saToken),
+		"SA tokens are signed by the issuing cluster's key and are invalid on the Standby")
+
+	opaque := newTestUnstructured(secretGVK, "proj", "gateway-cert")
+	require.NoError(t, unstructured.SetNestedField(opaque.Object, string(corev1.SecretTypeOpaque), "type"))
+	assert.False(t, skipServiceAccountTokenSecret(opaque))
+
+	untyped := newTestUnstructured(secretGVK, "proj", "no-type-field")
+	assert.False(t, skipServiceAccountTokenSecret(untyped))
+}
+
+func TestFullMirrorSet_CombinesBothSetsWithoutCollisions(t *testing.T) {
+	full := FullMirrorSet()
+	assert.Len(t, full, len(CRDMirrorSet)+len(CredentialMirrorSet))
+
+	seen := map[schema.GroupVersionKind]bool{}
+	for _, res := range full {
+		assert.False(t, seen[res.GVK], "duplicate mirror row for %s — byGVK keying would silently drop one", res.GVK)
+		seen[res.GVK] = true
+	}
+	assert.True(t, seen[nsGVK])
+	assert.True(t, seen[secretGVK])
+}
+
+func TestReconcileKey_MirrorsOpaqueSecretWithData(t *testing.T) {
+	ctx := context.Background()
+	key := syncKey{GVK: secretGVK, Namespace: "kubeslice-avesha", Name: "gateway-cert"}
+
+	src := newTestUnstructured(secretGVK, key.Namespace, key.Name)
+	require.NoError(t, unstructured.SetNestedField(src.Object, string(corev1.SecretTypeOpaque), "type"))
+	require.NoError(t, unstructured.SetNestedField(src.Object, "Y2VydC1kYXRh", "data", "ovpn.crt"))
+
+	remote := newStubRemote()
+	remote.objects[key] = src
+	registerMirroredNamespace(remote, key.Namespace)
+	s := buildCredentialSyncer(t, remote)
+
+	op, _, err := s.reconcileKey(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, opCreate, op)
+
+	got := getUnstructured(t, s.localClient, key)
+	assert.Equal(t, LabelValueActive, got.GetLabels()[LabelSyncedFromActive])
+	data, found, err := unstructured.NestedString(got.Object, "data", "ovpn.crt")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "Y2VydC1kYXRh", data, "the mirrored Secret must carry the source's data through unchanged")
+}
+
+func TestReconcileKey_SkipsServiceAccountTokenSecret(t *testing.T) {
+	ctx := context.Background()
+	key := syncKey{GVK: secretGVK, Namespace: "kubeslice-avesha", Name: "kubeslice-rbac-worker-w1"}
+
+	src := newTestUnstructured(secretGVK, key.Namespace, key.Name)
+	require.NoError(t, unstructured.SetNestedField(src.Object, string(corev1.SecretTypeServiceAccountToken), "type"))
+
+	remote := newStubRemote()
+	remote.objects[key] = src
+	registerMirroredNamespace(remote, key.Namespace)
+	s := buildCredentialSyncer(t, remote)
+
+	op, _, err := s.reconcileKey(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, mirrorOp(""), op)
+
+	existing := &unstructured.Unstructured{}
+	existing.SetGroupVersionKind(secretGVK)
+	err = s.localClient.Get(ctx, types.NamespacedName{Namespace: key.Namespace, Name: key.Name}, existing)
+	assert.Error(t, err, "an SA-token Secret must never be written onto the Standby")
+}
+
+// TestReconcileKey_SkipsCredentialsInUnmirroredNamespaces pins the boundary
+// that matters most: a namespace that is not label-mirrored is out of bounds
+// no matter what it is named. The concrete case that motivated this (found
+// live against a Helm-installed Active hub): under the chart's
+// --project-namespace-prefix ("kubeslice-"), the controller's own
+// kubeslice-controller namespace looks like a project namespace by name, and
+// a name-based rule would have mirrored its webhook TLS key and image-pull
+// Secrets onto the Standby.
+func TestReconcileKey_SkipsCredentialsInUnmirroredNamespaces(t *testing.T) {
+	ctx := context.Background()
+	for _, tc := range []struct {
+		gvk  schema.GroupVersionKind
+		ns   string
+		name string
+	}{
+		{secretGVK, "kubeslice-controller", "webhook-server-cert-secret"},
+		{secretGVK, "kube-system", "bootstrap-token"},
+		{saGVK, "kube-system", "hand-labeled-sa"},
+		{roleGVK, "default", "some-role"},
+		{rbGVK, "default", "some-rolebinding"},
+	} {
+		key := syncKey{GVK: tc.gvk, Namespace: tc.ns, Name: tc.name}
+		src := newTestUnstructured(tc.gvk, tc.ns, tc.name)
+		if tc.gvk == secretGVK {
+			require.NoError(t, unstructured.SetNestedField(src.Object, string(corev1.SecretTypeOpaque), "type"))
+		}
+
+		remote := newStubRemote()
+		remote.objects[key] = src // object visible, namespace deliberately NOT mirrored
+		s := buildCredentialSyncer(t, remote)
+
+		op, _, err := s.reconcileKey(ctx, key)
+		require.NoError(t, err)
+		assert.Equal(t, mirrorOp(""), op, "%s %s/%s: unmirrored namespace must mean skip", tc.gvk.Kind, tc.ns, tc.name)
+
+		existing := &unstructured.Unstructured{}
+		existing.SetGroupVersionKind(tc.gvk)
+		err = s.localClient.Get(ctx, types.NamespacedName{Namespace: tc.ns, Name: tc.name}, existing)
+		assert.Error(t, err, "%s %s/%s must not exist on the Standby", tc.gvk.Kind, tc.ns, tc.name)
+	}
+}
+
+func TestReconcileKey_NamespaceCheckErrorIsRetryable(t *testing.T) {
+	ctx := context.Background()
+	key := syncKey{GVK: secretGVK, Namespace: "kubeslice-avesha", Name: "gateway-cert"}
+
+	src := newTestUnstructured(secretGVK, key.Namespace, key.Name)
+	require.NoError(t, unstructured.SetNestedField(src.Object, string(corev1.SecretTypeOpaque), "type"))
+
+	remote := newStubRemote()
+	remote.objects[key] = src
+	remote.errs[syncKey{GVK: nsGVK, Name: key.Namespace}] = fmt.Errorf("simulated transient cache failure")
+	s := buildCredentialSyncer(t, remote)
+
+	_, _, err := s.reconcileKey(ctx, key)
+	assert.Error(t, err,
+		"a transient failure reading the namespace must surface as an error (workqueue retry), not as a silent skip")
+}
+
+func TestMirrorCacheByObject_ScopesCredentialInformers(t *testing.T) {
+	byObject := mirrorCacheByObject()
+
+	// The label-scoped types must match exactly what the controller stamps
+	// (via ReconcileProjectNamespace and util.GetOwnerLabel) and nothing else.
+	labeled := labels.Set(util.LabelsKubeSliceController)
+	for obj, cfg := range byObject {
+		if _, isSecret := obj.(*corev1.Secret); isSecret {
+			continue
+		}
+		require.NotNil(t, cfg.Label, "%T informer must be label-scoped", obj)
+		assert.True(t, cfg.Label.Matches(labeled), "%T: selector must match controller-stamped labels", obj)
+		assert.False(t, cfg.Label.Matches(labels.Set{}), "%T: selector must not match unlabeled objects", obj)
+	}
+
+	// Secret can't be label-scoped (cert Secrets come from the external
+	// cert-generator job, unlabeled) — it must be field-scoped to exclude
+	// SA-token Secrets at the watch itself.
+	var secretCfg cache.ByObject
+	ok := false
+	for obj, cfg := range byObject {
+		if _, isSecret := obj.(*corev1.Secret); isSecret {
+			secretCfg, ok = cfg, true
+		}
+	}
+	require.True(t, ok, "Secret informer must have a ByObject entry")
+	require.NotNil(t, secretCfg.Field)
+	assert.False(t, secretCfg.Field.Matches(fields.Set{"type": string(corev1.SecretTypeServiceAccountToken)}),
+		"the Secret watch itself must exclude SA-token Secrets")
+	assert.True(t, secretCfg.Field.Matches(fields.Set{"type": string(corev1.SecretTypeOpaque)}))
+}

--- a/pkg/ha/events_test.go
+++ b/pkg/ha/events_test.go
@@ -1,0 +1,153 @@
+/*
+ * 	Copyright (c) 2022 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/kubeslice/kubeslice-monitoring/pkg/events"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ossEvents "github.com/kubeslice/kubeslice-controller/events"
+)
+
+// syncFailedEvents lists the HAMirrorSyncFailed events currently on c, in
+// key.Namespace.
+func syncFailedEvents(t *testing.T, c client.Client, namespace string) []corev1.Event {
+	t.Helper()
+	list := &corev1.EventList{}
+	require.NoError(t, c.List(context.Background(), list, client.InNamespace(namespace)))
+	var out []corev1.Event
+	for _, ev := range list.Items {
+		if ev.Reason == string(ossEvents.EventHAMirrorSyncFailed) {
+			out = append(out, ev)
+		}
+	}
+	return out
+}
+
+func testEventRecorder(t *testing.T, c client.Client, eventsMap map[events.EventName]*events.EventSchema) events.EventRecorder {
+	t.Helper()
+	return events.NewEventRecorder(c, testScheme(t), eventsMap, events.EventRecorderOptions{
+		Version:   "v1alpha1",
+		Cluster:   "test-cluster",
+		Component: "controller",
+	})
+}
+
+func TestProcessOnce_EmitsHAMirrorSyncFailedOncePerFailureEpisode(t *testing.T) {
+	ctx := context.Background()
+	key := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "sc-1"}
+	remote := newStubRemote()
+	remote.errs[key] = fmt.Errorf("simulated transient read failure")
+
+	s := buildSyncer(t, remote)
+	eventsClient := fakeClient(t)
+	s.eventRecorder = testEventRecorder(t, eventsClient, ossEvents.EventsMap)
+
+	// First failure of the episode -> exactly one event.
+	s.queue.Add(key)
+	k, _ := s.queue.Get()
+	s.processOnce(ctx, k)
+
+	got := syncFailedEvents(t, eventsClient, key.Namespace)
+	require.Len(t, got, 1, "the first mirror failure must surface as a Kubernetes event")
+	assert.Equal(t, key.Name, got[0].InvolvedObject.Name, "the event must be attached to the object that failed to mirror")
+	assert.Equal(t, int32(1), got[0].Count)
+
+	// A retry failing within the same episode must not emit again — the
+	// recorder aggregates by Count, so an ungated second RecordEvent call
+	// would show up here as Count==2.
+	k, _ = s.queue.Get() // AddRateLimited's redelivery
+	s.processOnce(ctx, k)
+
+	got = syncFailedEvents(t, eventsClient, key.Namespace)
+	require.Len(t, got, 1)
+	assert.Equal(t, int32(1), got[0].Count, "retries within one failure episode must not re-emit the event")
+
+	// Recovery resets the episode (Forget zeroes NumRequeues)...
+	remote.mu.Lock()
+	delete(remote.errs, key)
+	remote.objects[key] = newTestUnstructured(testGVK, key.Namespace, key.Name)
+	remote.mu.Unlock()
+	k, _ = s.queue.Get()
+	s.processOnce(ctx, k)
+	require.Len(t, syncFailedEvents(t, eventsClient, key.Namespace), 1, "a successful sync must not emit a failure event")
+
+	// ...so a fresh failure afterwards is a new episode and emits again.
+	remote.mu.Lock()
+	remote.errs[key] = fmt.Errorf("simulated second outage")
+	remote.mu.Unlock()
+	s.queue.Add(key)
+	k, _ = s.queue.Get()
+	s.processOnce(ctx, k)
+
+	got = syncFailedEvents(t, eventsClient, key.Namespace)
+	require.Len(t, got, 1)
+	assert.Equal(t, int32(2), got[0].Count, "a new failure episode after recovery must emit again")
+}
+
+func TestProcessOnce_NoRecorderMeansNoEventButStillRetries(t *testing.T) {
+	ctx := context.Background()
+	key := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "sc-1"}
+	remote := newStubRemote()
+	remote.errs[key] = fmt.Errorf("simulated transient read failure")
+
+	s := buildSyncer(t, remote) // eventRecorder deliberately left nil
+	s.queue.Add(key)
+	k, _ := s.queue.Get()
+	s.processOnce(ctx, k)
+
+	// The nil recorder must not panic, and the retry contract is unchanged:
+	// the key comes back.
+	k, shutdown := s.queue.Get()
+	require.False(t, shutdown)
+	assert.Equal(t, key, k)
+}
+
+// TestHAMirrorSyncFailedEvent_RegisteredInGeneratedMap guards the
+// generate-events step this feature depends on: RecordEvent hard-fails for
+// any EventName missing from the generated EventsMap, so if the
+// config/events/controller.yaml entry (or the generated code) is ever
+// reverted, this fails in `go test` rather than silently no-opping at
+// runtime.
+func TestHAMirrorSyncFailedEvent_RegisteredInGeneratedMap(t *testing.T) {
+	ctx := context.Background()
+	require.Contains(t, ossEvents.EventsMap, ossEvents.EventHAMirrorSyncFailed,
+		"HAMirrorSyncFailed must be present in the generated EventsMap — re-run `make generate-events` if config/events/controller.yaml changed")
+
+	obj := newTestUnstructured(testGVK, "proj-a", "sc-1")
+	registered := testEventRecorder(t, fakeClient(t), ossEvents.EventsMap)
+	assert.NoError(t, registered.RecordEvent(ctx, &events.Event{
+		Object:            obj,
+		ReportingInstance: "controller",
+		Name:              ossEvents.EventHAMirrorSyncFailed,
+	}), "recording HAMirrorSyncFailed against the real generated EventsMap must succeed")
+
+	// And the failure mode being guarded against is loud, not silent:
+	unregistered := testEventRecorder(t, fakeClient(t), map[events.EventName]*events.EventSchema{})
+	assert.Error(t, unregistered.RecordEvent(ctx, &events.Event{
+		Object:            obj,
+		ReportingInstance: "controller",
+		Name:              ossEvents.EventHAMirrorSyncFailed,
+	}), "an EventName absent from EventsMap must error, proving a missing generated entry cannot no-op silently")
+}

--- a/pkg/ha/leader_elector.go
+++ b/pkg/ha/leader_elector.go
@@ -180,7 +180,7 @@ func (e *ClusterLeaderElector) StartLeaseRenewal(ctx context.Context) error {
 		case <-ctx.Done():
 			e.setLeader(false)
 			e.log.Infow("lease renewal stopped", "reason", ctx.Err())
-			return ctx.Err()
+			return nil
 		case <-ticker.C:
 			_ = e.renewOnce(ctx)
 		}
@@ -231,7 +231,7 @@ func (e *ClusterLeaderElector) WatchRemoteLease(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			e.log.Infow("remote lease watch stopped", "reason", ctx.Err())
-			return ctx.Err()
+			return nil
 		case <-ticker.C:
 			_, _ = e.checkRemoteLeaseOnce(ctx)
 		}

--- a/pkg/ha/leader_elector.go
+++ b/pkg/ha/leader_elector.go
@@ -1,0 +1,284 @@
+/*
+ * 	Copyright (c) 2022 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kubeslice/kubeslice-controller/util"
+)
+
+// Default Lease coordinates and timings. These mirror the ADR (#293) defaults
+// and are overridable through Options / controller flags.
+const (
+	DefaultLeaseName      = "kubeslice-controller-ha"
+	DefaultLeaseNamespace = "kubeslice-controller"
+	DefaultLeaseDuration  = 15 * time.Second
+	DefaultRenewDeadline  = 10 * time.Second
+	DefaultRetryPeriod    = 2 * time.Second
+	DefaultPaddingSeconds = 5 * time.Second
+)
+
+// Options configures a ClusterLeaderElector. Zero-valued fields fall back to the
+// Default* constants (or the OS hostname, for Identity).
+type Options struct {
+	Mode           HAMode
+	Identity       string
+	LeaseName      string
+	LeaseNamespace string
+	LeaseDuration  time.Duration
+	RenewDeadline  time.Duration
+	RetryPeriod    time.Duration
+	PaddingSeconds time.Duration
+	Log            *zap.SugaredLogger
+}
+
+// ClusterLeaderElector coordinates leadership between two hub clusters. Unlike
+// controller-runtime's in-cluster --leader-elect (which coordinates pods sharing
+// one API server), a Standby elector reads the Active's Lease across a cluster
+// boundary through remoteClient. See ADR #293.
+type ClusterLeaderElector struct {
+	localClient  client.Client // own cluster — create and renew the Lease
+	remoteClient client.Client // Standby only — read the Active's Lease (may be nil otherwise)
+
+	mode      HAMode
+	identity  string
+	leaseName string
+	leaseNS   string
+
+	leaseDuration time.Duration
+	renewDeadline time.Duration
+	retryPeriod   time.Duration
+	padding       time.Duration
+
+	// isLeader is the single source of truth read by IsLeader(). The background
+	// renewal loop keeps it current, so readers never touch the API server.
+	isLeader atomic.Bool
+	// lastRenew is the time of the last successful Lease renewal. Only the
+	// renewal goroutine reads and writes it.
+	lastRenew time.Time
+
+	log *zap.SugaredLogger
+}
+
+// NewClusterLeaderElector builds an elector. local is a client to this
+// controller's own cluster; remote is a client to the Active hub and is required
+// only in Standby mode (it may be nil otherwise).
+//
+// Note: issue #294 sketches a three-argument constructor, but the ADR lists the
+// Lease timings as configurable, so configuration is passed through Options.
+func NewClusterLeaderElector(local, remote client.Client, opts Options) *ClusterLeaderElector {
+	if opts.Mode == "" {
+		opts.Mode = ModeStandalone
+	}
+	if opts.LeaseName == "" {
+		opts.LeaseName = DefaultLeaseName
+	}
+	if opts.LeaseNamespace == "" {
+		opts.LeaseNamespace = DefaultLeaseNamespace
+	}
+	if opts.LeaseDuration == 0 {
+		opts.LeaseDuration = DefaultLeaseDuration
+	}
+	if opts.RenewDeadline == 0 {
+		opts.RenewDeadline = DefaultRenewDeadline
+	}
+	if opts.RetryPeriod == 0 {
+		opts.RetryPeriod = DefaultRetryPeriod
+	}
+	if opts.PaddingSeconds == 0 {
+		opts.PaddingSeconds = DefaultPaddingSeconds
+	}
+	if opts.Identity == "" {
+		if hostname, err := os.Hostname(); err == nil {
+			opts.Identity = hostname
+		} else {
+			opts.Identity = "kubeslice-controller"
+		}
+	}
+	if opts.Log == nil {
+		opts.Log = util.NewLogger().With("name", "ha-leader-elector")
+	}
+
+	e := &ClusterLeaderElector{
+		localClient:   local,
+		remoteClient:  remote,
+		mode:          opts.Mode,
+		identity:      opts.Identity,
+		leaseName:     opts.LeaseName,
+		leaseNS:       opts.LeaseNamespace,
+		leaseDuration: opts.LeaseDuration,
+		renewDeadline: opts.RenewDeadline,
+		retryPeriod:   opts.RetryPeriod,
+		padding:       opts.PaddingSeconds,
+		log:           opts.Log,
+	}
+	// Standalone is always the leader: no Lease, no remote watch — identical to
+	// the controller's behaviour before HA (the no-regression guarantee).
+	if e.mode == ModeStandalone {
+		e.isLeader.Store(true)
+	}
+	return e
+}
+
+// IsLeader reports whether this controller may perform mutating reconciles right
+// now. It reads an in-memory flag kept current by the background loops, so it is
+// cheap enough to call at the top of every Reconcile. The value reflects live
+// leadership (refreshed every retryPeriod), never a value frozen at startup.
+func (e *ClusterLeaderElector) IsLeader() bool {
+	return e.isLeader.Load()
+}
+
+// Mode returns the configured HA mode.
+func (e *ClusterLeaderElector) Mode() HAMode {
+	return e.mode
+}
+
+// Identity returns this instance's Lease holder identity.
+func (e *ClusterLeaderElector) Identity() string {
+	return e.identity
+}
+
+// StartLeaseRenewal runs the Active's renewal loop until ctx is cancelled. It is
+// a no-op in any other mode. It renews immediately, then every retryPeriod.
+func (e *ClusterLeaderElector) StartLeaseRenewal(ctx context.Context) error {
+	if e.mode != ModeActive {
+		e.log.Infow("lease renewal not started; not in active mode", "mode", e.mode)
+		return nil
+	}
+	e.log.Infow("starting lease renewal",
+		"lease", e.leaseName, "namespace", e.leaseNS, "identity", e.identity,
+		"leaseDuration", e.leaseDuration, "renewDeadline", e.renewDeadline, "retryPeriod", e.retryPeriod)
+
+	_ = e.renewOnce(ctx)
+	ticker := time.NewTicker(e.retryPeriod)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			e.setLeader(false)
+			e.log.Infow("lease renewal stopped", "reason", ctx.Err())
+			return ctx.Err()
+		case <-ticker.C:
+			_ = e.renewOnce(ctx)
+		}
+	}
+}
+
+// renewOnce performs a single acquire/renew attempt and updates leadership state.
+// On success it (re)acquires leadership. On failure it keeps leadership until
+// renewDeadline elapses without any successful renewal, then releases it — the
+// natural-fencing behaviour from the ADR: a dead API server means no renewal and
+// therefore no writes.
+func (e *ClusterLeaderElector) renewOnce(ctx context.Context) error {
+	if _, err := acquireOrRenewLease(ctx, e.localClient, e.leaseName, e.leaseNS, e.identity, e.leaseDuration); err != nil {
+		switch {
+		case e.lastRenew.IsZero():
+			e.log.Warnw("failed to acquire lease", "error", err)
+		case time.Since(e.lastRenew) > e.renewDeadline:
+			e.log.Warnw("failed to renew lease within renew deadline; releasing leadership",
+				"error", err, "renewDeadline", e.renewDeadline, "sinceLastRenew", time.Since(e.lastRenew))
+			e.setLeader(false)
+		default:
+			e.log.Warnw("failed to renew lease; still within renew deadline, keeping leadership", "error", err)
+		}
+		return err
+	}
+	e.lastRenew = time.Now()
+	e.setLeader(true)
+	return nil
+}
+
+// WatchRemoteLease runs the Standby's watch loop until ctx is cancelled. It reads
+// the Active's Lease every retryPeriod and logs whether it is fresh or stale. In
+// issue #294 it does not promote — detecting staleness and acquiring leadership
+// is issue #297.
+func (e *ClusterLeaderElector) WatchRemoteLease(ctx context.Context) error {
+	if e.mode != ModeStandby {
+		e.log.Infow("remote lease watch not started; not in standby mode", "mode", e.mode)
+		return nil
+	}
+	if e.remoteClient == nil {
+		return fmt.Errorf("standby mode requires a remote client to the active hub")
+	}
+	e.log.Infow("watching active hub lease", "lease", e.leaseName, "namespace", e.leaseNS)
+
+	ticker := time.NewTicker(e.retryPeriod)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			e.log.Infow("remote lease watch stopped", "reason", ctx.Err())
+			return ctx.Err()
+		case <-ticker.C:
+			_, _ = e.checkRemoteLeaseOnce(ctx)
+		}
+	}
+}
+
+// checkRemoteLeaseOnce reads the Active's Lease once and reports whether it is
+// stale. It never changes leadership in issue #294: a Standby stays a Standby.
+func (e *ClusterLeaderElector) checkRemoteLeaseOnce(ctx context.Context) (stale bool, err error) {
+	lease, err := getLease(ctx, e.remoteClient, e.leaseName, e.leaseNS)
+	if err != nil {
+		e.log.Warnw("could not read active hub lease", "error", err)
+		return false, err
+	}
+	if isLeaseStale(lease, e.padding, time.Now()) {
+		e.log.Warnw("active hub lease is STALE; promotion would trigger here (implemented in #297)",
+			"lease", e.leaseName, "holder", leaseHolder(lease), "renewTime", leaseRenewStr(lease))
+		return true, nil
+	}
+	e.log.Debugw("active hub lease is fresh",
+		"lease", e.leaseName, "holder", leaseHolder(lease), "renewTime", leaseRenewStr(lease))
+	return false, nil
+}
+
+// setLeader updates the leadership flag and logs LeadershipAcquired /
+// LeadershipLost only on an actual transition.
+func (e *ClusterLeaderElector) setLeader(leader bool) {
+	if e.isLeader.Swap(leader) == leader {
+		return
+	}
+	if leader {
+		e.log.Infow("LeadershipAcquired", "identity", e.identity, "lease", e.leaseName)
+	} else {
+		e.log.Infow("LeadershipLost", "identity", e.identity, "lease", e.leaseName)
+	}
+}
+
+func leaseHolder(lease *coordinationv1.Lease) string {
+	if lease == nil || lease.Spec.HolderIdentity == nil {
+		return ""
+	}
+	return *lease.Spec.HolderIdentity
+}
+
+func leaseRenewStr(lease *coordinationv1.Lease) string {
+	if lease == nil || lease.Spec.RenewTime == nil {
+		return ""
+	}
+	return lease.Spec.RenewTime.String()
+}

--- a/pkg/ha/leader_elector.go
+++ b/pkg/ha/leader_elector.go
@@ -42,11 +42,18 @@ const (
 )
 
 // Options configures a ClusterLeaderElector. Zero-valued fields fall back to the
-// Default* constants (or the OS hostname, for Identity).
+// Default* constants (or the OS hostname, for Identity; the downward-API
+// KUBESLICE_CONTROLLER_MANAGER_NAMESPACE env var, for LeaseNamespace).
 type Options struct {
-	Mode           HAMode
-	Identity       string
-	LeaseName      string
+	Mode      HAMode
+	Identity  string
+	LeaseName string
+	// LeaseNamespace, if empty, defaults to KUBESLICE_CONTROLLER_MANAGER_NAMESPACE
+	// (the controller's own namespace, injected via the downward API) so the
+	// Lease always lands where the leader-election Role grants access to it,
+	// regardless of which namespace the controller is actually deployed into.
+	// Only falls back to DefaultLeaseNamespace when that env var is unset too
+	// (e.g. running outside a pod).
 	LeaseNamespace string
 	LeaseDuration  time.Duration
 	RenewDeadline  time.Duration
@@ -97,7 +104,11 @@ func NewClusterLeaderElector(local, remote client.Client, opts Options) *Cluster
 		opts.LeaseName = DefaultLeaseName
 	}
 	if opts.LeaseNamespace == "" {
-		opts.LeaseNamespace = DefaultLeaseNamespace
+		if ns := os.Getenv("KUBESLICE_CONTROLLER_MANAGER_NAMESPACE"); ns != "" {
+			opts.LeaseNamespace = ns
+		} else {
+			opts.LeaseNamespace = DefaultLeaseNamespace
+		}
 	}
 	if opts.LeaseDuration == 0 {
 		opts.LeaseDuration = DefaultLeaseDuration

--- a/pkg/ha/leader_elector_test.go
+++ b/pkg/ha/leader_elector_test.go
@@ -1,0 +1,80 @@
+/*
+ * 	Copyright (c) 2022 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClusterLeaderElector_StandaloneIsAlwaysLeader(t *testing.T) {
+	e := NewClusterLeaderElector(fakeClient(t), nil, Options{Mode: ModeStandalone, Log: testLog()})
+	assert.True(t, e.IsLeader(), "standalone must be leader")
+	assert.Equal(t, ModeStandalone, e.Mode())
+}
+
+func TestNewClusterLeaderElector_DefaultsToStandalone(t *testing.T) {
+	e := NewClusterLeaderElector(fakeClient(t), nil, Options{Log: testLog()})
+	assert.Equal(t, ModeStandalone, e.Mode(), "empty mode must default to standalone (no regression)")
+	assert.True(t, e.IsLeader())
+}
+
+func TestActive_BecomesLeaderAfterRenew(t *testing.T) {
+	e := NewClusterLeaderElector(fakeClient(t), nil, Options{Mode: ModeActive, Log: testLog()})
+	assert.False(t, e.IsLeader(), "active is not leader until it renews")
+	require.NoError(t, e.renewOnce(context.Background()))
+	assert.True(t, e.IsLeader(), "active should hold leadership after a successful renew")
+}
+
+func TestActive_LosesLeadershipAfterRenewDeadline(t *testing.T) {
+	e := NewClusterLeaderElector(failingWriteClient(t), nil, Options{
+		Mode:          ModeActive,
+		RenewDeadline: 10 * time.Millisecond,
+		Log:           testLog(),
+	})
+	// Simulate having been the leader, with the last successful renew well past
+	// the renew deadline.
+	e.isLeader.Store(true)
+	e.lastRenew = time.Now().Add(-time.Hour)
+
+	err := e.renewOnce(context.Background())
+	require.Error(t, err)
+	assert.False(t, e.IsLeader(), "leadership must drop once renewDeadline is exceeded (natural fencing)")
+}
+
+func TestStandby_NeverLeaderEvenWhenLeaseStale(t *testing.T) {
+	// A fresh lease on the remote: the standby stays a standby.
+	freshRemote := fakeClient(t, newLease(DefaultLeaseName, DefaultLeaseNamespace, "hub-a", time.Now()))
+	e := NewClusterLeaderElector(fakeClient(t), freshRemote, Options{Mode: ModeStandby, Log: testLog()})
+	assert.False(t, e.IsLeader())
+	stale, err := e.checkRemoteLeaseOnce(context.Background())
+	require.NoError(t, err)
+	assert.False(t, stale)
+	assert.False(t, e.IsLeader())
+
+	// A stale lease on the remote: #294 detects staleness but must NOT promote.
+	staleRemote := fakeClient(t, newLease(DefaultLeaseName, DefaultLeaseNamespace, "hub-a", time.Now().Add(-time.Hour)))
+	e2 := NewClusterLeaderElector(fakeClient(t), staleRemote, Options{Mode: ModeStandby, Log: testLog()})
+	stale2, err := e2.checkRemoteLeaseOnce(context.Background())
+	require.NoError(t, err)
+	assert.True(t, stale2, "old renewTime should read as stale")
+	assert.False(t, e2.IsLeader(), "standby must not promote in #294 (promotion is #297)")
+}

--- a/pkg/ha/leader_elector_test.go
+++ b/pkg/ha/leader_elector_test.go
@@ -37,6 +37,20 @@ func TestNewClusterLeaderElector_DefaultsToStandalone(t *testing.T) {
 	assert.True(t, e.IsLeader())
 }
 
+func TestNewClusterLeaderElector_LeaseNamespacePrefersDownwardAPIEnvVar(t *testing.T) {
+	t.Setenv("KUBESLICE_CONTROLLER_MANAGER_NAMESPACE", "kubeslice-avesha")
+	e := NewClusterLeaderElector(fakeClient(t), nil, Options{Log: testLog()})
+	assert.Equal(t, "kubeslice-avesha", e.leaseNS,
+		"an empty LeaseNamespace must prefer the controller's own runtime namespace over the hard-coded default")
+}
+
+func TestNewClusterLeaderElector_LeaseNamespaceFallsBackWhenEnvVarUnset(t *testing.T) {
+	t.Setenv("KUBESLICE_CONTROLLER_MANAGER_NAMESPACE", "")
+	e := NewClusterLeaderElector(fakeClient(t), nil, Options{Log: testLog()})
+	assert.Equal(t, DefaultLeaseNamespace, e.leaseNS,
+		"with no env var and no explicit Options.LeaseNamespace, must fall back to DefaultLeaseNamespace")
+}
+
 func TestActive_BecomesLeaderAfterRenew(t *testing.T) {
 	e := NewClusterLeaderElector(fakeClient(t), nil, Options{Mode: ModeActive, Log: testLog()})
 	assert.False(t, e.IsLeader(), "active is not leader until it renews")

--- a/pkg/ha/leader_elector_test.go
+++ b/pkg/ha/leader_elector_test.go
@@ -23,6 +23,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestNewClusterLeaderElector_StandaloneIsAlwaysLeader(t *testing.T) {
@@ -91,4 +94,114 @@ func TestStandby_NeverLeaderEvenWhenLeaseStale(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, stale2, "old renewTime should read as stale")
 	assert.False(t, e2.IsLeader(), "standby must not promote in #294 (promotion is #297)")
+}
+
+func TestCheckRemoteLeaseOnce_PropagatesGetError(t *testing.T) {
+	remote := fakeClient(t) // the Active's lease is not present on the remote
+	e := NewClusterLeaderElector(fakeClient(t), remote, Options{Mode: ModeStandby, Log: testLog()})
+
+	stale, err := e.checkRemoteLeaseOnce(context.Background())
+	require.Error(t, err, "a missing remote lease must surface as an error, not silently report fresh")
+	assert.False(t, stale)
+}
+
+func TestRenewOnce_KeepsLeadershipWithinRenewDeadline(t *testing.T) {
+	e := NewClusterLeaderElector(failingWriteClient(t), nil, Options{
+		Mode:          ModeActive,
+		RenewDeadline: time.Hour,
+		Log:           testLog(),
+	})
+	e.isLeader.Store(true)
+	e.lastRenew = time.Now() // just renewed, well within the deadline
+
+	err := e.renewOnce(context.Background())
+	require.Error(t, err, "a failed renew attempt must still surface an error to the caller")
+	assert.True(t, e.IsLeader(), "leadership must be kept while still within renewDeadline (transient failure)")
+}
+
+func TestSetLeader_LogsOnlyOnTransition(t *testing.T) {
+	core, logs := observer.New(zapcore.InfoLevel)
+	log := zap.New(core).Sugar()
+
+	e := NewClusterLeaderElector(fakeClient(t), nil, Options{Mode: ModeActive, Identity: "hub-a", Log: log})
+
+	e.setLeader(true)
+	e.setLeader(true) // no transition; must not log again
+	e.setLeader(false)
+	e.setLeader(false) // no transition; must not log again
+
+	assert.Equal(t, 1, logs.FilterMessage("LeadershipAcquired").Len(),
+		"LeadershipAcquired must be logged exactly once per actual transition")
+	assert.Equal(t, 1, logs.FilterMessage("LeadershipLost").Len(),
+		"LeadershipLost must be logged exactly once per actual transition")
+}
+
+func TestStartLeaseRenewal_NoopWhenNotActive(t *testing.T) {
+	for _, mode := range []HAMode{ModeStandby, ModeStandalone} {
+		e := NewClusterLeaderElector(fakeClient(t), fakeClient(t), Options{Mode: mode, Log: testLog()})
+		err := e.StartLeaseRenewal(context.Background())
+		assert.NoError(t, err, "StartLeaseRenewal must be a no-op outside active mode")
+	}
+}
+
+func TestStartLeaseRenewal_ReturnsNilOnContextCancellation(t *testing.T) {
+	e := NewClusterLeaderElector(fakeClient(t), nil, Options{
+		Mode:        ModeActive,
+		RetryPeriod: 20 * time.Millisecond,
+		Log:         testLog(),
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- e.StartLeaseRenewal(ctx) }()
+
+	require.Eventually(t, e.IsLeader, time.Second, 5*time.Millisecond,
+		"elector should acquire leadership before shutdown")
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		assert.NoError(t, err, "a graceful shutdown (context cancellation) must not be reported as an error")
+	case <-time.After(time.Second):
+		t.Fatal("StartLeaseRenewal did not return after context cancellation")
+	}
+	assert.False(t, e.IsLeader(), "leadership must be released on shutdown")
+}
+
+func TestWatchRemoteLease_NoopWhenNotStandby(t *testing.T) {
+	for _, mode := range []HAMode{ModeActive, ModeStandalone} {
+		e := NewClusterLeaderElector(fakeClient(t), nil, Options{Mode: mode, Log: testLog()})
+		err := e.WatchRemoteLease(context.Background())
+		assert.NoError(t, err, "WatchRemoteLease must be a no-op outside standby mode")
+	}
+}
+
+func TestWatchRemoteLease_RequiresRemoteClientInStandbyMode(t *testing.T) {
+	e := NewClusterLeaderElector(fakeClient(t), nil, Options{Mode: ModeStandby, Log: testLog()})
+	err := e.WatchRemoteLease(context.Background())
+	assert.Error(t, err, "standby mode without a remote client must fail fast instead of watching nothing")
+}
+
+func TestWatchRemoteLease_ReturnsNilOnContextCancellation(t *testing.T) {
+	remote := fakeClient(t, newLease(DefaultLeaseName, DefaultLeaseNamespace, "hub-a", time.Now()))
+	e := NewClusterLeaderElector(fakeClient(t), remote, Options{
+		Mode:        ModeStandby,
+		RetryPeriod: 20 * time.Millisecond,
+		Log:         testLog(),
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- e.WatchRemoteLease(ctx) }()
+
+	time.Sleep(50 * time.Millisecond) // let at least one watch tick fire
+	cancel()
+
+	select {
+	case err := <-errCh:
+		assert.NoError(t, err, "a graceful shutdown (context cancellation) must not be reported as an error")
+	case <-time.After(time.Second):
+		t.Fatal("WatchRemoteLease did not return after context cancellation")
+	}
 }

--- a/pkg/ha/lease.go
+++ b/pkg/ha/lease.go
@@ -33,7 +33,13 @@ import (
 // It is used by the Active's renewal loop (StartLeaseRenewal → renewOnce).
 func acquireOrRenewLease(ctx context.Context, c client.Client, name, namespace, identity string, leaseDuration time.Duration) (*coordinationv1.Lease, error) {
 	now := metav1.NewMicroTime(time.Now())
-	durationSeconds := int32(leaseDuration / time.Second)
+	// Round up to whole seconds and enforce a minimum of 1s. LeaseDurationSeconds
+	// is an int32 count of seconds, so a sub-second duration must not truncate to
+	// 0 (an invalid lease duration that also skews staleness checks).
+	durationSeconds := int32((leaseDuration + time.Second - 1) / time.Second)
+	if durationSeconds < 1 {
+		durationSeconds = 1
+	}
 
 	lease := &coordinationv1.Lease{}
 	err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, lease)

--- a/pkg/ha/lease.go
+++ b/pkg/ha/lease.go
@@ -1,0 +1,106 @@
+/*
+ * 	Copyright (c) 2022 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"context"
+	"time"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// acquireOrRenewLease ensures a Lease named name/namespace exists, is held by
+// identity, and has its renewTime stamped to now. It creates the Lease if it is
+// missing and increments leaseTransitions whenever leadership changes hands.
+// It is used by the Active's renewal loop (StartLeaseRenewal → renewOnce).
+func acquireOrRenewLease(ctx context.Context, c client.Client, name, namespace, identity string, leaseDuration time.Duration) (*coordinationv1.Lease, error) {
+	now := metav1.NewMicroTime(time.Now())
+	durationSeconds := int32(leaseDuration / time.Second)
+
+	lease := &coordinationv1.Lease{}
+	err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, lease)
+	if apierrors.IsNotFound(err) {
+		transitions := int32(0)
+		lease = &coordinationv1.Lease{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+			Spec: coordinationv1.LeaseSpec{
+				HolderIdentity:       &identity,
+				LeaseDurationSeconds: &durationSeconds,
+				AcquireTime:          &now,
+				RenewTime:            &now,
+				LeaseTransitions:     &transitions,
+			},
+		}
+		if err := c.Create(ctx, lease); err != nil {
+			return nil, err
+		}
+		return lease, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// The Lease exists. If it was held by someone else (or no one), record a
+	// transition and a fresh acquireTime; otherwise simply renew it.
+	if lease.Spec.HolderIdentity == nil || *lease.Spec.HolderIdentity != identity {
+		transitions := int32(1)
+		if lease.Spec.LeaseTransitions != nil {
+			transitions = *lease.Spec.LeaseTransitions + 1
+		}
+		lease.Spec.HolderIdentity = &identity
+		lease.Spec.AcquireTime = &now
+		lease.Spec.LeaseTransitions = &transitions
+	}
+	lease.Spec.LeaseDurationSeconds = &durationSeconds
+	lease.Spec.RenewTime = &now
+	if err := c.Update(ctx, lease); err != nil {
+		return nil, err
+	}
+	return lease, nil
+}
+
+// getLease fetches a Lease. The Standby uses this to read the Active's Lease over
+// the remote client (WatchRemoteLease → checkRemoteLeaseOnce).
+func getLease(ctx context.Context, c client.Client, name, namespace string) (*coordinationv1.Lease, error) {
+	lease := &coordinationv1.Lease{}
+	if err := c.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, lease); err != nil {
+		return nil, err
+	}
+	return lease, nil
+}
+
+// isLeaseStale reports whether the lease's renewTime is older than
+// leaseDuration + padding relative to now. A nil lease or a missing renewTime is
+// treated as stale: the holder has never checked in.
+func isLeaseStale(lease *coordinationv1.Lease, padding time.Duration, now time.Time) bool {
+	if lease == nil || lease.Spec.RenewTime == nil {
+		return true
+	}
+	leaseDuration := time.Duration(0)
+	if lease.Spec.LeaseDurationSeconds != nil {
+		leaseDuration = time.Duration(*lease.Spec.LeaseDurationSeconds) * time.Second
+	}
+	deadline := lease.Spec.RenewTime.Time.Add(leaseDuration + padding)
+	return now.After(deadline)
+}

--- a/pkg/ha/lease_test.go
+++ b/pkg/ha/lease_test.go
@@ -144,3 +144,9 @@ func TestAcquireOrRenewLease_SubSecondDurationClampsToOne(t *testing.T) {
 	assert.Equal(t, int32(1), *lease.Spec.LeaseDurationSeconds,
 		"a sub-second duration must clamp to 1s, not truncate to 0")
 }
+
+func TestGetLease_NotFoundReturnsError(t *testing.T) {
+	c := fakeClient(t)
+	_, err := getLease(context.Background(), c, "missing", "ns")
+	assert.Error(t, err, "a missing lease must surface as an error, not a nil/zero value")
+}

--- a/pkg/ha/lease_test.go
+++ b/pkg/ha/lease_test.go
@@ -133,3 +133,14 @@ func TestAcquireOrRenewLease_TakeoverBumpsTransitions(t *testing.T) {
 	require.NotNil(t, lease.Spec.LeaseTransitions)
 	assert.Equal(t, int32(1), *lease.Spec.LeaseTransitions, "takeover should increment transitions")
 }
+
+func TestAcquireOrRenewLease_SubSecondDurationClampsToOne(t *testing.T) {
+	ctx := context.Background()
+	c := fakeClient(t)
+
+	lease, err := acquireOrRenewLease(ctx, c, "l", "ns", "hub-a", 500*time.Millisecond)
+	require.NoError(t, err)
+	require.NotNil(t, lease.Spec.LeaseDurationSeconds)
+	assert.Equal(t, int32(1), *lease.Spec.LeaseDurationSeconds,
+		"a sub-second duration must clamp to 1s, not truncate to 0")
+}

--- a/pkg/ha/lease_test.go
+++ b/pkg/ha/lease_test.go
@@ -1,0 +1,135 @@
+/*
+ * 	Copyright (c) 2022 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+// ---- shared test helpers, used across the ha package tests ----
+
+func testScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	return scheme
+}
+
+func fakeClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	return fake.NewClientBuilder().WithScheme(testScheme(t)).WithObjects(objs...).Build()
+}
+
+// failingWriteClient returns a client whose Create and Update always error,
+// simulating an unreachable API server (used to exercise natural fencing).
+func failingWriteClient(t *testing.T) client.Client {
+	t.Helper()
+	return fake.NewClientBuilder().WithScheme(testScheme(t)).WithInterceptorFuncs(interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			return fmt.Errorf("simulated API server down")
+		},
+		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			return fmt.Errorf("simulated API server down")
+		},
+	}).Build()
+}
+
+func testLog() *zap.SugaredLogger {
+	return zap.NewNop().Sugar()
+}
+
+func int32Ptr(i int32) *int32 { return &i }
+
+func microTimePtr(tm time.Time) *metav1.MicroTime {
+	m := metav1.NewMicroTime(tm)
+	return &m
+}
+
+func newLease(name, namespace, holder string, renew time.Time) *coordinationv1.Lease {
+	return &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: coordinationv1.LeaseSpec{
+			HolderIdentity:       &holder,
+			LeaseDurationSeconds: int32Ptr(15),
+			RenewTime:            microTimePtr(renew),
+		},
+	}
+}
+
+// ---- tests ----
+
+func TestIsLeaseStale(t *testing.T) {
+	now := time.Now()
+	padding := 5 * time.Second
+
+	fresh := newLease("l", "ns", "hub-a", now.Add(-2*time.Second))
+	stale := newLease("l", "ns", "hub-a", now.Add(-60*time.Second))
+	noRenew := &coordinationv1.Lease{Spec: coordinationv1.LeaseSpec{LeaseDurationSeconds: int32Ptr(15)}}
+
+	assert.False(t, isLeaseStale(fresh, padding, now), "fresh lease should not be stale")
+	assert.True(t, isLeaseStale(stale, padding, now), "old renewTime should be stale")
+	assert.True(t, isLeaseStale(noRenew, padding, now), "missing renewTime should be stale")
+	assert.True(t, isLeaseStale(nil, padding, now), "nil lease should be stale")
+}
+
+func TestAcquireOrRenewLease_CreatesThenRenews(t *testing.T) {
+	ctx := context.Background()
+	c := fakeClient(t)
+
+	lease, err := acquireOrRenewLease(ctx, c, "l", "ns", "hub-a", 15*time.Second)
+	require.NoError(t, err)
+	require.NotNil(t, lease.Spec.HolderIdentity)
+	assert.Equal(t, "hub-a", *lease.Spec.HolderIdentity)
+	require.NotNil(t, lease.Spec.RenewTime)
+	require.NotNil(t, lease.Spec.LeaseTransitions)
+	assert.Equal(t, int32(0), *lease.Spec.LeaseTransitions)
+	firstRenew := lease.Spec.RenewTime.Time
+
+	time.Sleep(2 * time.Millisecond)
+	lease2, err := acquireOrRenewLease(ctx, c, "l", "ns", "hub-a", 15*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, "hub-a", *lease2.Spec.HolderIdentity)
+	assert.False(t, lease2.Spec.RenewTime.Time.Before(firstRenew), "renewTime should not move backwards")
+	assert.Equal(t, int32(0), *lease2.Spec.LeaseTransitions, "same holder should not bump transitions")
+}
+
+func TestAcquireOrRenewLease_TakeoverBumpsTransitions(t *testing.T) {
+	ctx := context.Background()
+	existing := newLease("l", "ns", "hub-a", time.Now().Add(-time.Hour))
+	existing.Spec.LeaseTransitions = int32Ptr(0)
+	c := fakeClient(t, existing)
+
+	lease, err := acquireOrRenewLease(ctx, c, "l", "ns", "hub-b", 15*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, "hub-b", *lease.Spec.HolderIdentity)
+	require.NotNil(t, lease.Spec.LeaseTransitions)
+	assert.Equal(t, int32(1), *lease.Spec.LeaseTransitions, "takeover should increment transitions")
+}

--- a/pkg/ha/metrics.go
+++ b/pkg/ha/metrics.go
@@ -1,0 +1,53 @@
+/*
+ * 	Copyright (c) 2022 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// haSyncLagSeconds and haSyncErrorsTotal are RemoteSyncer's mirror-pipeline
+// metrics. Registered here via prometheus.MustRegister, the same self-
+// registration idiom metrics/prometheus.go already uses for
+// KubeSliceEventsCounter, rather than routed through
+// metrics.StartMetricsCollector (whose default labels are slice-specific and
+// don't apply to a cross-cluster mirror).
+var (
+	// haSyncLagSeconds observes, per kind and operation, how far behind the
+	// mirror is: time.Now() minus the source object's CreationTimestamp for
+	// creates, or minus the time the object was first enqueued for
+	// update/delete (the more useful number to alert on once a retry has
+	// backed off a few times — it reflects total time since the triggering
+	// change, not just the last dequeue).
+	haSyncLagSeconds = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "kubeslice_controller",
+		Name:      "ha_sync_lag_seconds",
+		Help:      "Time between a change on the Active hub and it being reflected on the Standby.",
+		Buckets:   prometheus.DefBuckets,
+	}, []string{"kind", "operation"})
+
+	// haSyncErrorsTotal counts mirror failures. The syncer keeps running and
+	// retries via its workqueue on every increment — this metric never
+	// indicates a crash, only a retry in progress.
+	haSyncErrorsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "kubeslice_controller",
+		Name:      "ha_sync_errors_total",
+		Help:      "Count of mirror sync failures, by kind and operation.",
+	}, []string{"kind", "operation"})
+)
+
+func init() {
+	prometheus.MustRegister(haSyncLagSeconds, haSyncErrorsTotal)
+}

--- a/pkg/ha/metrics_test.go
+++ b/pkg/ha/metrics_test.go
@@ -1,0 +1,36 @@
+/*
+ * 	Copyright (c) 2022 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHASyncMetrics_RecordAndLabel(t *testing.T) {
+	haSyncLagSeconds.Reset()
+	haSyncErrorsTotal.Reset()
+
+	haSyncLagSeconds.WithLabelValues("SliceConfig", "create").Observe(0.5)
+	haSyncErrorsTotal.WithLabelValues("SliceConfig", "update").Inc()
+	haSyncErrorsTotal.WithLabelValues("SliceConfig", "update").Inc()
+
+	assert.Equal(t, 1, testutil.CollectAndCount(haSyncLagSeconds))
+	assert.Equal(t, float64(2), testutil.ToFloat64(haSyncErrorsTotal.WithLabelValues("SliceConfig", "update")))
+}

--- a/pkg/ha/mirror.go
+++ b/pkg/ha/mirror.go
@@ -56,6 +56,24 @@ func mirrorCreateOrUpdate(ctx context.Context, localClient client.Client, key sy
 	payload.SetUID("")
 	payload.SetManagedFields(nil)
 	payload.SetFinalizers(nil)
+	// While an Active-side object is Terminating (deletionTimestamp set,
+	// contents still being garbage-collected), the informer delivers it as
+	// an ordinary Update, not a Delete yet — copying that onto a Standby
+	// copy that isn't itself terminating fails immutable-field validation
+	// on a real API server (confirmed live: "field is immutable" on both
+	// deletionTimestamp and deletionGracePeriodSeconds). Its status is
+	// dropped from payload too, explicitly rather than relying on a real
+	// API server silently ignoring .status on the main resource endpoint:
+	// for at least one type (confirmed live: Namespace), a stray
+	// status.Phase="Terminating" is itself invalid once deletionTimestamp
+	// is empty. The Standby converges correctly once Active reports
+	// NotFound and mirrorDelete takes over; there's nothing useful to
+	// reflect about the in-between Terminating state.
+	if src.GetDeletionTimestamp() != nil {
+		delete(payload.Object, "status")
+	}
+	payload.SetDeletionTimestamp(nil)
+	payload.SetDeletionGracePeriodSeconds(nil)
 	if res.StripOwnerRefs {
 		payload.SetOwnerReferences(nil)
 	}
@@ -105,10 +123,20 @@ func mirrorCreateOrUpdate(ctx context.Context, localClient client.Client, key sy
 	// registered — true for every entry in CRDMirrorSet. Mirror it
 	// explicitly, matching this repo's own UpdateStatus/CleanupUpdateStatus
 	// convention (util/reconciliation_utility.go, util/cleanup_utility.go).
-	if status, ok, _ := unstructured.NestedFieldNoCopy(src.Object, "status"); ok {
-		payload.Object["status"] = status
-		if err := localClient.Status().Update(ctx, payload); err != nil {
-			return op, fmt.Errorf("mirroring status of %s %s/%s: %w", key.GVK.Kind, key.Namespace, key.Name, err)
+	//
+	// Skipped while src is itself Terminating: its status is about to become
+	// meaningless anyway, and for at least one type (confirmed live:
+	// Namespace) copying a Terminating status onto a payload whose
+	// deletionTimestamp was just stripped above fails a real API server
+	// validation rule — status.Phase can only be "Terminating" if
+	// deletionTimestamp is set. The Standby converges correctly once Active
+	// reports NotFound and mirrorDelete takes over.
+	if src.GetDeletionTimestamp() == nil {
+		if status, ok, _ := unstructured.NestedFieldNoCopy(src.Object, "status"); ok {
+			payload.Object["status"] = status
+			if err := localClient.Status().Update(ctx, payload); err != nil {
+				return op, fmt.Errorf("mirroring status of %s %s/%s: %w", key.GVK.Kind, key.Namespace, key.Name, err)
+			}
 		}
 	}
 	return op, nil

--- a/pkg/ha/mirror.go
+++ b/pkg/ha/mirror.go
@@ -1,0 +1,137 @@
+/*
+ * 	Copyright (c) 2022 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// syncKey identifies one mirrored object by GVK and namespaced name. It is
+// RemoteSyncer's workqueue item type (see remote_syncer.go); mirror.go only
+// needs it to know what to read and where to write.
+type syncKey struct {
+	GVK       schema.GroupVersionKind
+	Namespace string
+	Name      string
+}
+
+// mirrorOp reports which write mirrorCreateOrUpdate actually performed (or
+// "" if the conflict guard skipped it), so callers can label metrics without
+// re-deriving it.
+type mirrorOp string
+
+const (
+	opCreate mirrorOp = "create"
+	opUpdate mirrorOp = "update"
+)
+
+// mirrorCreateOrUpdate writes src onto the Standby via localClient: create if
+// absent, update if present and syncer-owned. src is the informer's own
+// cached object and is never mutated in place.
+func mirrorCreateOrUpdate(ctx context.Context, localClient client.Client, key syncKey, res MirroredResource, src *unstructured.Unstructured) (mirrorOp, error) {
+	payload := src.DeepCopy()
+	payload.SetGroupVersionKind(key.GVK)
+	payload.SetResourceVersion("")
+	payload.SetUID("")
+	payload.SetManagedFields(nil)
+	payload.SetFinalizers(nil)
+	if res.StripOwnerRefs {
+		payload.SetOwnerReferences(nil)
+	}
+
+	labels := payload.GetLabels()
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[LabelSyncedFromActive] = LabelValueActive
+	payload.SetLabels(labels)
+
+	annotations := payload.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[AnnotationSourceRV] = src.GetResourceVersion()
+	payload.SetAnnotations(annotations)
+
+	existing := &unstructured.Unstructured{}
+	existing.SetGroupVersionKind(key.GVK)
+	err := localClient.Get(ctx, types.NamespacedName{Namespace: key.Namespace, Name: key.Name}, existing)
+
+	var op mirrorOp
+	switch {
+	case apierrors.IsNotFound(err):
+		if err := localClient.Create(ctx, payload); err != nil {
+			return "", fmt.Errorf("creating mirror of %s %s/%s: %w", key.GVK.Kind, key.Namespace, key.Name, err)
+		}
+		op = opCreate
+	case err != nil:
+		return "", fmt.Errorf("reading existing target %s %s/%s: %w", key.GVK.Kind, key.Namespace, key.Name, err)
+	default:
+		if existing.GetLabels()[LabelSyncedFromActive] != LabelValueActive {
+			// Conflict guard: never overwrite an object the Standby didn't
+			// create itself.
+			return "", nil
+		}
+		payload.SetResourceVersion(existing.GetResourceVersion())
+		payload.SetUID(existing.GetUID())
+		if err := localClient.Update(ctx, payload); err != nil {
+			return "", fmt.Errorf("updating mirror of %s %s/%s: %w", key.GVK.Kind, key.Namespace, key.Name, err)
+		}
+		op = opUpdate
+	}
+
+	// Update() silently drops .status once a status subresource is
+	// registered — true for every entry in CRDMirrorSet. Mirror it
+	// explicitly, matching this repo's own UpdateStatus/CleanupUpdateStatus
+	// convention (util/reconciliation_utility.go, util/cleanup_utility.go).
+	if status, ok, _ := unstructured.NestedFieldNoCopy(src.Object, "status"); ok {
+		payload.Object["status"] = status
+		if err := localClient.Status().Update(ctx, payload); err != nil {
+			return op, fmt.Errorf("mirroring status of %s %s/%s: %w", key.GVK.Kind, key.Namespace, key.Name, err)
+		}
+	}
+	return op, nil
+}
+
+// mirrorDelete removes the Standby's mirror of key, if the engine created it.
+// Deleting an already-absent object is treated as success (idempotent — a
+// concurrent prune pass may already have removed it).
+func mirrorDelete(ctx context.Context, localClient client.Client, key syncKey) error {
+	existing := &unstructured.Unstructured{}
+	existing.SetGroupVersionKind(key.GVK)
+	err := localClient.Get(ctx, types.NamespacedName{Namespace: key.Namespace, Name: key.Name}, existing)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("reading target %s %s/%s before delete: %w", key.GVK.Kind, key.Namespace, key.Name, err)
+	}
+	if existing.GetLabels()[LabelSyncedFromActive] != LabelValueActive {
+		return nil
+	}
+	if err := localClient.Delete(ctx, existing); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("deleting mirror of %s %s/%s: %w", key.GVK.Kind, key.Namespace, key.Name, err)
+	}
+	return nil
+}

--- a/pkg/ha/mirror_set.go
+++ b/pkg/ha/mirror_set.go
@@ -1,0 +1,81 @@
+/*
+ * 	Copyright (c) 2022 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// Label and annotation keys the mirror engine stamps onto every object it
+// writes to the Standby. LabelSyncedFromActive is the conflict guard: the
+// engine only ever overwrites or deletes a Standby object that carries it, so
+// it never touches anything the Standby's own reconcilers (or an operator)
+// created directly — including a pre-existing Namespace such as kube-system
+// or default, now that Namespace is an ordinary mirrored type (see
+// CRDMirrorSet below) rather than a special-cased cold-start step.
+const (
+	LabelSyncedFromActive = "ha.kubeslice.io/synced-from"
+	LabelValueActive      = "active"
+	AnnotationSourceRV    = "ha.kubeslice.io/source-rv"
+)
+
+// MirroredResource describes one GroupVersionKind RemoteSyncer mirrors from
+// the Active hub to the Standby.
+type MirroredResource struct {
+	GVK schema.GroupVersionKind
+	// StripOwnerRefs strips metadata.ownerReferences from the mirrored copy.
+	// Only VpnKeyRotation needs this: its ownerReference points at the
+	// Active-side SliceConfig's UID, which the Standby's mirrored SliceConfig
+	// does not share (a fresh UID is assigned on create) — left in place, the
+	// Standby's garbage collector would see a dangling reference and delete
+	// the object shortly after the mirror creates it.
+	StripOwnerRefs bool
+	// Skip, if set, excludes an object from mirroring based on its content —
+	// e.g. filtering out kubernetes.io/service-account-token Secrets in the
+	// credential mirror set.
+	Skip func(u *unstructured.Unstructured) bool
+}
+
+const (
+	groupController = "controller.kubeslice.io"
+	groupWorker     = "worker.kubeslice.io"
+)
+
+func gvk(group, kind string) schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: group, Version: "v1alpha1", Kind: kind}
+}
+
+// CRDMirrorSet is the set of hub-side resources mirrored Active -> Standby.
+//
+// This intentionally does not match issue #295's own CRD table, which names
+// Slice/SliceGateway/ServiceExport — none of those types exist in this repo.
+// They are worker-cluster data-plane CRDs (group networking.kubeslice.io)
+// owned by the separate worker-operator repo, irrelevant to hub-to-hub
+// mirroring. Verified against apis/controller/v1alpha1 and apis/worker/v1alpha1.
+var CRDMirrorSet = []MirroredResource{
+	{GVK: schema.GroupVersionKind{Version: "v1", Kind: "Namespace"}},
+	{GVK: gvk(groupController, "Project")},
+	{GVK: gvk(groupController, "Cluster")},
+	{GVK: gvk(groupController, "SliceConfig")},
+	{GVK: gvk(groupController, "ServiceExportConfig")},
+	{GVK: gvk(groupController, "SliceQoSConfig")},
+	{GVK: gvk(groupController, "VpnKeyRotation"), StripOwnerRefs: true},
+	{GVK: gvk(groupWorker, "WorkerSliceConfig")},
+	{GVK: gvk(groupWorker, "WorkerSliceGateway")},
+	{GVK: gvk(groupWorker, "WorkerServiceImport")},
+}

--- a/pkg/ha/mirror_set.go
+++ b/pkg/ha/mirror_set.go
@@ -17,6 +17,7 @@
 package ha
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -49,11 +50,24 @@ type MirroredResource struct {
 	// e.g. filtering out kubernetes.io/service-account-token Secrets in the
 	// credential mirror set.
 	Skip func(u *unstructured.Unstructured) bool
+	// RequireMirroredNamespace restricts mirroring to objects whose namespace
+	// the syncer itself mirrors — i.e. the namespace is present in the remote
+	// cache's label-scoped Namespace view (see namespaceMirrorSelector). Set
+	// on every credential row: core types exist in every namespace, and no
+	// name-based rule can draw this boundary safely — under the Helm chart's
+	// real-world --project-namespace-prefix ("kubeslice-"), the controller's
+	// own kubeslice-controller namespace matches the project-namespace naming
+	// pattern, and a prefix test would have mirrored its webhook TLS key,
+	// image-pull credentials, and Helm release Secrets onto the Standby
+	// (found live against a Helm-installed Active hub). The label boundary is
+	// the one ReconcileProjectNamespace actually maintains.
+	RequireMirroredNamespace bool
 }
 
 const (
 	groupController = "controller.kubeslice.io"
 	groupWorker     = "worker.kubeslice.io"
+	groupRBAC       = "rbac.authorization.k8s.io"
 )
 
 func gvk(group, kind string) schema.GroupVersionKind {
@@ -78,4 +92,61 @@ var CRDMirrorSet = []MirroredResource{
 	{GVK: gvk(groupWorker, "WorkerSliceConfig")},
 	{GVK: gvk(groupWorker, "WorkerSliceGateway")},
 	{GVK: gvk(groupWorker, "WorkerServiceImport")},
+}
+
+// skipServiceAccountTokenSecret excludes kubernetes.io/service-account-token
+// Secrets from mirroring. SA tokens are signed by the issuing cluster's own
+// service-account key, so an Active-minted token is cryptographically invalid
+// on the Standby; mirroring the ServiceAccount itself is what matters — the
+// Standby's token controller mints its own, locally-valid token for it.
+func skipServiceAccountTokenSecret(u *unstructured.Unstructured) bool {
+	secretType, _, _ := unstructured.NestedString(u.Object, "type")
+	return secretType == string(corev1.SecretTypeServiceAccountToken)
+}
+
+// FullMirrorSet is everything a production Standby mirrors: CRDMirrorSet
+// plus CredentialMirrorSet. Returned as a fresh slice so callers cannot
+// mutate the package-level tables through it.
+func FullMirrorSet() []MirroredResource {
+	full := make([]MirroredResource, 0, len(CRDMirrorSet)+len(CredentialMirrorSet))
+	full = append(full, CRDMirrorSet...)
+	return append(full, CredentialMirrorSet...)
+}
+
+// CredentialMirrorSet is the set of credential resources mirrored Active ->
+// Standby so a promoted Standby can serve its worker clusters without manual
+// re-provisioning: worker-identity RBAC (Role/RoleBinding/ServiceAccount, the
+// only RBAC kinds access_control_service.go ever creates — no ClusterRole or
+// ClusterRoleBinding, despite ADR Decision 6's broader wording) and Secrets
+// such as the gateway certificates the ovpn job generates.
+//
+// Every row sets RequireMirroredNamespace — see that field's doc comment for
+// why the boundary is the mirrored-namespace set and not a name pattern —
+// and StripOwnerRefs: ownerReferences resolve by UID, which never survives
+// the cross-cluster copy, and unlike the CRD set (audited — only
+// VpnKeyRotation ever gets a reference, from this repo's own code)
+// credential objects are also written by actors outside this repo (the
+// token controller, the cert-generator job), so no such audit can hold here.
+var CredentialMirrorSet = []MirroredResource{
+	{
+		GVK:                      schema.GroupVersionKind{Version: "v1", Kind: "Secret"},
+		StripOwnerRefs:           true,
+		Skip:                     skipServiceAccountTokenSecret,
+		RequireMirroredNamespace: true,
+	},
+	{
+		GVK:                      schema.GroupVersionKind{Version: "v1", Kind: "ServiceAccount"},
+		StripOwnerRefs:           true,
+		RequireMirroredNamespace: true,
+	},
+	{
+		GVK:                      schema.GroupVersionKind{Group: groupRBAC, Version: "v1", Kind: "Role"},
+		StripOwnerRefs:           true,
+		RequireMirroredNamespace: true,
+	},
+	{
+		GVK:                      schema.GroupVersionKind{Group: groupRBAC, Version: "v1", Kind: "RoleBinding"},
+		StripOwnerRefs:           true,
+		RequireMirroredNamespace: true,
+	},
 }

--- a/pkg/ha/mirror_test.go
+++ b/pkg/ha/mirror_test.go
@@ -146,6 +146,49 @@ func TestMirrorCreateOrUpdate_StripOwnerRefsOnlyWhenConfigured(t *testing.T) {
 	assert.Len(t, got2.GetOwnerReferences(), 1, "StripOwnerRefs=false must leave ownerReferences untouched")
 }
 
+func TestMirrorCreateOrUpdate_StripsDeletionTimestampFromTerminatingSource(t *testing.T) {
+	ctx := context.Background()
+	gracePeriod := int64(0)
+	terminating := func(u *unstructured.Unstructured) {
+		now := metav1.Now()
+		u.SetDeletionTimestamp(&now)
+		u.SetDeletionGracePeriodSeconds(&gracePeriod)
+	}
+
+	t.Run("update path", func(t *testing.T) {
+		key := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "sc-1"}
+		existing := newTestUnstructured(testGVK, key.Namespace, key.Name)
+		existing.SetLabels(map[string]string{LabelSyncedFromActive: LabelValueActive})
+		c := mirrorFakeClient(t, existing)
+
+		src := newTestUnstructured(testGVK, key.Namespace, key.Name)
+		terminating(src)
+
+		op, err := mirrorCreateOrUpdate(ctx, c, key, MirroredResource{GVK: testGVK}, src)
+		require.NoError(t, err, "an Active-side object mid-Terminating must not fail mirroring")
+		assert.Equal(t, opUpdate, op)
+
+		got := getUnstructured(t, c, key)
+		assert.Nil(t, got.GetDeletionTimestamp(), "the Standby mirror must never carry a deletionTimestamp copied from a Terminating Active-side object")
+		assert.Nil(t, got.GetDeletionGracePeriodSeconds())
+	})
+
+	t.Run("create path", func(t *testing.T) {
+		key := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "sc-2"}
+		c := mirrorFakeClient(t)
+
+		src := newTestUnstructured(testGVK, key.Namespace, key.Name)
+		terminating(src)
+
+		op, err := mirrorCreateOrUpdate(ctx, c, key, MirroredResource{GVK: testGVK}, src)
+		require.NoError(t, err, "creating a mirror from an already-Terminating source must not fail")
+		assert.Equal(t, opCreate, op)
+
+		got := getUnstructured(t, c, key)
+		assert.Nil(t, got.GetDeletionTimestamp())
+	})
+}
+
 func TestMirrorCreateOrUpdate_MirrorsStatusExplicitly(t *testing.T) {
 	ctx := context.Background()
 	key := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "sc-1"}
@@ -160,6 +203,25 @@ func TestMirrorCreateOrUpdate_MirrorsStatusExplicitly(t *testing.T) {
 	phase, ok, _ := unstructured.NestedString(got.Object, "status", "phase")
 	require.True(t, ok, "status.phase must be present after mirroring — a plain Update() alone would have dropped it")
 	assert.Equal(t, "Ready", phase)
+}
+
+func TestMirrorCreateOrUpdate_SkipsStatusMirrorWhenSourceIsTerminating(t *testing.T) {
+	ctx := context.Background()
+	key := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "sc-1"}
+	c := mirrorFakeClient(t)
+
+	src := newTestUnstructured(testGVK, key.Namespace, key.Name)
+	now := metav1.Now()
+	src.SetDeletionTimestamp(&now)
+	require.NoError(t, unstructured.SetNestedField(src.Object, "Terminating", "status", "phase"))
+
+	op, err := mirrorCreateOrUpdate(ctx, c, key, MirroredResource{GVK: testGVK}, src)
+	require.NoError(t, err, "mirroring a Terminating source must not fail trying to write an invalid status combination")
+	assert.Equal(t, opCreate, op)
+
+	got := getUnstructured(t, c, key)
+	_, ok, _ := unstructured.NestedString(got.Object, "status", "phase")
+	assert.False(t, ok, "status must not be mirrored while the source is Terminating — see mirror.go for the real API-server validation rule this avoids")
 }
 
 func TestMirrorDelete_IdempotentOnNotFound(t *testing.T) {

--- a/pkg/ha/mirror_test.go
+++ b/pkg/ha/mirror_test.go
@@ -1,0 +1,198 @@
+/*
+ * 	Copyright (c) 2022 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var testGVK = schema.GroupVersionKind{Group: groupController, Version: "v1alpha1", Kind: "SliceConfig"}
+
+func newTestUnstructured(gvk schema.GroupVersionKind, namespace, name string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(gvk)
+	u.SetNamespace(namespace)
+	u.SetName(name)
+	return u
+}
+
+// mirrorFakeClient builds a fake client that emulates the status-subresource
+// split real clusters apply to every CRDMirrorSet entry: Update() must not
+// alter .status, only Status().Update() may.
+func mirrorFakeClient(t *testing.T, objs ...client.Object) client.Client {
+	t.Helper()
+	statusGVKObj := &unstructured.Unstructured{}
+	statusGVKObj.SetGroupVersionKind(testGVK)
+	return fake.NewClientBuilder().
+		WithScheme(testScheme(t)).
+		WithStatusSubresource(statusGVKObj).
+		WithObjects(objs...).
+		Build()
+}
+
+func getUnstructured(t *testing.T, c client.Client, key syncKey) *unstructured.Unstructured {
+	t.Helper()
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(key.GVK)
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Namespace: key.Namespace, Name: key.Name}, got))
+	return got
+}
+
+func TestMirrorCreateOrUpdate_CreatesWithLabelAndAnnotation(t *testing.T) {
+	ctx := context.Background()
+	c := mirrorFakeClient(t)
+	key := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "sc-1"}
+	src := newTestUnstructured(testGVK, key.Namespace, key.Name)
+	src.SetResourceVersion("999")
+
+	op, err := mirrorCreateOrUpdate(ctx, c, key, MirroredResource{GVK: testGVK}, src)
+	require.NoError(t, err)
+	assert.Equal(t, opCreate, op)
+
+	got := getUnstructured(t, c, key)
+	assert.Equal(t, LabelValueActive, got.GetLabels()[LabelSyncedFromActive])
+	assert.Equal(t, "999", got.GetAnnotations()[AnnotationSourceRV])
+}
+
+func TestMirrorCreateOrUpdate_UpdatesExistingSyncedObject(t *testing.T) {
+	ctx := context.Background()
+	key := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "sc-1"}
+	existing := newTestUnstructured(testGVK, key.Namespace, key.Name)
+	existing.SetLabels(map[string]string{LabelSyncedFromActive: LabelValueActive})
+	existing.SetResourceVersion("1")
+	existing.SetUID("standby-uid-1")
+	c := mirrorFakeClient(t, existing)
+
+	src := newTestUnstructured(testGVK, key.Namespace, key.Name)
+	require.NoError(t, unstructured.SetNestedField(src.Object, "updated-value", "spec", "field"))
+	src.SetResourceVersion("active-rv-2")
+
+	op, err := mirrorCreateOrUpdate(ctx, c, key, MirroredResource{GVK: testGVK}, src)
+	require.NoError(t, err)
+	assert.Equal(t, opUpdate, op)
+
+	got := getUnstructured(t, c, key)
+	val, _, _ := unstructured.NestedString(got.Object, "spec", "field")
+	assert.Equal(t, "updated-value", val)
+	assert.Equal(t, "active-rv-2", got.GetAnnotations()[AnnotationSourceRV],
+		"source-rv annotation should reflect the Active object's resourceVersion")
+}
+
+func TestMirrorCreateOrUpdate_ConflictGuardSkipsUnlabeledExisting(t *testing.T) {
+	ctx := context.Background()
+	key := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "sc-1"}
+	existing := newTestUnstructured(testGVK, key.Namespace, key.Name)
+	require.NoError(t, unstructured.SetNestedField(existing.Object, "hand-applied", "spec", "field"))
+	c := mirrorFakeClient(t, existing)
+
+	src := newTestUnstructured(testGVK, key.Namespace, key.Name)
+	require.NoError(t, unstructured.SetNestedField(src.Object, "from-active", "spec", "field"))
+
+	op, err := mirrorCreateOrUpdate(ctx, c, key, MirroredResource{GVK: testGVK}, src)
+	require.NoError(t, err)
+	assert.Equal(t, mirrorOp(""), op, "conflict guard should report no-op")
+
+	got := getUnstructured(t, c, key)
+	val, _, _ := unstructured.NestedString(got.Object, "spec", "field")
+	assert.Equal(t, "hand-applied", val, "an unlabeled existing object must never be overwritten")
+}
+
+func TestMirrorCreateOrUpdate_StripOwnerRefsOnlyWhenConfigured(t *testing.T) {
+	ctx := context.Background()
+	ownerRef := metav1.OwnerReference{APIVersion: "v1alpha1", Kind: "SliceConfig", Name: "owner", UID: "owner-uid"}
+
+	stripKey := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "vpn-1"}
+	src := newTestUnstructured(testGVK, stripKey.Namespace, stripKey.Name)
+	src.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
+	c := mirrorFakeClient(t)
+
+	_, err := mirrorCreateOrUpdate(ctx, c, stripKey, MirroredResource{GVK: testGVK, StripOwnerRefs: true}, src)
+	require.NoError(t, err)
+	got := getUnstructured(t, c, stripKey)
+	assert.Empty(t, got.GetOwnerReferences(), "StripOwnerRefs=true must strip ownerReferences")
+
+	keepKey := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "vpn-2"}
+	src2 := newTestUnstructured(testGVK, keepKey.Namespace, keepKey.Name)
+	src2.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
+
+	_, err = mirrorCreateOrUpdate(ctx, c, keepKey, MirroredResource{GVK: testGVK, StripOwnerRefs: false}, src2)
+	require.NoError(t, err)
+	got2 := getUnstructured(t, c, keepKey)
+	assert.Len(t, got2.GetOwnerReferences(), 1, "StripOwnerRefs=false must leave ownerReferences untouched")
+}
+
+func TestMirrorCreateOrUpdate_MirrorsStatusExplicitly(t *testing.T) {
+	ctx := context.Background()
+	key := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "sc-1"}
+	src := newTestUnstructured(testGVK, key.Namespace, key.Name)
+	require.NoError(t, unstructured.SetNestedField(src.Object, "Ready", "status", "phase"))
+	c := mirrorFakeClient(t)
+
+	_, err := mirrorCreateOrUpdate(ctx, c, key, MirroredResource{GVK: testGVK}, src)
+	require.NoError(t, err)
+
+	got := getUnstructured(t, c, key)
+	phase, ok, _ := unstructured.NestedString(got.Object, "status", "phase")
+	require.True(t, ok, "status.phase must be present after mirroring — a plain Update() alone would have dropped it")
+	assert.Equal(t, "Ready", phase)
+}
+
+func TestMirrorDelete_IdempotentOnNotFound(t *testing.T) {
+	c := mirrorFakeClient(t)
+	key := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "missing"}
+	assert.NoError(t, mirrorDelete(context.Background(), c, key))
+}
+
+func TestMirrorDelete_DeletesSyncedObject(t *testing.T) {
+	ctx := context.Background()
+	key := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "sc-1"}
+	existing := newTestUnstructured(testGVK, key.Namespace, key.Name)
+	existing.SetLabels(map[string]string{LabelSyncedFromActive: LabelValueActive})
+	c := mirrorFakeClient(t, existing)
+
+	require.NoError(t, mirrorDelete(ctx, c, key))
+
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(key.GVK)
+	err := c.Get(ctx, types.NamespacedName{Namespace: key.Namespace, Name: key.Name}, got)
+	assert.True(t, apierrors.IsNotFound(err), "object should be gone after delete")
+}
+
+func TestMirrorDelete_ConflictGuardSkipsUnlabeledExisting(t *testing.T) {
+	ctx := context.Background()
+	key := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "sc-1"}
+	existing := newTestUnstructured(testGVK, key.Namespace, key.Name)
+	c := mirrorFakeClient(t, existing)
+
+	require.NoError(t, mirrorDelete(ctx, c, key))
+
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(key.GVK)
+	err := c.Get(ctx, types.NamespacedName{Namespace: key.Namespace, Name: key.Name}, got)
+	assert.NoError(t, err, "an unlabeled existing object must never be deleted")
+}

--- a/pkg/ha/mode.go
+++ b/pkg/ha/mode.go
@@ -1,0 +1,65 @@
+/*
+ * 	Copyright (c) 2022 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+// Package ha implements cross-cluster (Active/Standby) high availability for the
+// kubeslice-controller. It coordinates leadership between two separate hub
+// clusters so that only the Active hub writes to worker clusters. This is
+// distinct from controller-runtime's in-cluster --leader-elect, which only
+// coordinates multiple pods sharing a single API server. See ADR #293.
+package ha
+
+import "strings"
+
+// HAMode identifies the high-availability role this controller instance plays.
+type HAMode string
+
+const (
+	// ModeActive means this controller holds (or competes for) leadership by
+	// renewing a Lease on its own cluster; while it is the leader its reconcilers
+	// write to worker clusters.
+	ModeActive HAMode = "active"
+	// ModeStandby means this controller mirrors the Active hub and never writes.
+	// In issue #294 a Standby watches the Active's Lease but does not promote;
+	// promotion is issue #297.
+	ModeStandby HAMode = "standby"
+	// ModeStandalone is the default single-hub behaviour: always the leader, no
+	// Lease and no remote watching — identical to the controller before HA.
+	ModeStandalone HAMode = "standalone"
+)
+
+// ParseHAMode converts a flag/env string into an HAMode. Empty or unrecognised
+// values map to ModeStandalone so that a misconfiguration fails safe to today's
+// behaviour rather than silently disabling writes.
+func ParseHAMode(s string) HAMode {
+	switch HAMode(strings.ToLower(strings.TrimSpace(s))) {
+	case ModeActive:
+		return ModeActive
+	case ModeStandby:
+		return ModeStandby
+	default:
+		return ModeStandalone
+	}
+}
+
+// IsValid reports whether m is one of the known modes.
+func (m HAMode) IsValid() bool {
+	switch m {
+	case ModeActive, ModeStandby, ModeStandalone:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/ha/mode_test.go
+++ b/pkg/ha/mode_test.go
@@ -1,0 +1,46 @@
+/*
+ * 	Copyright (c) 2022 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import "testing"
+
+func TestParseHAMode(t *testing.T) {
+	cases := map[string]HAMode{
+		"active":     ModeActive,
+		"ACTIVE":     ModeActive,
+		" standby ":  ModeStandby,
+		"standalone": ModeStandalone,
+		"":           ModeStandalone,
+		"garbage":    ModeStandalone,
+	}
+	for in, want := range cases {
+		if got := ParseHAMode(in); got != want {
+			t.Errorf("ParseHAMode(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestHAModeIsValid(t *testing.T) {
+	for _, m := range []HAMode{ModeActive, ModeStandby, ModeStandalone} {
+		if !m.IsValid() {
+			t.Errorf("%q should be valid", m)
+		}
+	}
+	if HAMode("nope").IsValid() {
+		t.Error("unknown mode should be invalid")
+	}
+}

--- a/pkg/ha/prune.go
+++ b/pkg/ha/prune.go
@@ -1,0 +1,132 @@
+/*
+ * 	Copyright (c) 2022 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"context"
+	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DefaultPruneInterval is how often the prune backstop diffs the Standby's
+// mirrored objects against the Active hub. Overridable through
+// RemoteSyncerOptions.PruneInterval (--ha-sync-interval in main.go).
+const DefaultPruneInterval = 60 * time.Second
+
+// opPrune labels ha_sync_errors_total increments coming from the prune
+// loop's own list calls; failures of the deletes it triggers are labeled by
+// the worker that performs them (opDelete), like any other queued item.
+const opPrune mirrorOp = "prune"
+
+// remoteListFunc lists, for one GVK, the keys of every object currently
+// present on the Active hub. The real implementation (listFromRemoteCache)
+// reads controller-runtime's cache — a local-indexer read, not a network
+// call. Overridable in tests, the same seam pattern as remoteGetFunc.
+type remoteListFunc func(ctx context.Context, gvk schema.GroupVersionKind) (map[syncKey]struct{}, error)
+
+// runPrune periodically removes Standby-side drift the informers never
+// reported: a mirrored object whose Active-side original was deleted while
+// this process wasn't watching (e.g. between two Standby runs) never gets a
+// Delete event — cold-start informers only deliver what currently exists —
+// so its mirror would otherwise survive as an orphan forever. The workqueue
+// owns retry-on-transient-failure and the informers' periodic resync
+// self-heals missed updates; pruning orphans is this loop's only job.
+//
+// It blocks until the remote cache has synced before the first pass: an
+// unsynced cache lists empty, and an empty "Active" view would read as
+// "everything was deleted" and prune every mirror on the Standby.
+func (s *RemoteSyncer) runPrune(ctx context.Context) {
+	if !s.waitForCacheSync(ctx) {
+		return // ctx cancelled before the remote cache ever synced
+	}
+	ticker := time.NewTicker(s.pruneInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.pruneOnce(ctx)
+		}
+	}
+}
+
+// pruneOnce diffs one round: for each mirrored type, every Standby object
+// carrying the sync label but no longer present on the Active hub is
+// enqueued onto the ordinary mirror workqueue rather than deleted here
+// directly — the worker re-reads Active at dequeue time (so an object that
+// reappeared in the meantime is mirrored, not deleted), and the conflict
+// guard and rate-limited retry apply unchanged, with no second write path
+// racing the workers.
+//
+// A failed list skips that type for this round instead of pruning on partial
+// information — deleting mirrors is the one operation where acting on an
+// incomplete view is worse than doing nothing until the next tick.
+func (s *RemoteSyncer) pruneOnce(ctx context.Context) {
+	for _, res := range s.resources {
+		activeKeys, err := s.remoteList(ctx, res.GVK)
+		if err != nil {
+			haSyncErrorsTotal.WithLabelValues(res.GVK.Kind, string(opPrune)).Inc()
+			s.log.Warnw("prune: listing active hub failed; skipping kind this round",
+				"kind", res.GVK.Kind, "error", err)
+			continue
+		}
+
+		local := &unstructured.UnstructuredList{}
+		local.SetGroupVersionKind(res.GVK.GroupVersion().WithKind(res.GVK.Kind + "List"))
+		if err := s.localClient.List(ctx, local,
+			client.MatchingLabels{LabelSyncedFromActive: LabelValueActive}); err != nil {
+			haSyncErrorsTotal.WithLabelValues(res.GVK.Kind, string(opPrune)).Inc()
+			s.log.Warnw("prune: listing local mirrors failed; skipping kind this round",
+				"kind", res.GVK.Kind, "error", err)
+			continue
+		}
+
+		for i := range local.Items {
+			item := &local.Items[i]
+			key := syncKey{GVK: res.GVK, Namespace: item.GetNamespace(), Name: item.GetName()}
+			if _, onActive := activeKeys[key]; onActive {
+				continue
+			}
+			s.log.Infow("prune: enqueuing orphaned mirror",
+				"kind", key.GVK.Kind, "namespace", key.Namespace, "name", key.Name)
+			s.enqueue(key)
+		}
+	}
+}
+
+// listFromRemoteCache is remoteListFunc's real implementation: a List against
+// controller-runtime's cache, served from the informer's local indexer. For
+// Namespace this inherits the cache's label scoping (see
+// namespaceMirrorSelector), so a namespace that loses the controller label on
+// Active disappears from this view exactly as it does from the informer's.
+func (s *RemoteSyncer) listFromRemoteCache(ctx context.Context, gvk schema.GroupVersionKind) (map[syncKey]struct{}, error) {
+	ul := &unstructured.UnstructuredList{}
+	ul.SetGroupVersionKind(gvk.GroupVersion().WithKind(gvk.Kind + "List"))
+	if err := s.remoteCache.List(ctx, ul); err != nil {
+		return nil, err
+	}
+	keys := make(map[syncKey]struct{}, len(ul.Items))
+	for i := range ul.Items {
+		item := &ul.Items[i]
+		keys[syncKey{GVK: gvk, Namespace: item.GetNamespace(), Name: item.GetName()}] = struct{}{}
+	}
+	return keys, nil
+}

--- a/pkg/ha/prune.go
+++ b/pkg/ha/prune.go
@@ -41,13 +41,15 @@ const opPrune mirrorOp = "prune"
 // call. Overridable in tests, the same seam pattern as remoteGetFunc.
 type remoteListFunc func(ctx context.Context, gvk schema.GroupVersionKind) (map[syncKey]struct{}, error)
 
-// runPrune periodically removes Standby-side drift the informers never
-// reported: a mirrored object whose Active-side original was deleted while
-// this process wasn't watching (e.g. between two Standby runs) never gets a
-// Delete event — cold-start informers only deliver what currently exists —
-// so its mirror would otherwise survive as an orphan forever. The workqueue
-// owns retry-on-transient-failure and the informers' periodic resync
-// self-heals missed updates; pruning orphans is this loop's only job.
+// runPrune periodically reconciles drift between the Standby's mirrors and
+// the Active hub that the informers never reported. Forward direction: a
+// mirrored object whose Active-side original was deleted while this process
+// wasn't watching (e.g. between two Standby runs) never gets a Delete event
+// — cold-start informers only deliver what currently exists — so its mirror
+// would otherwise survive as an orphan forever. Reverse direction: an
+// Active-side object with no Standby mirror is re-enqueued (see pruneOnce
+// for the cases that produces). The workqueue still owns
+// retry-on-transient-failure; this loop only feeds it.
 //
 // It blocks until the remote cache has synced before the first pass: an
 // unsynced cache lists empty, and an empty "Active" view would read as
@@ -99,15 +101,31 @@ func (s *RemoteSyncer) pruneOnce(ctx context.Context) {
 			continue
 		}
 
+		localKeys := make(map[syncKey]struct{}, len(local.Items))
 		for i := range local.Items {
 			item := &local.Items[i]
 			key := syncKey{GVK: res.GVK, Namespace: item.GetNamespace(), Name: item.GetName()}
+			localKeys[key] = struct{}{}
 			if _, onActive := activeKeys[key]; onActive {
 				continue
 			}
 			s.log.Infow("prune: enqueuing orphaned mirror",
 				"kind", key.GVK.Kind, "namespace", key.Namespace, "name", key.Name)
 			s.enqueue(key)
+		}
+
+		// Reverse diff: an Active-side object with no mirror on the Standby.
+		// Usually a create this loop's forward pass can't see — a mirror
+		// someone deleted directly on the Standby, an object whose skip
+		// verdict was decided before its namespace had synced (see
+		// namespaceIsMirrored), or a key stuck deep in retry backoff.
+		// Re-enqueueing is always safe: the worker re-reads Active and runs
+		// the full Skip/namespace/conflict-guard chain, so objects that
+		// should not mirror simply no-op again.
+		for key := range activeKeys {
+			if _, mirrored := localKeys[key]; !mirrored {
+				s.enqueue(key)
+			}
 		}
 	}
 }

--- a/pkg/ha/prune_test.go
+++ b/pkg/ha/prune_test.go
@@ -1,0 +1,172 @@
+/*
+ * 	Copyright (c) 2022 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// stubRemoteList returns a fixed key set (or error) regardless of GVK,
+// standing in for listFromRemoteCache the same way stubRemote stands in for
+// getFromRemoteCache.
+func stubRemoteList(keys []syncKey, err error) remoteListFunc {
+	return func(_ context.Context, gvk schema.GroupVersionKind) (map[syncKey]struct{}, error) {
+		if err != nil {
+			return nil, err
+		}
+		set := make(map[syncKey]struct{}, len(keys))
+		for _, k := range keys {
+			if k.GVK == gvk {
+				set[k] = struct{}{}
+			}
+		}
+		return set, nil
+	}
+}
+
+func labeledMirror(gvk schema.GroupVersionKind, namespace, name string) *unstructured.Unstructured {
+	u := newTestUnstructured(gvk, namespace, name)
+	u.SetLabels(map[string]string{LabelSyncedFromActive: LabelValueActive})
+	return u
+}
+
+func TestPruneOnce_EnqueuesOnlyOrphanedMirrors(t *testing.T) {
+	ctx := context.Background()
+	kept := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "sc-kept"}
+	orphan := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "sc-orphan"}
+
+	s := buildSyncer(t, newStubRemote())
+	require.NoError(t, s.localClient.Create(ctx, labeledMirror(testGVK, kept.Namespace, kept.Name)))
+	require.NoError(t, s.localClient.Create(ctx, labeledMirror(testGVK, orphan.Namespace, orphan.Name)))
+	s.remoteList = stubRemoteList([]syncKey{kept}, nil)
+
+	s.pruneOnce(ctx)
+
+	require.Equal(t, 1, s.queue.Len(), "only the mirror missing from Active should be enqueued")
+	got, _ := s.queue.Get()
+	assert.Equal(t, orphan, got)
+}
+
+func TestPruneOnce_ThenWorkerDeletesOrphan(t *testing.T) {
+	ctx := context.Background()
+	orphan := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "sc-orphan"}
+
+	// The stub remote holds nothing, so the worker's re-read reports NotFound
+	// — the same path an informer-delivered delete takes.
+	s := buildSyncer(t, newStubRemote())
+	require.NoError(t, s.localClient.Create(ctx, labeledMirror(testGVK, orphan.Namespace, orphan.Name)))
+	s.remoteList = stubRemoteList(nil, nil)
+
+	s.pruneOnce(ctx)
+	key, shutdown := s.queue.Get()
+	require.False(t, shutdown)
+	s.processOnce(ctx, key)
+
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(testGVK)
+	err := s.localClient.Get(ctx, types.NamespacedName{Namespace: orphan.Namespace, Name: orphan.Name}, got)
+	assert.True(t, apierrors.IsNotFound(err), "the orphaned mirror should be gone after the worker processes the pruned key")
+}
+
+func TestPruneOnce_LeavesUnlabeledObjectsAlone(t *testing.T) {
+	ctx := context.Background()
+	s := buildSyncer(t, newStubRemote())
+	// An object the Standby's own users created — no sync label — must never
+	// be pruned, even though Active has no such object.
+	require.NoError(t, s.localClient.Create(ctx, newTestUnstructured(testGVK, "proj-a", "hand-created")))
+	s.remoteList = stubRemoteList(nil, nil)
+
+	s.pruneOnce(ctx)
+
+	assert.Equal(t, 0, s.queue.Len(), "objects without the sync label are not the engine's to prune")
+}
+
+func TestPruneOnce_SkipsKindWhenRemoteListFails(t *testing.T) {
+	ctx := context.Background()
+	orphan := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "sc-orphan"}
+
+	s := buildSyncer(t, newStubRemote())
+	require.NoError(t, s.localClient.Create(ctx, labeledMirror(testGVK, orphan.Namespace, orphan.Name)))
+	s.remoteList = stubRemoteList(nil, fmt.Errorf("simulated transient list failure"))
+
+	s.pruneOnce(ctx)
+
+	assert.Equal(t, 0, s.queue.Len(), "a failed list must not be read as \"everything was deleted on Active\"")
+}
+
+func TestRunPrune_DoesNotPruneBeforeCacheSync(t *testing.T) {
+	s := buildSyncer(t, newStubRemote())
+	s.pruneInterval = time.Millisecond
+	s.waitForCacheSync = func(ctx context.Context) bool { return false } // never syncs (ctx cancelled)
+
+	var listCalls int32
+	s.remoteList = func(_ context.Context, _ schema.GroupVersionKind) (map[syncKey]struct{}, error) {
+		atomic.AddInt32(&listCalls, 1)
+		return nil, nil
+	}
+
+	done := make(chan struct{})
+	go func() { s.runPrune(context.Background()); close(done) }()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runPrune did not return after waitForCacheSync reported failure")
+	}
+	assert.Equal(t, int32(0), atomic.LoadInt32(&listCalls),
+		"pruning against an unsynced cache would delete every mirror; runPrune must bail out instead")
+}
+
+func TestRunPrune_TicksAndStopsOnContextCancel(t *testing.T) {
+	s := buildSyncer(t, newStubRemote())
+	s.pruneInterval = 5 * time.Millisecond
+	s.waitForCacheSync = func(ctx context.Context) bool { return true }
+
+	var listCalls int32
+	s.remoteList = func(_ context.Context, _ schema.GroupVersionKind) (map[syncKey]struct{}, error) {
+		atomic.AddInt32(&listCalls, 1)
+		return nil, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { s.runPrune(ctx); close(done) }()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for atomic.LoadInt32(&listCalls) == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	require.Greater(t, atomic.LoadInt32(&listCalls), int32(0), "the prune loop should tick once the cache is synced")
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runPrune did not return after context cancellation")
+	}
+}

--- a/pkg/ha/prune_test.go
+++ b/pkg/ha/prune_test.go
@@ -119,6 +119,49 @@ func TestPruneOnce_SkipsKindWhenRemoteListFails(t *testing.T) {
 	assert.Equal(t, 0, s.queue.Len(), "a failed list must not be read as \"everything was deleted on Active\"")
 }
 
+func TestPruneOnce_ReverseDiffEnqueuesActiveObjectsMissingLocally(t *testing.T) {
+	ctx := context.Background()
+	missing := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "sc-missing"}
+
+	// Active has an object the Standby has no mirror of — a create the
+	// forward (orphan) pass can't see: a mirror deleted directly on the
+	// Standby, a skip decided before the namespace informer synced, or a key
+	// stuck deep in retry backoff.
+	s := buildSyncer(t, newStubRemote())
+	s.remoteList = stubRemoteList([]syncKey{missing}, nil)
+
+	s.pruneOnce(ctx)
+
+	require.Equal(t, 1, s.queue.Len())
+	got, _ := s.queue.Get()
+	assert.Equal(t, missing, got)
+}
+
+func TestPruneOnce_ReverseDiffCannotOverrideConflictGuard(t *testing.T) {
+	ctx := context.Background()
+	key := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "hand-created"}
+
+	// The object exists on both sides, but the Standby's copy is not
+	// syncer-owned (no sync label) — so it is absent from the forward pass's
+	// labeled listing and the reverse diff re-enqueues it every round. That
+	// must stay harmless: the worker's conflict guard refuses the write.
+	remote := newStubRemote()
+	remote.objects[key] = newTestUnstructured(testGVK, key.Namespace, key.Name)
+	s := buildSyncer(t, remote)
+	require.NoError(t, s.localClient.Create(ctx, newTestUnstructured(testGVK, key.Namespace, key.Name)))
+	s.remoteList = stubRemoteList([]syncKey{key}, nil)
+
+	s.pruneOnce(ctx)
+	k, shutdown := s.queue.Get()
+	require.False(t, shutdown)
+	require.Equal(t, key, k)
+	s.processOnce(ctx, k)
+
+	got := getUnstructured(t, s.localClient, key)
+	assert.NotEqual(t, LabelValueActive, got.GetLabels()[LabelSyncedFromActive],
+		"a hand-created Standby object must never be adopted by the mirror, even via the prune loop")
+}
+
 func TestRunPrune_DoesNotPruneBeforeCacheSync(t *testing.T) {
 	s := buildSyncer(t, newStubRemote())
 	s.pruneInterval = time.Millisecond

--- a/pkg/ha/remote_syncer.go
+++ b/pkg/ha/remote_syncer.go
@@ -1,0 +1,316 @@
+/*
+ * 	Copyright (c) 2022 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/rest"
+	toolscache "k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kubeslice/kubeslice-controller/util"
+)
+
+// Default RemoteSyncer tunables, overridable through RemoteSyncerOptions.
+const (
+	DefaultSyncWorkers          = 4
+	DefaultInformerResyncPeriod = 10 * time.Minute
+)
+
+// opDelete extends mirror.go's opCreate/opUpdate for use in this file's
+// metrics/logging; mirrorDelete itself has no ambiguity about which
+// operation it performed, so it doesn't need to return one.
+const opDelete mirrorOp = "delete"
+
+// remoteGetFunc reads one object from the Active hub by key. The real
+// implementation (getFromRemoteCache) reads controller-runtime's cache, which
+// is itself a local-indexer read, not network I/O — so retrying via this
+// function is cheap even under the workqueue's backoff. Overridable in tests
+// so the retry engine is exercised without a real *rest.Config.
+type remoteGetFunc func(ctx context.Context, key syncKey) (*unstructured.Unstructured, error)
+
+// RemoteSyncerOptions configures a RemoteSyncer. Zero-valued fields fall back
+// to the Default* constants, matching pkg/ha's existing Options pattern
+// (see ClusterLeaderElector's Options in leader_elector.go).
+type RemoteSyncerOptions struct {
+	// Resources is the mirrored-resource table. Defaults to CRDMirrorSet.
+	Resources []MirroredResource
+	// Workers is the number of goroutines draining the mirror workqueue.
+	Workers int
+	Log     *zap.SugaredLogger
+}
+
+// RemoteSyncer mirrors a fixed set of resources from the Active hub onto the
+// Standby's own cluster. It runs only in standby mode: informer event
+// handlers enqueue a syncKey (no mirror logic in the callback itself), and a
+// small worker pool dequeues, re-reads the object from the Active cache, and
+// mirrors it — retrying with backoff via a rate-limited workqueue on any
+// failure, the same primitive controller-runtime's own Controller uses
+// internally. See ADR #293 and issue #295.
+type RemoteSyncer struct {
+	mode        HAMode
+	localClient client.Client
+	remoteCache cache.Cache
+	remoteGet   remoteGetFunc
+
+	resources []MirroredResource
+	byGVK     map[schema.GroupVersionKind]MirroredResource
+
+	workers int
+	queue   workqueue.TypedRateLimitingInterface[syncKey]
+
+	// enqueuedAt tracks first-enqueue time per key, so update/delete lag
+	// reflects total time since the triggering change even after a
+	// coalescing queue collapses repeated events and retries into one item.
+	mu         sync.Mutex
+	enqueuedAt map[syncKey]time.Time
+
+	log *zap.SugaredLogger
+}
+
+// NewRemoteSyncer builds a RemoteSyncer. remoteCfg and scheme are only used
+// (and required) in standby mode, mirroring how NewClusterLeaderElector
+// accepts a possibly-nil remote client for non-standby modes.
+func NewRemoteSyncer(localClient client.Client, remoteCfg *rest.Config, scheme *runtime.Scheme, mode HAMode, opts RemoteSyncerOptions) (*RemoteSyncer, error) {
+	if len(opts.Resources) == 0 {
+		opts.Resources = CRDMirrorSet
+	}
+	if opts.Workers == 0 {
+		opts.Workers = DefaultSyncWorkers
+	}
+	if opts.Log == nil {
+		opts.Log = util.NewLogger().With("name", "ha-remote-syncer")
+	}
+
+	byGVK := make(map[schema.GroupVersionKind]MirroredResource, len(opts.Resources))
+	for _, res := range opts.Resources {
+		byGVK[res.GVK] = res
+	}
+
+	s := &RemoteSyncer{
+		mode:        mode,
+		localClient: localClient,
+		resources:   opts.Resources,
+		byGVK:       byGVK,
+		workers:     opts.Workers,
+		queue:       workqueue.NewTypedRateLimitingQueue[syncKey](workqueue.DefaultTypedControllerRateLimiter[syncKey]()),
+		enqueuedAt:  make(map[syncKey]time.Time),
+		log:         opts.Log,
+	}
+
+	if mode == ModeStandby {
+		if remoteCfg == nil {
+			return nil, fmt.Errorf("standby mode requires a remote config for the active hub")
+		}
+		remoteCache, err := cache.New(remoteCfg, cache.Options{Scheme: scheme})
+		if err != nil {
+			return nil, fmt.Errorf("building remote cache: %w", err)
+		}
+		s.remoteCache = remoteCache
+		s.remoteGet = s.getFromRemoteCache
+	}
+
+	return s, nil
+}
+
+// Start runs RemoteSyncer until ctx is cancelled. It is a no-op in any mode
+// other than standby. It returns nil (not ctx.Err()) on graceful shutdown,
+// the same contract StartLeaseRenewal/WatchRemoteLease use.
+func (s *RemoteSyncer) Start(ctx context.Context) error {
+	if s.mode != ModeStandby {
+		s.log.Infow("remote syncer not started; not in standby mode", "mode", s.mode)
+		return nil
+	}
+
+	for _, res := range s.resources {
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(res.GVK)
+		inf, err := s.remoteCache.GetInformer(ctx, u)
+		if err != nil {
+			return fmt.Errorf("remote syncer: getting informer for %s: %w", res.GVK, err)
+		}
+		if _, err := inf.AddEventHandlerWithResyncPeriod(s.handlersFor(res.GVK), DefaultInformerResyncPeriod); err != nil {
+			return fmt.Errorf("remote syncer: adding handler for %s: %w", res.GVK, err)
+		}
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < s.workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			s.runWorker(ctx)
+		}()
+	}
+
+	s.log.Infow("remote syncer started", "resources", len(s.resources), "workers", s.workers)
+	err := s.remoteCache.Start(ctx) // blocks until ctx.Done(); returns nil on graceful shutdown
+	s.queue.ShutDown()
+	wg.Wait()
+	return err
+}
+
+// handlersFor returns the informer callbacks for one GVK. They only enqueue a
+// syncKey — no mirror logic runs on the informer's own goroutine. A burst of
+// Update events for the same object coalesces into one queued item; the
+// worker determines the real action at dequeue time by re-reading the Active
+// cache (found -> mirror, NotFound -> delete), the same way a Reconcile call
+// would.
+func (s *RemoteSyncer) handlersFor(objGVK schema.GroupVersionKind) toolscache.ResourceEventHandlerFuncs {
+	enqueue := func(obj interface{}) {
+		if tomb, ok := obj.(toolscache.DeletedFinalStateUnknown); ok {
+			obj = tomb.Obj
+		}
+		u, ok := obj.(*unstructured.Unstructured)
+		if !ok {
+			s.log.Warnw("remote syncer: unexpected informer object type", "type", fmt.Sprintf("%T", obj))
+			return
+		}
+		key := syncKey{GVK: objGVK, Namespace: u.GetNamespace(), Name: u.GetName()}
+		s.markEnqueued(key)
+		s.queue.Add(key)
+	}
+	return toolscache.ResourceEventHandlerFuncs{
+		AddFunc:    func(obj interface{}) { enqueue(obj) },
+		UpdateFunc: func(_, newObj interface{}) { enqueue(newObj) },
+		DeleteFunc: func(obj interface{}) { enqueue(obj) },
+	}
+}
+
+func (s *RemoteSyncer) runWorker(ctx context.Context) {
+	for {
+		key, shutdown := s.queue.Get()
+		if shutdown {
+			return
+		}
+		s.processOnce(ctx, key)
+	}
+}
+
+// processOnce dequeues exactly one key and mirrors it. Any error — including
+// a namespaced object created before its Namespace has synced, the concrete
+// failure mode that motivated this design — is retried with backoff via
+// queue.AddRateLimited rather than dropped, satisfying issue #295's own
+// acceptance criterion that the syncer retries without crashing.
+func (s *RemoteSyncer) processOnce(ctx context.Context, key syncKey) {
+	defer s.queue.Done(key)
+
+	op, lagSeconds, err := s.reconcileKey(ctx, key)
+	if err != nil {
+		label := string(op)
+		if label == "" {
+			label = "sync"
+		}
+		haSyncErrorsTotal.WithLabelValues(key.GVK.Kind, label).Inc()
+		s.log.Warnw("mirror sync failed; will retry", "kind", key.GVK.Kind,
+			"namespace", key.Namespace, "name", key.Name,
+			"attempt", s.queue.NumRequeues(key), "error", err)
+		s.queue.AddRateLimited(key)
+		return
+	}
+	if op != "" {
+		haSyncLagSeconds.WithLabelValues(key.GVK.Kind, string(op)).Observe(lagSeconds)
+	}
+	s.queue.Forget(key)
+	s.clearEnqueued(key)
+}
+
+// reconcileKey reads the current state of key from the Active hub and
+// mirrors it: NotFound -> delete, found -> create-or-update. It returns the
+// operation performed ("" if the conflict guard or a Skip predicate
+// suppressed it) and the lag to record for that operation.
+func (s *RemoteSyncer) reconcileKey(ctx context.Context, key syncKey) (mirrorOp, float64, error) {
+	res, ok := s.byGVK[key.GVK]
+	if !ok {
+		return "", 0, nil
+	}
+
+	src, err := s.remoteGet(ctx, key)
+	switch {
+	case apierrors.IsNotFound(err):
+		if err := mirrorDelete(ctx, s.localClient, key); err != nil {
+			return opDelete, 0, err
+		}
+		return opDelete, time.Since(s.enqueuedTime(key)).Seconds(), nil
+	case err != nil:
+		return "", 0, fmt.Errorf("reading from active cache: %w", err)
+	}
+
+	if res.Skip != nil && res.Skip(src) {
+		return "", 0, nil
+	}
+
+	op, err := mirrorCreateOrUpdate(ctx, s.localClient, key, res, src)
+	if err != nil {
+		return op, 0, err
+	}
+	if op == "" {
+		return "", 0, nil // conflict guard skipped it
+	}
+	if op == opCreate {
+		return op, time.Since(src.GetCreationTimestamp().Time).Seconds(), nil
+	}
+	return op, time.Since(s.enqueuedTime(key)).Seconds(), nil
+}
+
+// getFromRemoteCache is remoteGetFunc's real implementation: a read from
+// controller-runtime's cache, which serves Get from the informer's local
+// indexer rather than the network, so it stays cheap even when a retry
+// re-reads the same key minutes later under backoff.
+func (s *RemoteSyncer) getFromRemoteCache(ctx context.Context, key syncKey) (*unstructured.Unstructured, error) {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(key.GVK)
+	if err := s.remoteCache.Get(ctx, types.NamespacedName{Namespace: key.Namespace, Name: key.Name}, u); err != nil {
+		return nil, err
+	}
+	return u, nil
+}
+
+func (s *RemoteSyncer) markEnqueued(key syncKey) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.enqueuedAt[key]; !exists {
+		s.enqueuedAt[key] = time.Now()
+	}
+}
+
+func (s *RemoteSyncer) clearEnqueued(key syncKey) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.enqueuedAt, key)
+}
+
+func (s *RemoteSyncer) enqueuedTime(key syncKey) time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if t, ok := s.enqueuedAt[key]; ok {
+		return t
+	}
+	return time.Now()
+}

--- a/pkg/ha/remote_syncer.go
+++ b/pkg/ha/remote_syncer.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kubeslice/kubeslice-monitoring/pkg/events"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -36,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ossEvents "github.com/kubeslice/kubeslice-controller/events"
 	"github.com/kubeslice/kubeslice-controller/util"
 )
 
@@ -89,6 +91,11 @@ type RemoteSyncerOptions struct {
 	// PruneInterval is how often the prune backstop diffs Standby mirrors
 	// against the Active hub and removes orphans (see prune.go).
 	PruneInterval time.Duration
+	// EventRecorder, if set, gets an HAMirrorSyncFailed event on the first
+	// failure of each mirror-failure episode, attached to the object that
+	// failed to sync. Nil disables event emission (metrics and retries are
+	// unaffected).
+	EventRecorder events.EventRecorder
 	Log           *zap.SugaredLogger
 }
 
@@ -139,7 +146,8 @@ type RemoteSyncer struct {
 	mu         sync.Mutex
 	enqueuedAt map[syncKey]time.Time
 
-	log *zap.SugaredLogger
+	eventRecorder events.EventRecorder
+	log           *zap.SugaredLogger
 }
 
 // NewRemoteSyncer builds a RemoteSyncer. remoteCfg and scheme are only used
@@ -178,6 +186,7 @@ func NewRemoteSyncer(localClient client.Client, remoteCfg *rest.Config, scheme *
 		queue:             workqueue.NewTypedRateLimitingQueue[syncKey](workqueue.DefaultTypedControllerRateLimiter[syncKey]()),
 		handlerRegistered: make(map[schema.GroupVersionKind]bool, len(opts.Resources)),
 		enqueuedAt:        make(map[syncKey]time.Time),
+		eventRecorder:     opts.EventRecorder,
 		log:               opts.Log,
 	}
 	s.register = s.registerInformersOnce
@@ -356,6 +365,33 @@ func (s *RemoteSyncer) processOnce(ctx context.Context, key syncKey) {
 		s.log.Warnw("mirror sync failed; will retry", "kind", key.GVK.Kind,
 			"namespace", key.Namespace, "name", key.Name,
 			"attempt", s.queue.NumRequeues(key), "error", err)
+		// One HAMirrorSyncFailed event per failure episode (NumRequeues is
+		// still 0 here on the first failure; Forget resets it on success).
+		// The retries that follow are milliseconds apart under early
+		// backoff, and although the recorder aggregates repeats into one
+		// Event's Count, every call is still an API-server write —
+		// per-attempt emission would turn each outage into a write storm
+		// while ha_sync_errors_total already counts every attempt.
+		// The recorder is called directly rather than through
+		// util.RecordEvent: that helper logs via util.CtxLogger, which
+		// panics on any context that didn't pass through a reconciler's
+		// PrepareKubeSliceControllersRequestContext — and Start's context
+		// (main.go's signal-handler context) never does.
+		if s.eventRecorder != nil && s.queue.NumRequeues(key) == 0 {
+			obj := &unstructured.Unstructured{}
+			obj.SetGroupVersionKind(key.GVK)
+			obj.SetNamespace(key.Namespace)
+			obj.SetName(key.Name)
+			if recErr := s.eventRecorder.RecordEvent(ctx, &events.Event{
+				Object:            obj,
+				ReportingInstance: util.InstanceController,
+				Name:              ossEvents.EventHAMirrorSyncFailed,
+			}); recErr != nil {
+				s.log.Warnw("failed to record mirror-sync-failed event",
+					"kind", key.GVK.Kind, "namespace", key.Namespace,
+					"name", key.Name, "error", recErr)
+			}
+		}
 		s.queue.AddRateLimited(key)
 		return
 	}

--- a/pkg/ha/remote_syncer.go
+++ b/pkg/ha/remote_syncer.go
@@ -23,8 +23,10 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -41,7 +43,25 @@ import (
 const (
 	DefaultSyncWorkers          = 4
 	DefaultInformerResyncPeriod = 10 * time.Minute
+	// DefaultInformerSetupRetryPeriod is how long Start waits between retries
+	// when wiring up the remote informers fails (e.g. the Active hub is
+	// briefly unreachable, or its RBAC from config/ha hasn't been applied
+	// yet at the moment the Standby pod starts).
+	DefaultInformerSetupRetryPeriod = 5 * time.Second
 )
+
+// namespaceMirrorSelector scopes the Namespace informer to only the
+// namespaces this controller itself manages — every project namespace
+// NamespaceService.ReconcileProjectNamespace creates carries this label (see
+// util.LabelsKubeSliceController). Without it, the informer would watch
+// every namespace on the Active hub cluster-wide (kube-system, kube-public,
+// unrelated infra namespaces), and mirrorDelete (mirror.go) would delete any
+// of those incidentally-mirrored namespaces — cascading to delete everything
+// inside them on the Standby — the moment the Active hub deletes its copy
+// for a completely unrelated reason.
+func namespaceMirrorSelector() labels.Selector {
+	return labels.SelectorFromSet(util.LabelsKubeSliceController)
+}
 
 // opDelete extends mirror.go's opCreate/opUpdate for use in this file's
 // metrics/logging; mirrorDelete itself has no ambiguity about which
@@ -63,7 +83,10 @@ type RemoteSyncerOptions struct {
 	Resources []MirroredResource
 	// Workers is the number of goroutines draining the mirror workqueue.
 	Workers int
-	Log     *zap.SugaredLogger
+	// SetupRetryPeriod is how long Start waits between retries when wiring up
+	// the remote informers fails.
+	SetupRetryPeriod time.Duration
+	Log              *zap.SugaredLogger
 }
 
 // RemoteSyncer mirrors a fixed set of resources from the Active hub onto the
@@ -82,8 +105,24 @@ type RemoteSyncer struct {
 	resources []MirroredResource
 	byGVK     map[schema.GroupVersionKind]MirroredResource
 
-	workers int
-	queue   workqueue.TypedRateLimitingInterface[syncKey]
+	workers          int
+	setupRetryPeriod time.Duration
+	queue            workqueue.TypedRateLimitingInterface[syncKey]
+	// register performs one attempt at wiring informer event handlers for
+	// every mirrored resource. Kept as a field (rather than calling
+	// registerInformersOnce directly) so tests can exercise the retry loop
+	// in Start without a real *rest.Config, the same reason remoteGet exists.
+	register func(ctx context.Context) error
+	// handlerRegistered tracks which GVKs already have their event handler
+	// wired up, so a retried registerInformersOnce (after a later resource in
+	// the list failed) skips the ones that already succeeded instead of
+	// calling AddEventHandlerWithResyncPeriod on them again. Informer.
+	// AddEventHandlerWithResyncPeriod adds an independent handler on every
+	// call — it is not idempotent like GetInformer — so without this guard a
+	// retry would double (or triple, ...) that resource's event and resync
+	// load for the rest of the process's lifetime. Only ever touched from
+	// Start's single call path, so it needs no locking.
+	handlerRegistered map[schema.GroupVersionKind]bool
 
 	// enqueuedAt tracks first-enqueue time per key, so update/delete lag
 	// reflects total time since the triggering change even after a
@@ -104,6 +143,9 @@ func NewRemoteSyncer(localClient client.Client, remoteCfg *rest.Config, scheme *
 	if opts.Workers == 0 {
 		opts.Workers = DefaultSyncWorkers
 	}
+	if opts.SetupRetryPeriod == 0 {
+		opts.SetupRetryPeriod = DefaultInformerSetupRetryPeriod
+	}
 	if opts.Log == nil {
 		opts.Log = util.NewLogger().With("name", "ha-remote-syncer")
 	}
@@ -114,21 +156,31 @@ func NewRemoteSyncer(localClient client.Client, remoteCfg *rest.Config, scheme *
 	}
 
 	s := &RemoteSyncer{
-		mode:        mode,
-		localClient: localClient,
-		resources:   opts.Resources,
-		byGVK:       byGVK,
-		workers:     opts.Workers,
-		queue:       workqueue.NewTypedRateLimitingQueue[syncKey](workqueue.DefaultTypedControllerRateLimiter[syncKey]()),
-		enqueuedAt:  make(map[syncKey]time.Time),
-		log:         opts.Log,
+		mode:              mode,
+		localClient:       localClient,
+		resources:         opts.Resources,
+		byGVK:             byGVK,
+		workers:           opts.Workers,
+		setupRetryPeriod:  opts.SetupRetryPeriod,
+		queue:             workqueue.NewTypedRateLimitingQueue[syncKey](workqueue.DefaultTypedControllerRateLimiter[syncKey]()),
+		handlerRegistered: make(map[schema.GroupVersionKind]bool, len(opts.Resources)),
+		enqueuedAt:        make(map[syncKey]time.Time),
+		log:               opts.Log,
 	}
+	s.register = s.registerInformersOnce
 
 	if mode == ModeStandby {
 		if remoteCfg == nil {
 			return nil, fmt.Errorf("standby mode requires a remote config for the active hub")
 		}
-		remoteCache, err := cache.New(remoteCfg, cache.Options{Scheme: scheme})
+		remoteCache, err := cache.New(remoteCfg, cache.Options{
+			Scheme: scheme,
+			ByObject: map[client.Object]cache.ByObject{
+				// Namespace is cluster-scoped and otherwise unfiltered; see
+				// namespaceMirrorSelector's doc comment for why this matters.
+				&corev1.Namespace{}: {Label: namespaceMirrorSelector()},
+			},
+		})
 		if err != nil {
 			return nil, fmt.Errorf("building remote cache: %w", err)
 		}
@@ -148,16 +200,8 @@ func (s *RemoteSyncer) Start(ctx context.Context) error {
 		return nil
 	}
 
-	for _, res := range s.resources {
-		u := &unstructured.Unstructured{}
-		u.SetGroupVersionKind(res.GVK)
-		inf, err := s.remoteCache.GetInformer(ctx, u)
-		if err != nil {
-			return fmt.Errorf("remote syncer: getting informer for %s: %w", res.GVK, err)
-		}
-		if _, err := inf.AddEventHandlerWithResyncPeriod(s.handlersFor(res.GVK), DefaultInformerResyncPeriod); err != nil {
-			return fmt.Errorf("remote syncer: adding handler for %s: %w", res.GVK, err)
-		}
+	if !s.registerInformers(ctx) {
+		return nil // ctx cancelled while retrying informer setup
 	}
 
 	var wg sync.WaitGroup
@@ -174,6 +218,55 @@ func (s *RemoteSyncer) Start(ctx context.Context) error {
 	s.queue.ShutDown()
 	wg.Wait()
 	return err
+}
+
+// registerInformers wires up an event handler for every mirrored resource,
+// retrying with backoff via s.register on failure — e.g. the Active hub
+// briefly unreachable at Standby startup, or its config/ha RBAC not yet
+// applied — instead of giving up after one attempt. Without this, a single
+// transient failure here would return an error from Start and permanently
+// disable mirroring for the process's lifetime (main.go only logs that
+// error; nothing restarts the goroutine), unlike StartLeaseRenewal and
+// WatchRemoteLease, which retry every tick regardless of error. Returns
+// false only if ctx is cancelled before setup succeeds.
+func (s *RemoteSyncer) registerInformers(ctx context.Context) bool {
+	for {
+		err := s.register(ctx)
+		if err == nil {
+			return true
+		}
+		s.log.Warnw("remote syncer: informer setup failed; retrying",
+			"error", err, "retryAfter", s.setupRetryPeriod)
+		select {
+		case <-ctx.Done():
+			return false
+		case <-time.After(s.setupRetryPeriod):
+		}
+	}
+}
+
+// registerInformersOnce is register's real implementation: a single attempt
+// at wiring an event handler for every mirrored resource onto the remote
+// cache. Resources whose handler already got registered by an earlier,
+// partially-failed attempt are skipped — see handlerRegistered's doc comment
+// for why that matters.
+func (s *RemoteSyncer) registerInformersOnce(ctx context.Context) error {
+	for _, res := range s.resources {
+		if s.handlerRegistered[res.GVK] {
+			continue
+		}
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(res.GVK)
+		inf, err := s.remoteCache.GetInformer(ctx, u)
+		if err != nil {
+			return fmt.Errorf("remote syncer: getting informer for %s: %w", res.GVK, err)
+		}
+		if _, err := inf.AddEventHandlerWithResyncPeriod(s.handlersFor(res.GVK), DefaultInformerResyncPeriod); err != nil {
+			return fmt.Errorf("remote syncer: adding handler for %s: %w", res.GVK, err)
+		}
+		s.handlerRegistered[res.GVK] = true
+	}
+	return nil
 }
 
 // handlersFor returns the informer callbacks for one GVK. They only enqueue a

--- a/pkg/ha/remote_syncer.go
+++ b/pkg/ha/remote_syncer.go
@@ -25,8 +25,10 @@ import (
 	"github.com/kubeslice/kubeslice-monitoring/pkg/events"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -63,6 +65,36 @@ const (
 // for a completely unrelated reason.
 func namespaceMirrorSelector() labels.Selector {
 	return labels.SelectorFromSet(util.LabelsKubeSliceController)
+}
+
+// mirrorCacheByObject scopes the remote cache's informers server-side, so
+// unrelated Active-hub objects never reach this process at all — the mirror
+// set's Skip predicates enforce the same boundaries client-side, but for
+// core types that exist cluster-wide (Secrets above all) not watching them
+// in the first place is both the cheaper and the safer layer.
+//
+//   - Namespace, ServiceAccount, Role, RoleBinding: label-scoped to
+//     util.LabelsKubeSliceController — stamped on every project namespace by
+//     ReconcileProjectNamespace and on every credential object the
+//     controller creates via util.GetOwnerLabel (which embeds the same
+//     key/value pair).
+//   - Secret: cannot be label-scoped — gateway certificate Secrets are
+//     created by the external cert-generator job, unlabeled. Scoped instead
+//     with a field selector excluding SA-token Secrets (the API server
+//     supports "type" as a Secret field selector), the highest-volume
+//     class; the project-namespace boundary stays client-side in
+//     CredentialMirrorSet's Skip predicate.
+func mirrorCacheByObject() map[client.Object]cache.ByObject {
+	controllerManaged := namespaceMirrorSelector()
+	return map[client.Object]cache.ByObject{
+		&corev1.Namespace{}:      {Label: controllerManaged},
+		&corev1.ServiceAccount{}: {Label: controllerManaged},
+		&rbacv1.Role{}:           {Label: controllerManaged},
+		&rbacv1.RoleBinding{}:    {Label: controllerManaged},
+		&corev1.Secret{}: {
+			Field: fields.OneTermNotEqualSelector("type", string(corev1.SecretTypeServiceAccountToken)),
+		},
+	}
 }
 
 // opDelete extends mirror.go's opCreate/opUpdate for use in this file's
@@ -196,12 +228,8 @@ func NewRemoteSyncer(localClient client.Client, remoteCfg *rest.Config, scheme *
 			return nil, fmt.Errorf("standby mode requires a remote config for the active hub")
 		}
 		remoteCache, err := cache.New(remoteCfg, cache.Options{
-			Scheme: scheme,
-			ByObject: map[client.Object]cache.ByObject{
-				// Namespace is cluster-scoped and otherwise unfiltered; see
-				// namespaceMirrorSelector's doc comment for why this matters.
-				&corev1.Namespace{}: {Label: namespaceMirrorSelector()},
-			},
+			Scheme:   scheme,
+			ByObject: mirrorCacheByObject(),
 		})
 		if err != nil {
 			return nil, fmt.Errorf("building remote cache: %w", err)
@@ -426,6 +454,15 @@ func (s *RemoteSyncer) reconcileKey(ctx context.Context, key syncKey) (mirrorOp,
 	if res.Skip != nil && res.Skip(src) {
 		return "", 0, nil
 	}
+	if res.RequireMirroredNamespace {
+		mirrored, err := s.namespaceIsMirrored(ctx, src.GetNamespace())
+		if err != nil {
+			return "", 0, fmt.Errorf("checking namespace of %s %s/%s: %w", key.GVK.Kind, key.Namespace, key.Name, err)
+		}
+		if !mirrored {
+			return "", 0, nil
+		}
+	}
 
 	op, err := mirrorCreateOrUpdate(ctx, s.localClient, key, res, src)
 	if err != nil {
@@ -438,6 +475,32 @@ func (s *RemoteSyncer) reconcileKey(ctx context.Context, key syncKey) (mirrorOp,
 		return op, time.Since(src.GetCreationTimestamp().Time).Seconds(), nil
 	}
 	return op, time.Since(s.enqueuedTime(key)).Seconds(), nil
+}
+
+// namespaceIsMirrored reports whether ns is one of the namespaces the syncer
+// itself mirrors, by reading the remote cache's Namespace view — which is
+// label-scoped to controller-managed project namespaces (see
+// namespaceMirrorSelector), so any namespace outside that boundary reads as
+// NotFound here no matter what it is named. This is the namespace gate
+// behind MirroredResource.RequireMirroredNamespace.
+//
+// A skip verdict is terminal for this queue item (no retry), so an object
+// racing its own namespace's informer delivery on cold start can be skipped
+// once — the prune loop's reverse diff re-enqueues it within one
+// --ha-sync-interval (see pruneOnce), rather than waiting for the informer's
+// much longer resync period.
+func (s *RemoteSyncer) namespaceIsMirrored(ctx context.Context, ns string) (bool, error) {
+	if ns == "" {
+		return true, nil // cluster-scoped objects have no namespace to gate on
+	}
+	nsKey := syncKey{GVK: schema.GroupVersionKind{Version: "v1", Kind: "Namespace"}, Name: ns}
+	if _, err := s.remoteGet(ctx, nsKey); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 // getFromRemoteCache is remoteGetFunc's real implementation: a read from

--- a/pkg/ha/remote_syncer.go
+++ b/pkg/ha/remote_syncer.go
@@ -86,7 +86,10 @@ type RemoteSyncerOptions struct {
 	// SetupRetryPeriod is how long Start waits between retries when wiring up
 	// the remote informers fails.
 	SetupRetryPeriod time.Duration
-	Log              *zap.SugaredLogger
+	// PruneInterval is how often the prune backstop diffs Standby mirrors
+	// against the Active hub and removes orphans (see prune.go).
+	PruneInterval time.Duration
+	Log           *zap.SugaredLogger
 }
 
 // RemoteSyncer mirrors a fixed set of resources from the Active hub onto the
@@ -107,6 +110,12 @@ type RemoteSyncer struct {
 
 	workers          int
 	setupRetryPeriod time.Duration
+	pruneInterval    time.Duration
+	// remoteList and waitForCacheSync back the prune loop (prune.go); like
+	// remoteGet, they are fields so tests can drive pruning without a real
+	// *rest.Config.
+	remoteList       remoteListFunc
+	waitForCacheSync func(ctx context.Context) bool
 	queue            workqueue.TypedRateLimitingInterface[syncKey]
 	// register performs one attempt at wiring informer event handlers for
 	// every mirrored resource. Kept as a field (rather than calling
@@ -146,6 +155,9 @@ func NewRemoteSyncer(localClient client.Client, remoteCfg *rest.Config, scheme *
 	if opts.SetupRetryPeriod == 0 {
 		opts.SetupRetryPeriod = DefaultInformerSetupRetryPeriod
 	}
+	if opts.PruneInterval == 0 {
+		opts.PruneInterval = DefaultPruneInterval
+	}
 	if opts.Log == nil {
 		opts.Log = util.NewLogger().With("name", "ha-remote-syncer")
 	}
@@ -162,6 +174,7 @@ func NewRemoteSyncer(localClient client.Client, remoteCfg *rest.Config, scheme *
 		byGVK:             byGVK,
 		workers:           opts.Workers,
 		setupRetryPeriod:  opts.SetupRetryPeriod,
+		pruneInterval:     opts.PruneInterval,
 		queue:             workqueue.NewTypedRateLimitingQueue[syncKey](workqueue.DefaultTypedControllerRateLimiter[syncKey]()),
 		handlerRegistered: make(map[schema.GroupVersionKind]bool, len(opts.Resources)),
 		enqueuedAt:        make(map[syncKey]time.Time),
@@ -186,6 +199,8 @@ func NewRemoteSyncer(localClient client.Client, remoteCfg *rest.Config, scheme *
 		}
 		s.remoteCache = remoteCache
 		s.remoteGet = s.getFromRemoteCache
+		s.remoteList = s.listFromRemoteCache
+		s.waitForCacheSync = remoteCache.WaitForCacheSync
 	}
 
 	return s, nil
@@ -212,9 +227,20 @@ func (s *RemoteSyncer) Start(ctx context.Context) error {
 			s.runWorker(ctx)
 		}()
 	}
+	// The prune loop only watches its context, unlike the workers (which exit
+	// on queue shutdown) — cancel it explicitly so wg.Wait can't hang if the
+	// cache ever stops with an error before ctx itself is cancelled.
+	pruneCtx, cancelPrune := context.WithCancel(ctx)
+	defer cancelPrune()
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s.runPrune(pruneCtx)
+	}()
 
-	s.log.Infow("remote syncer started", "resources", len(s.resources), "workers", s.workers)
+	s.log.Infow("remote syncer started", "resources", len(s.resources), "workers", s.workers, "pruneInterval", s.pruneInterval)
 	err := s.remoteCache.Start(ctx) // blocks until ctx.Done(); returns nil on graceful shutdown
+	cancelPrune()
 	s.queue.ShutDown()
 	wg.Wait()
 	return err
@@ -285,15 +311,21 @@ func (s *RemoteSyncer) handlersFor(objGVK schema.GroupVersionKind) toolscache.Re
 			s.log.Warnw("remote syncer: unexpected informer object type", "type", fmt.Sprintf("%T", obj))
 			return
 		}
-		key := syncKey{GVK: objGVK, Namespace: u.GetNamespace(), Name: u.GetName()}
-		s.markEnqueued(key)
-		s.queue.Add(key)
+		s.enqueue(syncKey{GVK: objGVK, Namespace: u.GetNamespace(), Name: u.GetName()})
 	}
 	return toolscache.ResourceEventHandlerFuncs{
 		AddFunc:    func(obj interface{}) { enqueue(obj) },
 		UpdateFunc: func(_, newObj interface{}) { enqueue(newObj) },
 		DeleteFunc: func(obj interface{}) { enqueue(obj) },
 	}
+}
+
+// enqueue hands one key to the worker pool, stamping its first-enqueue time
+// for the lag metric. Both the informer handlers and the prune loop go
+// through here, so every mirror write shares one queue and one retry policy.
+func (s *RemoteSyncer) enqueue(key syncKey) {
+	s.markEnqueued(key)
+	s.queue.Add(key)
 }
 
 func (s *RemoteSyncer) runWorker(ctx context.Context) {

--- a/pkg/ha/remote_syncer_test.go
+++ b/pkg/ha/remote_syncer_test.go
@@ -1,0 +1,188 @@
+/*
+ * 	Copyright (c) 2022 Avesha, Inc. All rights reserved. # # SPDX-License-Identifier: Apache-2.0
+ *
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ */
+
+package ha
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	toolscache "k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+)
+
+// stubRemote is a remoteGetFunc backend the retry-engine tests drive
+// directly, so they exercise RemoteSyncer's workqueue/retry logic without a
+// real *rest.Config or live cluster.
+type stubRemote struct {
+	mu      sync.Mutex
+	objects map[syncKey]*unstructured.Unstructured
+	errs    map[syncKey]error
+	calls   map[syncKey]int
+}
+
+func newStubRemote() *stubRemote {
+	return &stubRemote{
+		objects: map[syncKey]*unstructured.Unstructured{},
+		errs:    map[syncKey]error{},
+		calls:   map[syncKey]int{},
+	}
+}
+
+func (s *stubRemote) get(_ context.Context, key syncKey) (*unstructured.Unstructured, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.calls[key]++
+	if err, ok := s.errs[key]; ok {
+		return nil, err
+	}
+	if obj, ok := s.objects[key]; ok {
+		return obj, nil
+	}
+	return nil, apierrors.NewNotFound(schema.GroupResource{Group: key.GVK.Group, Resource: key.GVK.Kind}, key.Name)
+}
+
+func (s *stubRemote) callCount(key syncKey) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.calls[key]
+}
+
+// buildSyncer constructs a RemoteSyncer by struct literal (in-package test),
+// backed by remote and a fast-backoff queue, bypassing NewRemoteSyncer's
+// cache.New so no *rest.Config is needed.
+func buildSyncer(t *testing.T, remote *stubRemote) *RemoteSyncer {
+	t.Helper()
+	return &RemoteSyncer{
+		mode:        ModeStandby,
+		localClient: mirrorFakeClient(t),
+		remoteGet:   remote.get,
+		resources:   []MirroredResource{{GVK: testGVK}},
+		byGVK:       map[schema.GroupVersionKind]MirroredResource{testGVK: {GVK: testGVK}},
+		workers:     1,
+		queue: workqueue.NewTypedRateLimitingQueue[syncKey](
+			workqueue.NewTypedItemExponentialFailureRateLimiter[syncKey](time.Millisecond, time.Second),
+		),
+		enqueuedAt: map[syncKey]time.Time{},
+		log:        testLog(),
+	}
+}
+
+func TestRemoteSyncer_ReconcileKey_FoundMirrorsCreate(t *testing.T) {
+	ctx := context.Background()
+	key := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "sc-1"}
+	remote := newStubRemote()
+	remote.objects[key] = newTestUnstructured(testGVK, key.Namespace, key.Name)
+
+	s := buildSyncer(t, remote)
+	op, _, err := s.reconcileKey(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, opCreate, op)
+
+	got := getUnstructured(t, s.localClient, key)
+	assert.Equal(t, LabelValueActive, got.GetLabels()[LabelSyncedFromActive])
+}
+
+func TestRemoteSyncer_ReconcileKey_NotFoundMirrorsDelete(t *testing.T) {
+	ctx := context.Background()
+	key := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "sc-1"}
+	remote := newStubRemote() // nothing registered -> NotFound
+
+	s := buildSyncer(t, remote)
+	existing := newTestUnstructured(testGVK, key.Namespace, key.Name)
+	existing.SetLabels(map[string]string{LabelSyncedFromActive: LabelValueActive})
+	require.NoError(t, s.localClient.Create(ctx, existing))
+
+	op, _, err := s.reconcileKey(ctx, key)
+	require.NoError(t, err)
+	assert.Equal(t, opDelete, op)
+
+	got := &unstructured.Unstructured{}
+	got.SetGroupVersionKind(key.GVK)
+	err = s.localClient.Get(ctx, types.NamespacedName{Namespace: key.Namespace, Name: key.Name}, got)
+	assert.True(t, apierrors.IsNotFound(err), "the Standby mirror should be gone once Active reports NotFound")
+}
+
+func TestRemoteSyncer_ProcessOnce_RetriesOnErrorAndRedelivers(t *testing.T) {
+	ctx := context.Background()
+	key := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "sc-1"}
+	remote := newStubRemote()
+	remote.errs[key] = fmt.Errorf("simulated transient read failure")
+
+	s := buildSyncer(t, remote)
+	s.queue.Add(key)
+
+	got, shutdown := s.queue.Get()
+	require.False(t, shutdown)
+	require.Equal(t, key, got)
+	s.processOnce(ctx, got)
+
+	// AddRateLimited schedules redelivery asynchronously; poll briefly for it
+	// rather than sleeping a fixed guess.
+	deadline := time.Now().Add(2 * time.Second)
+	redelivered := false
+	for time.Now().Before(deadline) {
+		if s.queue.Len() > 0 {
+			redelivered = true
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	assert.True(t, redelivered, "a failed sync must be retried, not dropped (issue #295's own acceptance criterion)")
+	assert.GreaterOrEqual(t, remote.callCount(key), 1)
+}
+
+func TestRemoteSyncer_HandlersFor_UnwrapsDeletedFinalStateUnknown(t *testing.T) {
+	s := buildSyncer(t, newStubRemote())
+	handlers := s.handlersFor(testGVK)
+
+	u := newTestUnstructured(testGVK, "proj-a", "sc-1")
+	handlers.DeleteFunc(toolscache.DeletedFinalStateUnknown{Key: "proj-a/sc-1", Obj: u})
+
+	key := syncKey{GVK: testGVK, Namespace: "proj-a", Name: "sc-1"}
+	require.Equal(t, 1, s.queue.Len())
+	got, _ := s.queue.Get()
+	assert.Equal(t, key, got)
+}
+
+func TestRemoteSyncer_HandlersFor_IgnoresUnexpectedType(t *testing.T) {
+	s := buildSyncer(t, newStubRemote())
+	handlers := s.handlersFor(testGVK)
+	handlers.AddFunc("not-an-unstructured")
+	assert.Equal(t, 0, s.queue.Len())
+}
+
+func TestRemoteSyncer_Start_NoopWhenNotStandby(t *testing.T) {
+	c := mirrorFakeClient(t)
+	s, err := NewRemoteSyncer(c, nil, nil, ModeStandalone, RemoteSyncerOptions{Log: testLog()})
+	require.NoError(t, err)
+	assert.NoError(t, s.Start(context.Background()))
+}
+
+func TestNewRemoteSyncer_StandbyRequiresRemoteConfig(t *testing.T) {
+	c := mirrorFakeClient(t)
+	_, err := NewRemoteSyncer(c, nil, testScheme(t), ModeStandby, RemoteSyncerOptions{Log: testLog()})
+	assert.Error(t, err)
+}

--- a/pkg/ha/remote_syncer_test.go
+++ b/pkg/ha/remote_syncer_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -27,10 +28,15 @@ import (
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	toolscache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kubeslice/kubeslice-controller/util"
 )
 
 // stubRemote is a remoteGetFunc backend the retry-engine tests drive
@@ -85,9 +91,44 @@ func buildSyncer(t *testing.T, remote *stubRemote) *RemoteSyncer {
 		queue: workqueue.NewTypedRateLimitingQueue[syncKey](
 			workqueue.NewTypedItemExponentialFailureRateLimiter[syncKey](time.Millisecond, time.Second),
 		),
-		enqueuedAt: map[syncKey]time.Time{},
-		log:        testLog(),
+		handlerRegistered: map[schema.GroupVersionKind]bool{},
+		enqueuedAt:        map[syncKey]time.Time{},
+		log:               testLog(),
 	}
+}
+
+// stubInformer is a minimal cache.Informer fake that only counts
+// AddEventHandlerWithResyncPeriod calls; every other method panics via the
+// embedded nil interface if exercised (registerInformersOnce never touches
+// them).
+type stubInformer struct {
+	cache.Informer
+	addCalls int
+}
+
+func (i *stubInformer) AddEventHandlerWithResyncPeriod(_ toolscache.ResourceEventHandler, _ time.Duration) (toolscache.ResourceEventHandlerRegistration, error) {
+	i.addCalls++
+	return nil, nil
+}
+
+// stubCache is a minimal cache.Cache fake that only implements GetInformer,
+// letting tests drive registerInformersOnce's retry/dedup behaviour without a
+// real *rest.Config.
+type stubCache struct {
+	cache.Cache
+	informer         *stubInformer
+	failGVKs         map[schema.GroupVersionKind]int // remaining failures before success, per GVK
+	getInformerCalls map[schema.GroupVersionKind]int
+}
+
+func (c *stubCache) GetInformer(_ context.Context, obj client.Object, _ ...cache.InformerGetOption) (cache.Informer, error) {
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	c.getInformerCalls[gvk]++
+	if c.failGVKs[gvk] > 0 {
+		c.failGVKs[gvk]--
+		return nil, fmt.Errorf("simulated GetInformer failure for %s", gvk)
+	}
+	return c.informer, nil
 }
 
 func TestRemoteSyncer_ReconcileKey_FoundMirrorsCreate(t *testing.T) {
@@ -185,4 +226,82 @@ func TestNewRemoteSyncer_StandbyRequiresRemoteConfig(t *testing.T) {
 	c := mirrorFakeClient(t)
 	_, err := NewRemoteSyncer(c, nil, testScheme(t), ModeStandby, RemoteSyncerOptions{Log: testLog()})
 	assert.Error(t, err)
+}
+
+func TestNamespaceMirrorSelector_MatchesOnlyProjectNamespaces(t *testing.T) {
+	sel := namespaceMirrorSelector()
+	assert.True(t, sel.Matches(labels.Set(util.LabelsKubeSliceController)),
+		"selector must match the labels NamespaceService.ReconcileProjectNamespace actually stamps on project namespaces")
+	assert.False(t, sel.Matches(labels.Set{"kubernetes.io/metadata.name": "kube-system"}),
+		"selector must not match an unrelated system namespace that happens to exist on the Active hub")
+}
+
+func TestRegisterInformers_RetriesUntilSuccess(t *testing.T) {
+	s := buildSyncer(t, newStubRemote())
+	s.setupRetryPeriod = time.Millisecond
+
+	var calls int32
+	s.register = func(_ context.Context) error {
+		if atomic.AddInt32(&calls, 1) < 3 {
+			return fmt.Errorf("simulated transient informer setup failure")
+		}
+		return nil
+	}
+
+	ok := s.registerInformers(context.Background())
+	assert.True(t, ok, "registerInformers must keep retrying instead of giving up on the first failure")
+	assert.GreaterOrEqual(t, atomic.LoadInt32(&calls), int32(3))
+}
+
+func TestRegisterInformersOnce_SkipsAlreadyRegisteredHandlersOnRetry(t *testing.T) {
+	resA := MirroredResource{GVK: schema.GroupVersionKind{Group: groupController, Version: "v1alpha1", Kind: "Cluster"}}
+	resB := MirroredResource{GVK: schema.GroupVersionKind{Group: groupController, Version: "v1alpha1", Kind: "Project"}}
+
+	informer := &stubInformer{}
+	sc := &stubCache{
+		informer:         informer,
+		failGVKs:         map[schema.GroupVersionKind]int{resB.GVK: 1}, // fails once, then succeeds
+		getInformerCalls: map[schema.GroupVersionKind]int{},
+	}
+
+	s := buildSyncer(t, newStubRemote())
+	s.resources = []MirroredResource{resA, resB}
+	s.remoteCache = sc
+
+	// First attempt: resA succeeds and its handler gets registered; resB
+	// fails at GetInformer, so registerInformersOnce returns an error before
+	// reaching the end of the resource list.
+	err := s.registerInformersOnce(context.Background())
+	require.Error(t, err)
+	assert.Equal(t, 1, informer.addCalls, "resA's handler should be registered exactly once after the first (partial) attempt")
+
+	// Second attempt (what registerInformers' retry loop would do): resA
+	// must NOT be re-registered — AddEventHandlerWithResyncPeriod is not
+	// idempotent, so a naive from-scratch retry would double resA's event
+	// and resync load. resB now succeeds and gets registered for the first time.
+	err = s.registerInformersOnce(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, 2, informer.addCalls, "retry must add resB's handler but must not double-register resA's")
+}
+
+func TestRegisterInformers_StopsRetryingOnContextCancel(t *testing.T) {
+	s := buildSyncer(t, newStubRemote())
+	s.setupRetryPeriod = 50 * time.Millisecond
+	s.register = func(_ context.Context) error {
+		return fmt.Errorf("always fails")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan bool, 1)
+	go func() { done <- s.registerInformers(ctx) }()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case ok := <-done:
+		assert.False(t, ok, "registerInformers must report failure when ctx is cancelled mid-retry")
+	case <-time.After(2 * time.Second):
+		t.Fatal("registerInformers did not return after context cancellation")
+	}
 }

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/lint.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/lint.go
@@ -1,0 +1,46 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil/promlint"
+)
+
+// CollectAndLint registers the provided Collector with a newly created pedantic
+// Registry. It then calls GatherAndLint with that Registry and with the
+// provided metricNames.
+func CollectAndLint(c prometheus.Collector, metricNames ...string) ([]promlint.Problem, error) {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		return nil, fmt.Errorf("registering collector failed: %w", err)
+	}
+	return GatherAndLint(reg, metricNames...)
+}
+
+// GatherAndLint gathers all metrics from the provided Gatherer and checks them
+// with the linter in the promlint package. If any metricNames are provided,
+// only metrics with those names are checked.
+func GatherAndLint(g prometheus.Gatherer, metricNames ...string) ([]promlint.Problem, error) {
+	got, err := g.Gather()
+	if err != nil {
+		return nil, fmt.Errorf("gathering metrics failed: %w", err)
+	}
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+	}
+	return promlint.NewWithMetricFamilies(got).Lint()
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/problem.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/problem.go
@@ -1,0 +1,33 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promlint
+
+import dto "github.com/prometheus/client_model/go"
+
+// A Problem is an issue detected by a linter.
+type Problem struct {
+	// The name of the metric indicated by this Problem.
+	Metric string
+
+	// A description of the issue for this Problem.
+	Text string
+}
+
+// newProblem is helper function to create a Problem.
+func newProblem(mf *dto.MetricFamily, text string) Problem {
+	return Problem{
+		Metric: mf.GetName(),
+		Text:   text,
+	}
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/promlint.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/promlint.go
@@ -1,0 +1,123 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package promlint provides a linter for Prometheus metrics.
+package promlint
+
+import (
+	"errors"
+	"io"
+	"sort"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+)
+
+// A Linter is a Prometheus metrics linter.  It identifies issues with metric
+// names, types, and metadata, and reports them to the caller.
+type Linter struct {
+	// The linter will read metrics in the Prometheus text format from r and
+	// then lint it, _and_ it will lint the metrics provided directly as
+	// MetricFamily proto messages in mfs. Note, however, that the current
+	// constructor functions New and NewWithMetricFamilies only ever set one
+	// of them.
+	r   io.Reader
+	mfs []*dto.MetricFamily
+
+	customValidations []Validation
+}
+
+// New creates a new Linter that reads an input stream of Prometheus metrics in
+// the Prometheus text exposition format.
+func New(r io.Reader) *Linter {
+	return &Linter{
+		r: r,
+	}
+}
+
+// NewWithMetricFamilies creates a new Linter that reads from a slice of
+// MetricFamily protobuf messages.
+func NewWithMetricFamilies(mfs []*dto.MetricFamily) *Linter {
+	return &Linter{
+		mfs: mfs,
+	}
+}
+
+// AddCustomValidations adds custom validations to the linter.
+func (l *Linter) AddCustomValidations(vs ...Validation) {
+	if l.customValidations == nil {
+		l.customValidations = make([]Validation, 0, len(vs))
+	}
+	l.customValidations = append(l.customValidations, vs...)
+}
+
+// Lint performs a linting pass, returning a slice of Problems indicating any
+// issues found in the metrics stream. The slice is sorted by metric name
+// and issue description.
+func (l *Linter) Lint() ([]Problem, error) {
+	var problems []Problem
+
+	if l.r != nil {
+		d := expfmt.NewDecoder(l.r, expfmt.NewFormat(expfmt.TypeTextPlain))
+
+		mf := &dto.MetricFamily{}
+		for {
+			if err := d.Decode(mf); err != nil {
+				if errors.Is(err, io.EOF) {
+					break
+				}
+
+				return nil, err
+			}
+
+			problems = append(problems, l.lint(mf)...)
+		}
+	}
+	for _, mf := range l.mfs {
+		problems = append(problems, l.lint(mf)...)
+	}
+
+	// Ensure deterministic output.
+	sort.SliceStable(problems, func(i, j int) bool {
+		if problems[i].Metric == problems[j].Metric {
+			return problems[i].Text < problems[j].Text
+		}
+		return problems[i].Metric < problems[j].Metric
+	})
+
+	return problems, nil
+}
+
+// lint is the entry point for linting a single metric.
+func (l *Linter) lint(mf *dto.MetricFamily) []Problem {
+	var problems []Problem
+
+	for _, fn := range defaultValidations {
+		errs := fn(mf)
+		for _, err := range errs {
+			problems = append(problems, newProblem(mf, err.Error()))
+		}
+	}
+
+	if l.customValidations != nil {
+		for _, fn := range l.customValidations {
+			errs := fn(mf)
+			for _, err := range errs {
+				problems = append(problems, newProblem(mf, err.Error()))
+			}
+		}
+	}
+
+	// TODO(mdlayher): lint rules for specific metrics types.
+	return problems
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validation.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validation.go
@@ -1,0 +1,33 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promlint
+
+import (
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/prometheus/client_golang/prometheus/testutil/promlint/validations"
+)
+
+type Validation = func(mf *dto.MetricFamily) []error
+
+var defaultValidations = []Validation{
+	validations.LintHelp,
+	validations.LintMetricUnits,
+	validations.LintCounter,
+	validations.LintHistogramSummaryReserved,
+	validations.LintMetricTypeInName,
+	validations.LintReservedChars,
+	validations.LintCamelCase,
+	validations.LintUnitAbbreviations,
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/counter_validations.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/counter_validations.go
@@ -1,0 +1,40 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validations
+
+import (
+	"errors"
+	"strings"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// LintCounter detects issues specific to counters, as well as patterns that should
+// only be used with counters.
+func LintCounter(mf *dto.MetricFamily) []error {
+	var problems []error
+
+	isCounter := mf.GetType() == dto.MetricType_COUNTER
+	isUntyped := mf.GetType() == dto.MetricType_UNTYPED
+	hasTotalSuffix := strings.HasSuffix(mf.GetName(), "_total")
+
+	switch {
+	case isCounter && !hasTotalSuffix:
+		problems = append(problems, errors.New(`counter metrics should have "_total" suffix`))
+	case !isUntyped && !isCounter && hasTotalSuffix:
+		problems = append(problems, errors.New(`non-counter metrics should not have "_total" suffix`))
+	}
+
+	return problems
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/generic_name_validations.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/generic_name_validations.go
@@ -1,0 +1,101 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validations
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+var camelCase = regexp.MustCompile(`[a-z][A-Z]`)
+
+// LintMetricUnits detects issues with metric unit names.
+func LintMetricUnits(mf *dto.MetricFamily) []error {
+	var problems []error
+
+	unit, base, ok := metricUnits(*mf.Name)
+	if !ok {
+		// No known units detected.
+		return nil
+	}
+
+	// Unit is already a base unit.
+	if unit == base {
+		return nil
+	}
+
+	problems = append(problems, fmt.Errorf("use base unit %q instead of %q", base, unit))
+
+	return problems
+}
+
+// LintMetricTypeInName detects when metric types are included in the metric name.
+func LintMetricTypeInName(mf *dto.MetricFamily) []error {
+	var problems []error
+	n := strings.ToLower(mf.GetName())
+
+	for i, t := range dto.MetricType_name {
+		if i == int32(dto.MetricType_UNTYPED) {
+			continue
+		}
+
+		typename := strings.ToLower(t)
+		if strings.Contains(n, "_"+typename+"_") || strings.HasSuffix(n, "_"+typename) {
+			problems = append(problems, fmt.Errorf(`metric name should not include type '%s'`, typename))
+		}
+	}
+	return problems
+}
+
+// LintReservedChars detects colons in metric names.
+func LintReservedChars(mf *dto.MetricFamily) []error {
+	var problems []error
+	if strings.Contains(mf.GetName(), ":") {
+		problems = append(problems, errors.New("metric names should not contain ':'"))
+	}
+	return problems
+}
+
+// LintCamelCase detects metric names and label names written in camelCase.
+func LintCamelCase(mf *dto.MetricFamily) []error {
+	var problems []error
+	if camelCase.FindString(mf.GetName()) != "" {
+		problems = append(problems, errors.New("metric names should be written in 'snake_case' not 'camelCase'"))
+	}
+
+	for _, m := range mf.GetMetric() {
+		for _, l := range m.GetLabel() {
+			if camelCase.FindString(l.GetName()) != "" {
+				problems = append(problems, errors.New("label names should be written in 'snake_case' not 'camelCase'"))
+			}
+		}
+	}
+	return problems
+}
+
+// LintUnitAbbreviations detects abbreviated units in the metric name.
+func LintUnitAbbreviations(mf *dto.MetricFamily) []error {
+	var problems []error
+	n := strings.ToLower(mf.GetName())
+	for _, s := range unitAbbreviations {
+		if strings.Contains(n, "_"+s+"_") || strings.HasSuffix(n, "_"+s) {
+			problems = append(problems, errors.New("metric names should not contain abbreviated units"))
+		}
+	}
+	return problems
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/help_validations.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/help_validations.go
@@ -1,0 +1,32 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validations
+
+import (
+	"errors"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// LintHelp detects issues related to the help text for a metric.
+func LintHelp(mf *dto.MetricFamily) []error {
+	var problems []error
+
+	// Expect all metrics to have help text available.
+	if mf.Help == nil {
+		problems = append(problems, errors.New("no help text"))
+	}
+
+	return problems
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/histogram_validations.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/histogram_validations.go
@@ -1,0 +1,63 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validations
+
+import (
+	"errors"
+	"strings"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+// LintHistogramSummaryReserved detects when other types of metrics use names or labels
+// reserved for use by histograms and/or summaries.
+func LintHistogramSummaryReserved(mf *dto.MetricFamily) []error {
+	// These rules do not apply to untyped metrics.
+	t := mf.GetType()
+	if t == dto.MetricType_UNTYPED {
+		return nil
+	}
+
+	var problems []error
+
+	isHistogram := t == dto.MetricType_HISTOGRAM
+	isSummary := t == dto.MetricType_SUMMARY
+
+	n := mf.GetName()
+
+	if !isHistogram && strings.HasSuffix(n, "_bucket") {
+		problems = append(problems, errors.New(`non-histogram metrics should not have "_bucket" suffix`))
+	}
+	if !isHistogram && !isSummary && strings.HasSuffix(n, "_count") {
+		problems = append(problems, errors.New(`non-histogram and non-summary metrics should not have "_count" suffix`))
+	}
+	if !isHistogram && !isSummary && strings.HasSuffix(n, "_sum") {
+		problems = append(problems, errors.New(`non-histogram and non-summary metrics should not have "_sum" suffix`))
+	}
+
+	for _, m := range mf.GetMetric() {
+		for _, l := range m.GetLabel() {
+			ln := l.GetName()
+
+			if !isHistogram && ln == "le" {
+				problems = append(problems, errors.New(`non-histogram metrics should not have "le" label`))
+			}
+			if !isSummary && ln == "quantile" {
+				problems = append(problems, errors.New(`non-summary metrics should not have "quantile" label`))
+			}
+		}
+	}
+
+	return problems
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/units.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/promlint/validations/units.go
@@ -1,0 +1,118 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validations
+
+import "strings"
+
+// Units and their possible prefixes recognized by this library.  More can be
+// added over time as needed.
+var (
+	// map a unit to the appropriate base unit.
+	units = map[string]string{
+		// Base units.
+		"amperes": "amperes",
+		"bytes":   "bytes",
+		"celsius": "celsius", // Also allow Celsius because it is common in typical Prometheus use cases.
+		"grams":   "grams",
+		"joules":  "joules",
+		"kelvin":  "kelvin", // SI base unit, used in special cases (e.g. color temperature, scientific measurements).
+		"meters":  "meters", // Both American and international spelling permitted.
+		"metres":  "metres",
+		"seconds": "seconds",
+		"volts":   "volts",
+
+		// Non base units.
+		// Time.
+		"minutes": "seconds",
+		"hours":   "seconds",
+		"days":    "seconds",
+		"weeks":   "seconds",
+		// Temperature.
+		"kelvins":    "kelvin",
+		"fahrenheit": "celsius",
+		"rankine":    "celsius",
+		// Length.
+		"inches": "meters",
+		"yards":  "meters",
+		"miles":  "meters",
+		// Bytes.
+		"bits": "bytes",
+		// Energy.
+		"calories": "joules",
+		// Mass.
+		"pounds": "grams",
+		"ounces": "grams",
+	}
+
+	unitPrefixes = []string{
+		"pico",
+		"nano",
+		"micro",
+		"milli",
+		"centi",
+		"deci",
+		"deca",
+		"hecto",
+		"kilo",
+		"kibi",
+		"mega",
+		"mibi",
+		"giga",
+		"gibi",
+		"tera",
+		"tebi",
+		"peta",
+		"pebi",
+	}
+
+	// Common abbreviations that we'd like to discourage.
+	unitAbbreviations = []string{
+		"s",
+		"ms",
+		"us",
+		"ns",
+		"sec",
+		"b",
+		"kb",
+		"mb",
+		"gb",
+		"tb",
+		"pb",
+		"m",
+		"h",
+		"d",
+	}
+)
+
+// metricUnits attempts to detect known unit types used as part of a metric name,
+// e.g. "foo_bytes_total" or "bar_baz_milligrams".
+func metricUnits(m string) (unit, base string, ok bool) {
+	ss := strings.Split(m, "_")
+
+	for _, s := range ss {
+		if base, found := units[s]; found {
+			return s, base, true
+		}
+
+		for _, p := range unitPrefixes {
+			if strings.HasPrefix(s, p) {
+				if base, found := units[s[len(p):]]; found {
+					return s, base, true
+				}
+			}
+		}
+	}
+
+	return "", "", false
+}

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go
@@ -1,0 +1,358 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package testutil provides helpers to test code using the prometheus package
+// of client_golang.
+//
+// While writing unit tests to verify correct instrumentation of your code, it's
+// a common mistake to mostly test the instrumentation library instead of your
+// own code. Rather than verifying that a prometheus.Counter's value has changed
+// as expected or that it shows up in the exposition after registration, it is
+// in general more robust and more faithful to the concept of unit tests to use
+// mock implementations of the prometheus.Counter and prometheus.Registerer
+// interfaces that simply assert that the Add or Register methods have been
+// called with the expected arguments. However, this might be overkill in simple
+// scenarios. The ToFloat64 function is provided for simple inspection of a
+// single-value metric, but it has to be used with caution.
+//
+// End-to-end tests to verify all or larger parts of the metrics exposition can
+// be implemented with the CollectAndCompare or GatherAndCompare functions. The
+// most appropriate use is not so much testing instrumentation of your code, but
+// testing custom prometheus.Collector implementations and in particular whole
+// exporters, i.e. programs that retrieve telemetry data from a 3rd party source
+// and convert it into Prometheus metrics.
+//
+// In a similar pattern, CollectAndLint and GatherAndLint can be used to detect
+// metrics that have issues with their name, type, or metadata without being
+// necessarily invalid, e.g. a counter with a name missing the “_total” suffix.
+package testutil
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+
+	"github.com/davecgh/go-spew/spew"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/internal"
+)
+
+// ToFloat64 collects all Metrics from the provided Collector. It expects that
+// this results in exactly one Metric being collected, which must be a Gauge,
+// Counter, or Untyped. In all other cases, ToFloat64 panics. ToFloat64 returns
+// the value of the collected Metric.
+//
+// The Collector provided is typically a simple instance of Gauge or Counter, or
+// – less commonly – a GaugeVec or CounterVec with exactly one element. But any
+// Collector fulfilling the prerequisites described above will do.
+//
+// Use this function with caution. It is computationally very expensive and thus
+// not suited at all to read values from Metrics in regular code. This is really
+// only for testing purposes, and even for testing, other approaches are often
+// more appropriate (see this package's documentation).
+//
+// A clear anti-pattern would be to use a metric type from the prometheus
+// package to track values that are also needed for something else than the
+// exposition of Prometheus metrics. For example, you would like to track the
+// number of items in a queue because your code should reject queuing further
+// items if a certain limit is reached. It is tempting to track the number of
+// items in a prometheus.Gauge, as it is then easily available as a metric for
+// exposition, too. However, then you would need to call ToFloat64 in your
+// regular code, potentially quite often. The recommended way is to track the
+// number of items conventionally (in the way you would have done it without
+// considering Prometheus metrics) and then expose the number with a
+// prometheus.GaugeFunc.
+func ToFloat64(c prometheus.Collector) float64 {
+	var (
+		m      prometheus.Metric
+		mCount int
+		mChan  = make(chan prometheus.Metric)
+		done   = make(chan struct{})
+	)
+
+	go func() {
+		for m = range mChan {
+			mCount++
+		}
+		close(done)
+	}()
+
+	c.Collect(mChan)
+	close(mChan)
+	<-done
+
+	if mCount != 1 {
+		panic(fmt.Errorf("collected %d metrics instead of exactly 1", mCount))
+	}
+
+	pb := &dto.Metric{}
+	if err := m.Write(pb); err != nil {
+		panic(fmt.Errorf("error happened while collecting metrics: %w", err))
+	}
+	if pb.Gauge != nil {
+		return pb.Gauge.GetValue()
+	}
+	if pb.Counter != nil {
+		return pb.Counter.GetValue()
+	}
+	if pb.Untyped != nil {
+		return pb.Untyped.GetValue()
+	}
+	panic(fmt.Errorf("collected a non-gauge/counter/untyped metric: %s", pb))
+}
+
+// CollectAndCount registers the provided Collector with a newly created
+// pedantic Registry. It then calls GatherAndCount with that Registry and with
+// the provided metricNames. In the unlikely case that the registration or the
+// gathering fails, this function panics. (This is inconsistent with the other
+// CollectAnd… functions in this package and has historical reasons. Changing
+// the function signature would be a breaking change and will therefore only
+// happen with the next major version bump.)
+func CollectAndCount(c prometheus.Collector, metricNames ...string) int {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		panic(fmt.Errorf("registering collector failed: %w", err))
+	}
+	result, err := GatherAndCount(reg, metricNames...)
+	if err != nil {
+		panic(err)
+	}
+	return result
+}
+
+// GatherAndCount gathers all metrics from the provided Gatherer and counts
+// them. It returns the number of metric children in all gathered metric
+// families together. If any metricNames are provided, only metrics with those
+// names are counted.
+func GatherAndCount(g prometheus.Gatherer, metricNames ...string) (int, error) {
+	got, err := g.Gather()
+	if err != nil {
+		return 0, fmt.Errorf("gathering metrics failed: %w", err)
+	}
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+	}
+
+	result := 0
+	for _, mf := range got {
+		result += len(mf.GetMetric())
+	}
+	return result, nil
+}
+
+// ScrapeAndCompare calls a remote exporter's endpoint which is expected to return some metrics in
+// plain text format. Then it compares it with the results that the `expected` would return.
+// If the `metricNames` is not empty it would filter the comparison only to the given metric names.
+func ScrapeAndCompare(url string, expected io.Reader, metricNames ...string) error {
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("scraping metrics failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("the scraping target returned a status code other than 200: %d",
+			resp.StatusCode)
+	}
+
+	scraped, err := convertReaderToMetricFamily(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	wanted, err := convertReaderToMetricFamily(expected)
+	if err != nil {
+		return err
+	}
+
+	return compareMetricFamilies(scraped, wanted, metricNames...)
+}
+
+// CollectAndCompare registers the provided Collector with a newly created
+// pedantic Registry. It then calls GatherAndCompare with that Registry and with
+// the provided metricNames.
+func CollectAndCompare(c prometheus.Collector, expected io.Reader, metricNames ...string) error {
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(c); err != nil {
+		return fmt.Errorf("registering collector failed: %w", err)
+	}
+	return GatherAndCompare(reg, expected, metricNames...)
+}
+
+// GatherAndCompare gathers all metrics from the provided Gatherer and compares
+// it to an expected output read from the provided Reader in the Prometheus text
+// exposition format. If any metricNames are provided, only metrics with those
+// names are compared.
+func GatherAndCompare(g prometheus.Gatherer, expected io.Reader, metricNames ...string) error {
+	return TransactionalGatherAndCompare(prometheus.ToTransactionalGatherer(g), expected, metricNames...)
+}
+
+// TransactionalGatherAndCompare gathers all metrics from the provided Gatherer and compares
+// it to an expected output read from the provided Reader in the Prometheus text
+// exposition format. If any metricNames are provided, only metrics with those
+// names are compared.
+func TransactionalGatherAndCompare(g prometheus.TransactionalGatherer, expected io.Reader, metricNames ...string) error {
+	got, done, err := g.Gather()
+	defer done()
+	if err != nil {
+		return fmt.Errorf("gathering metrics failed: %w", err)
+	}
+
+	wanted, err := convertReaderToMetricFamily(expected)
+	if err != nil {
+		return err
+	}
+
+	return compareMetricFamilies(got, wanted, metricNames...)
+}
+
+// convertReaderToMetricFamily would read from a io.Reader object and convert it to a slice of
+// dto.MetricFamily.
+func convertReaderToMetricFamily(reader io.Reader) ([]*dto.MetricFamily, error) {
+	var tp expfmt.TextParser
+	notNormalized, err := tp.TextToMetricFamilies(reader)
+	if err != nil {
+		return nil, fmt.Errorf("converting reader to metric families failed: %w", err)
+	}
+
+	// The text protocol handles empty help fields inconsistently. When
+	// encoding, any non-nil value, include the empty string, produces a
+	// "# HELP" line. But when decoding, the help field is only set to a
+	// non-nil value if the "# HELP" line contains a non-empty value.
+	//
+	// Because metrics in a registry always have non-nil help fields, populate
+	// any nil help fields in the parsed metrics with the empty string so that
+	// when we compare text encodings, the results are consistent.
+	for _, metric := range notNormalized {
+		if metric.Help == nil {
+			metric.Help = proto.String("")
+		}
+	}
+
+	return internal.NormalizeMetricFamilies(notNormalized), nil
+}
+
+// compareMetricFamilies would compare 2 slices of metric families, and optionally filters both of
+// them to the `metricNames` provided.
+func compareMetricFamilies(got, expected []*dto.MetricFamily, metricNames ...string) error {
+	if metricNames != nil {
+		got = filterMetrics(got, metricNames)
+		expected = filterMetrics(expected, metricNames)
+	}
+
+	return compare(got, expected)
+}
+
+// compare encodes both provided slices of metric families into the text format,
+// compares their string message, and returns an error if they do not match.
+// The error contains the encoded text of both the desired and the actual
+// result.
+func compare(got, want []*dto.MetricFamily) error {
+	var gotBuf, wantBuf bytes.Buffer
+	enc := expfmt.NewEncoder(&gotBuf, expfmt.NewFormat(expfmt.TypeTextPlain))
+	for _, mf := range got {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding gathered metrics failed: %w", err)
+		}
+	}
+	enc = expfmt.NewEncoder(&wantBuf, expfmt.NewFormat(expfmt.TypeTextPlain))
+	for _, mf := range want {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding expected metrics failed: %w", err)
+		}
+	}
+	if diffErr := diff(wantBuf, gotBuf); diffErr != "" {
+		return fmt.Errorf(diffErr)
+	}
+	return nil
+}
+
+// diff returns a diff of both values as long as both are of the same type and
+// are a struct, map, slice, array or string. Otherwise it returns an empty string.
+func diff(expected, actual interface{}) string {
+	if expected == nil || actual == nil {
+		return ""
+	}
+
+	et, ek := typeAndKind(expected)
+	at, _ := typeAndKind(actual)
+	if et != at {
+		return ""
+	}
+
+	if ek != reflect.Struct && ek != reflect.Map && ek != reflect.Slice && ek != reflect.Array && ek != reflect.String {
+		return ""
+	}
+
+	var e, a string
+	c := spew.ConfigState{
+		Indent:                  " ",
+		DisablePointerAddresses: true,
+		DisableCapacities:       true,
+		SortKeys:                true,
+	}
+	if et != reflect.TypeOf("") {
+		e = c.Sdump(expected)
+		a = c.Sdump(actual)
+	} else {
+		e = reflect.ValueOf(expected).String()
+		a = reflect.ValueOf(actual).String()
+	}
+
+	diff, _ := internal.GetUnifiedDiffString(internal.UnifiedDiff{
+		A:        internal.SplitLines(e),
+		B:        internal.SplitLines(a),
+		FromFile: "metric output does not match expectation; want",
+		FromDate: "",
+		ToFile:   "got:",
+		ToDate:   "",
+		Context:  1,
+	})
+
+	if diff == "" {
+		return ""
+	}
+
+	return "\n\nDiff:\n" + diff
+}
+
+// typeAndKind returns the type and kind of the given interface{}
+func typeAndKind(v interface{}) (reflect.Type, reflect.Kind) {
+	t := reflect.TypeOf(v)
+	k := t.Kind()
+
+	if k == reflect.Ptr {
+		t = t.Elem()
+		k = t.Kind()
+	}
+	return t, k
+}
+
+func filterMetrics(metrics []*dto.MetricFamily, names []string) []*dto.MetricFamily {
+	var filtered []*dto.MetricFamily
+	for _, m := range metrics {
+		for _, name := range names {
+			if m.GetName() == name {
+				filtered = append(filtered, m)
+				break
+			}
+		}
+	}
+	return filtered
+}

--- a/vendor/go.uber.org/zap/zaptest/observer/logged_entry.go
+++ b/vendor/go.uber.org/zap/zaptest/observer/logged_entry.go
@@ -1,0 +1,39 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package observer
+
+import "go.uber.org/zap/zapcore"
+
+// An LoggedEntry is an encoding-agnostic representation of a log message.
+// Field availability is context dependant.
+type LoggedEntry struct {
+	zapcore.Entry
+	Context []zapcore.Field
+}
+
+// ContextMap returns a map for all fields in Context.
+func (e LoggedEntry) ContextMap() map[string]interface{} {
+	encoder := zapcore.NewMapObjectEncoder()
+	for _, f := range e.Context {
+		f.AddTo(encoder)
+	}
+	return encoder.Fields
+}

--- a/vendor/go.uber.org/zap/zaptest/observer/observer.go
+++ b/vendor/go.uber.org/zap/zaptest/observer/observer.go
@@ -1,0 +1,196 @@
+// Copyright (c) 2016-2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package observer provides a zapcore.Core that keeps an in-memory,
+// encoding-agnostic representation of log entries. It's useful for
+// applications that want to unit test their log output without tying their
+// tests to a particular output encoding.
+package observer // import "go.uber.org/zap/zaptest/observer"
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"go.uber.org/zap/internal"
+	"go.uber.org/zap/zapcore"
+)
+
+// ObservedLogs is a concurrency-safe, ordered collection of observed logs.
+type ObservedLogs struct {
+	mu   sync.RWMutex
+	logs []LoggedEntry
+}
+
+// Len returns the number of items in the collection.
+func (o *ObservedLogs) Len() int {
+	o.mu.RLock()
+	n := len(o.logs)
+	o.mu.RUnlock()
+	return n
+}
+
+// All returns a copy of all the observed logs.
+func (o *ObservedLogs) All() []LoggedEntry {
+	o.mu.RLock()
+	ret := make([]LoggedEntry, len(o.logs))
+	copy(ret, o.logs)
+	o.mu.RUnlock()
+	return ret
+}
+
+// TakeAll returns a copy of all the observed logs, and truncates the observed
+// slice.
+func (o *ObservedLogs) TakeAll() []LoggedEntry {
+	o.mu.Lock()
+	ret := o.logs
+	o.logs = nil
+	o.mu.Unlock()
+	return ret
+}
+
+// AllUntimed returns a copy of all the observed logs, but overwrites the
+// observed timestamps with time.Time's zero value. This is useful when making
+// assertions in tests.
+func (o *ObservedLogs) AllUntimed() []LoggedEntry {
+	ret := o.All()
+	for i := range ret {
+		ret[i].Time = time.Time{}
+	}
+	return ret
+}
+
+// FilterLevelExact filters entries to those logged at exactly the given level.
+func (o *ObservedLogs) FilterLevelExact(level zapcore.Level) *ObservedLogs {
+	return o.Filter(func(e LoggedEntry) bool {
+		return e.Level == level
+	})
+}
+
+// FilterMessage filters entries to those that have the specified message.
+func (o *ObservedLogs) FilterMessage(msg string) *ObservedLogs {
+	return o.Filter(func(e LoggedEntry) bool {
+		return e.Message == msg
+	})
+}
+
+// FilterMessageSnippet filters entries to those that have a message containing the specified snippet.
+func (o *ObservedLogs) FilterMessageSnippet(snippet string) *ObservedLogs {
+	return o.Filter(func(e LoggedEntry) bool {
+		return strings.Contains(e.Message, snippet)
+	})
+}
+
+// FilterField filters entries to those that have the specified field.
+func (o *ObservedLogs) FilterField(field zapcore.Field) *ObservedLogs {
+	return o.Filter(func(e LoggedEntry) bool {
+		for _, ctxField := range e.Context {
+			if ctxField.Equals(field) {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// FilterFieldKey filters entries to those that have the specified key.
+func (o *ObservedLogs) FilterFieldKey(key string) *ObservedLogs {
+	return o.Filter(func(e LoggedEntry) bool {
+		for _, ctxField := range e.Context {
+			if ctxField.Key == key {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+// Filter returns a copy of this ObservedLogs containing only those entries
+// for which the provided function returns true.
+func (o *ObservedLogs) Filter(keep func(LoggedEntry) bool) *ObservedLogs {
+	o.mu.RLock()
+	defer o.mu.RUnlock()
+
+	var filtered []LoggedEntry
+	for _, entry := range o.logs {
+		if keep(entry) {
+			filtered = append(filtered, entry)
+		}
+	}
+	return &ObservedLogs{logs: filtered}
+}
+
+func (o *ObservedLogs) add(log LoggedEntry) {
+	o.mu.Lock()
+	o.logs = append(o.logs, log)
+	o.mu.Unlock()
+}
+
+// New creates a new Core that buffers logs in memory (without any encoding).
+// It's particularly useful in tests.
+func New(enab zapcore.LevelEnabler) (zapcore.Core, *ObservedLogs) {
+	ol := &ObservedLogs{}
+	return &contextObserver{
+		LevelEnabler: enab,
+		logs:         ol,
+	}, ol
+}
+
+type contextObserver struct {
+	zapcore.LevelEnabler
+	logs    *ObservedLogs
+	context []zapcore.Field
+}
+
+var (
+	_ zapcore.Core            = (*contextObserver)(nil)
+	_ internal.LeveledEnabler = (*contextObserver)(nil)
+)
+
+func (co *contextObserver) Level() zapcore.Level {
+	return zapcore.LevelOf(co.LevelEnabler)
+}
+
+func (co *contextObserver) Check(ent zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if co.Enabled(ent.Level) {
+		return ce.AddCore(ent, co)
+	}
+	return ce
+}
+
+func (co *contextObserver) With(fields []zapcore.Field) zapcore.Core {
+	return &contextObserver{
+		LevelEnabler: co.LevelEnabler,
+		logs:         co.logs,
+		context:      append(co.context[:len(co.context):len(co.context)], fields...),
+	}
+}
+
+func (co *contextObserver) Write(ent zapcore.Entry, fields []zapcore.Field) error {
+	all := make([]zapcore.Field, 0, len(fields)+len(co.context))
+	all = append(all, co.context...)
+	all = append(all, fields...)
+	co.logs.add(LoggedEntry{ent, all})
+	return nil
+}
+
+func (co *contextObserver) Sync() error {
+	return nil
+}

--- a/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/rand/rand.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rand provides utilities related to randomization.
+package rand
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+)
+
+var rng = struct {
+	sync.Mutex
+	rand *rand.Rand
+}{
+	rand: rand.New(rand.NewSource(time.Now().UnixNano())),
+}
+
+// Int returns a non-negative pseudo-random int.
+func Int() int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int()
+}
+
+// Intn generates an integer in range [0,max).
+// By design this should panic if input is invalid, <= 0.
+func Intn(max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max)
+}
+
+// IntnRange generates an integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func IntnRange(min, max int) int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Intn(max-min) + min
+}
+
+// IntnRange generates an int64 integer in range [min,max).
+// By design this should panic if input is invalid, <= 0.
+func Int63nRange(min, max int64) int64 {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Int63n(max-min) + min
+}
+
+// Seed seeds the rng with the provided seed.
+func Seed(seed int64) {
+	rng.Lock()
+	defer rng.Unlock()
+
+	rng.rand = rand.New(rand.NewSource(seed))
+}
+
+// Perm returns, as a slice of n ints, a pseudo-random permutation of the integers [0,n)
+// from the default Source.
+func Perm(n int) []int {
+	rng.Lock()
+	defer rng.Unlock()
+	return rng.rand.Perm(n)
+}
+
+const (
+	// We omit vowels from the set of available characters to reduce the chances
+	// of "bad words" being formed.
+	alphanums = "bcdfghjklmnpqrstvwxz2456789"
+	// No. of bits required to index into alphanums string.
+	alphanumsIdxBits = 5
+	// Mask used to extract last alphanumsIdxBits of an int.
+	alphanumsIdxMask = 1<<alphanumsIdxBits - 1
+	// No. of random letters we can extract from a single int63.
+	maxAlphanumsPerInt = 63 / alphanumsIdxBits
+)
+
+// String generates a random alphanumeric string, without vowels, which is n
+// characters long.  This will panic if n is less than zero.
+// How the random string is created:
+// - we generate random int63's
+// - from each int63, we are extracting multiple random letters by bit-shifting and masking
+// - if some index is out of range of alphanums we neglect it (unlikely to happen multiple times in a row)
+func String(n int) string {
+	b := make([]byte, n)
+	rng.Lock()
+	defer rng.Unlock()
+
+	randomInt63 := rng.rand.Int63()
+	remaining := maxAlphanumsPerInt
+	for i := 0; i < n; {
+		if remaining == 0 {
+			randomInt63, remaining = rng.rand.Int63(), maxAlphanumsPerInt
+		}
+		if idx := int(randomInt63 & alphanumsIdxMask); idx < len(alphanums) {
+			b[i] = alphanums[idx]
+			i++
+		}
+		randomInt63 >>= alphanumsIdxBits
+		remaining--
+	}
+	return string(b)
+}
+
+// SafeEncodeString encodes s using the same characters as rand.String. This reduces the chances of bad words and
+// ensures that strings generated from hash functions appear consistent throughout the API.
+func SafeEncodeString(s string) string {
+	r := make([]byte, len(s))
+	for i, b := range []rune(s) {
+		r[i] = alphanums[(int(b) % len(alphanums))]
+	}
+	return string(r)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -228,6 +228,9 @@ github.com/prometheus/client_golang/prometheus/collectors
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promauto
 github.com/prometheus/client_golang/prometheus/promhttp
+github.com/prometheus/client_golang/prometheus/testutil
+github.com/prometheus/client_golang/prometheus/testutil/promlint
+github.com/prometheus/client_golang/prometheus/testutil/promlint/validations
 # github.com/prometheus/client_model v0.6.1
 ## explicit; go 1.19
 github.com/prometheus/client_model/go

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -641,6 +641,7 @@ k8s.io/apimachinery/pkg/util/mergepatch
 k8s.io/apimachinery/pkg/util/naming
 k8s.io/apimachinery/pkg/util/net
 k8s.io/apimachinery/pkg/util/portforward
+k8s.io/apimachinery/pkg/util/rand
 k8s.io/apimachinery/pkg/util/remotecommand
 k8s.io/apimachinery/pkg/util/runtime
 k8s.io/apimachinery/pkg/util/sets
@@ -1040,6 +1041,8 @@ sigs.k8s.io/controller-runtime/pkg/certwatcher/metrics
 sigs.k8s.io/controller-runtime/pkg/client
 sigs.k8s.io/controller-runtime/pkg/client/apiutil
 sigs.k8s.io/controller-runtime/pkg/client/config
+sigs.k8s.io/controller-runtime/pkg/client/fake
+sigs.k8s.io/controller-runtime/pkg/client/interceptor
 sigs.k8s.io/controller-runtime/pkg/cluster
 sigs.k8s.io/controller-runtime/pkg/config
 sigs.k8s.io/controller-runtime/pkg/controller
@@ -1057,6 +1060,7 @@ sigs.k8s.io/controller-runtime/pkg/internal/flock
 sigs.k8s.io/controller-runtime/pkg/internal/httpserver
 sigs.k8s.io/controller-runtime/pkg/internal/log
 sigs.k8s.io/controller-runtime/pkg/internal/metrics
+sigs.k8s.io/controller-runtime/pkg/internal/objectutil
 sigs.k8s.io/controller-runtime/pkg/internal/recorder
 sigs.k8s.io/controller-runtime/pkg/internal/source
 sigs.k8s.io/controller-runtime/pkg/internal/syncs

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -328,6 +328,7 @@ go.uber.org/zap/internal/exit
 go.uber.org/zap/internal/pool
 go.uber.org/zap/internal/stacktrace
 go.uber.org/zap/zapcore
+go.uber.org/zap/zaptest/observer
 # golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
 ## explicit; go 1.20
 golang.org/x/exp/constraints

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/client.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/client.go
@@ -1,0 +1,1593 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"runtime/debug"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	// Using v4 to match upstream
+	jsonpatch "gopkg.in/evanphx/json-patch.v4"
+	appsv1 "k8s.io/api/apps/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/testing"
+	"k8s.io/utils/ptr"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/internal/field/selector"
+	"sigs.k8s.io/controller-runtime/pkg/internal/objectutil"
+)
+
+type versionedTracker struct {
+	testing.ObjectTracker
+	scheme                *runtime.Scheme
+	withStatusSubresource sets.Set[schema.GroupVersionKind]
+}
+
+type fakeClient struct {
+	// trackerWriteLock must be acquired before writing to
+	// the tracker or performing reads that affect a following
+	// write.
+	trackerWriteLock sync.Mutex
+	tracker          versionedTracker
+
+	schemeLock sync.RWMutex
+	scheme     *runtime.Scheme
+
+	restMapper            meta.RESTMapper
+	withStatusSubresource sets.Set[schema.GroupVersionKind]
+
+	// indexes maps each GroupVersionKind (GVK) to the indexes registered for that GVK.
+	// The inner map maps from index name to IndexerFunc.
+	indexes map[schema.GroupVersionKind]map[string]client.IndexerFunc
+	// indexesLock must be held when accessing indexes.
+	indexesLock sync.RWMutex
+}
+
+var _ client.WithWatch = &fakeClient{}
+
+const (
+	maxNameLength          = 63
+	randomLength           = 5
+	maxGeneratedNameLength = maxNameLength - randomLength
+
+	subResourceScale = "scale"
+)
+
+// NewFakeClient creates a new fake client for testing.
+// You can choose to initialize it with a slice of runtime.Object.
+func NewFakeClient(initObjs ...runtime.Object) client.WithWatch {
+	return NewClientBuilder().WithRuntimeObjects(initObjs...).Build()
+}
+
+// NewClientBuilder returns a new builder to create a fake client.
+func NewClientBuilder() *ClientBuilder {
+	return &ClientBuilder{}
+}
+
+// ClientBuilder builds a fake client.
+type ClientBuilder struct {
+	scheme                *runtime.Scheme
+	restMapper            meta.RESTMapper
+	initObject            []client.Object
+	initLists             []client.ObjectList
+	initRuntimeObjects    []runtime.Object
+	withStatusSubresource []client.Object
+	objectTracker         testing.ObjectTracker
+	interceptorFuncs      *interceptor.Funcs
+
+	// indexes maps each GroupVersionKind (GVK) to the indexes registered for that GVK.
+	// The inner map maps from index name to IndexerFunc.
+	indexes map[schema.GroupVersionKind]map[string]client.IndexerFunc
+}
+
+// WithScheme sets this builder's internal scheme.
+// If not set, defaults to client-go's global scheme.Scheme.
+func (f *ClientBuilder) WithScheme(scheme *runtime.Scheme) *ClientBuilder {
+	f.scheme = scheme
+	return f
+}
+
+// WithRESTMapper sets this builder's restMapper.
+// The restMapper is directly set as mapper in the Client. This can be used for example
+// with a meta.DefaultRESTMapper to provide a static rest mapping.
+// If not set, defaults to an empty meta.DefaultRESTMapper.
+func (f *ClientBuilder) WithRESTMapper(restMapper meta.RESTMapper) *ClientBuilder {
+	f.restMapper = restMapper
+	return f
+}
+
+// WithObjects can be optionally used to initialize this fake client with client.Object(s).
+func (f *ClientBuilder) WithObjects(initObjs ...client.Object) *ClientBuilder {
+	f.initObject = append(f.initObject, initObjs...)
+	return f
+}
+
+// WithLists can be optionally used to initialize this fake client with client.ObjectList(s).
+func (f *ClientBuilder) WithLists(initLists ...client.ObjectList) *ClientBuilder {
+	f.initLists = append(f.initLists, initLists...)
+	return f
+}
+
+// WithRuntimeObjects can be optionally used to initialize this fake client with runtime.Object(s).
+func (f *ClientBuilder) WithRuntimeObjects(initRuntimeObjs ...runtime.Object) *ClientBuilder {
+	f.initRuntimeObjects = append(f.initRuntimeObjects, initRuntimeObjs...)
+	return f
+}
+
+// WithObjectTracker can be optionally used to initialize this fake client with testing.ObjectTracker.
+func (f *ClientBuilder) WithObjectTracker(ot testing.ObjectTracker) *ClientBuilder {
+	f.objectTracker = ot
+	return f
+}
+
+// WithIndex can be optionally used to register an index with name `field` and indexer `extractValue`
+// for API objects of the same GroupVersionKind (GVK) as `obj` in the fake client.
+// It can be invoked multiple times, both with objects of the same GVK or different ones.
+// Invoking WithIndex twice with the same `field` and GVK (via `obj`) arguments will panic.
+// WithIndex retrieves the GVK of `obj` using the scheme registered via WithScheme if
+// WithScheme was previously invoked, the default scheme otherwise.
+func (f *ClientBuilder) WithIndex(obj runtime.Object, field string, extractValue client.IndexerFunc) *ClientBuilder {
+	objScheme := f.scheme
+	if objScheme == nil {
+		objScheme = scheme.Scheme
+	}
+
+	gvk, err := apiutil.GVKForObject(obj, objScheme)
+	if err != nil {
+		panic(err)
+	}
+
+	// If this is the first index being registered, we initialize the map storing all the indexes.
+	if f.indexes == nil {
+		f.indexes = make(map[schema.GroupVersionKind]map[string]client.IndexerFunc)
+	}
+
+	// If this is the first index being registered for the GroupVersionKind of `obj`, we initialize
+	// the map storing the indexes for that GroupVersionKind.
+	if f.indexes[gvk] == nil {
+		f.indexes[gvk] = make(map[string]client.IndexerFunc)
+	}
+
+	if _, fieldAlreadyIndexed := f.indexes[gvk][field]; fieldAlreadyIndexed {
+		panic(fmt.Errorf("indexer conflict: field %s for GroupVersionKind %v is already indexed",
+			field, gvk))
+	}
+
+	f.indexes[gvk][field] = extractValue
+
+	return f
+}
+
+// WithStatusSubresource configures the passed object with a status subresource, which means
+// calls to Update and Patch will not alter its status.
+func (f *ClientBuilder) WithStatusSubresource(o ...client.Object) *ClientBuilder {
+	f.withStatusSubresource = append(f.withStatusSubresource, o...)
+	return f
+}
+
+// WithInterceptorFuncs configures the client methods to be intercepted using the provided interceptor.Funcs.
+func (f *ClientBuilder) WithInterceptorFuncs(interceptorFuncs interceptor.Funcs) *ClientBuilder {
+	f.interceptorFuncs = &interceptorFuncs
+	return f
+}
+
+// Build builds and returns a new fake client.
+func (f *ClientBuilder) Build() client.WithWatch {
+	if f.scheme == nil {
+		f.scheme = scheme.Scheme
+	}
+	if f.restMapper == nil {
+		f.restMapper = meta.NewDefaultRESTMapper([]schema.GroupVersion{})
+	}
+
+	var tracker versionedTracker
+
+	withStatusSubResource := sets.New(inTreeResourcesWithStatus()...)
+	for _, o := range f.withStatusSubresource {
+		gvk, err := apiutil.GVKForObject(o, f.scheme)
+		if err != nil {
+			panic(fmt.Errorf("failed to get gvk for object %T: %w", withStatusSubResource, err))
+		}
+		withStatusSubResource.Insert(gvk)
+	}
+
+	if f.objectTracker == nil {
+		tracker = versionedTracker{ObjectTracker: testing.NewObjectTracker(f.scheme, scheme.Codecs.UniversalDecoder()), scheme: f.scheme, withStatusSubresource: withStatusSubResource}
+	} else {
+		tracker = versionedTracker{ObjectTracker: f.objectTracker, scheme: f.scheme, withStatusSubresource: withStatusSubResource}
+	}
+
+	for _, obj := range f.initObject {
+		if err := tracker.Add(obj); err != nil {
+			panic(fmt.Errorf("failed to add object %v to fake client: %w", obj, err))
+		}
+	}
+	for _, obj := range f.initLists {
+		if err := tracker.Add(obj); err != nil {
+			panic(fmt.Errorf("failed to add list %v to fake client: %w", obj, err))
+		}
+	}
+	for _, obj := range f.initRuntimeObjects {
+		if err := tracker.Add(obj); err != nil {
+			panic(fmt.Errorf("failed to add runtime object %v to fake client: %w", obj, err))
+		}
+	}
+
+	var result client.WithWatch = &fakeClient{
+		tracker:               tracker,
+		scheme:                f.scheme,
+		restMapper:            f.restMapper,
+		indexes:               f.indexes,
+		withStatusSubresource: withStatusSubResource,
+	}
+
+	if f.interceptorFuncs != nil {
+		result = interceptor.NewClient(result, *f.interceptorFuncs)
+	}
+
+	return result
+}
+
+const trackerAddResourceVersion = "999"
+
+func (t versionedTracker) Add(obj runtime.Object) error {
+	var objects []runtime.Object
+	if meta.IsListType(obj) {
+		var err error
+		objects, err = meta.ExtractList(obj)
+		if err != nil {
+			return err
+		}
+	} else {
+		objects = []runtime.Object{obj}
+	}
+	for _, obj := range objects {
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return fmt.Errorf("failed to get accessor for object: %w", err)
+		}
+		if accessor.GetDeletionTimestamp() != nil && len(accessor.GetFinalizers()) == 0 {
+			return fmt.Errorf("refusing to create obj %s with metadata.deletionTimestamp but no finalizers", accessor.GetName())
+		}
+		if accessor.GetResourceVersion() == "" {
+			// We use a "magic" value of 999 here because this field
+			// is parsed as uint and and 0 is already used in Update.
+			// As we can't go lower, go very high instead so this can
+			// be recognized
+			accessor.SetResourceVersion(trackerAddResourceVersion)
+		}
+
+		obj, err = convertFromUnstructuredIfNecessary(t.scheme, obj)
+		if err != nil {
+			return err
+		}
+		if err := t.ObjectTracker.Add(obj); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (t versionedTracker) Create(gvr schema.GroupVersionResource, obj runtime.Object, ns string, opts ...metav1.CreateOptions) error {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return fmt.Errorf("failed to get accessor for object: %w", err)
+	}
+	if accessor.GetName() == "" {
+		return apierrors.NewInvalid(
+			obj.GetObjectKind().GroupVersionKind().GroupKind(),
+			accessor.GetName(),
+			field.ErrorList{field.Required(field.NewPath("metadata.name"), "name is required")})
+	}
+	if accessor.GetResourceVersion() != "" {
+		return apierrors.NewBadRequest("resourceVersion can not be set for Create requests")
+	}
+	accessor.SetResourceVersion("1")
+	obj, err = convertFromUnstructuredIfNecessary(t.scheme, obj)
+	if err != nil {
+		return err
+	}
+	if err := t.ObjectTracker.Create(gvr, obj, ns, opts...); err != nil {
+		accessor.SetResourceVersion("")
+		return err
+	}
+
+	return nil
+}
+
+// convertFromUnstructuredIfNecessary will convert runtime.Unstructured for a GVK that is recognized
+// by the schema into the whatever the schema produces with New() for said GVK.
+// This is required because the tracker unconditionally saves on manipulations, but its List() implementation
+// tries to assign whatever it finds into a ListType it gets from schema.New() - Thus we have to ensure
+// we save as the very same type, otherwise subsequent List requests will fail.
+func convertFromUnstructuredIfNecessary(s *runtime.Scheme, o runtime.Object) (runtime.Object, error) {
+	u, isUnstructured := o.(runtime.Unstructured)
+	if !isUnstructured {
+		return o, nil
+	}
+	gvk := o.GetObjectKind().GroupVersionKind()
+	if !s.Recognizes(gvk) {
+		return o, nil
+	}
+
+	typed, err := s.New(gvk)
+	if err != nil {
+		return nil, fmt.Errorf("scheme recognizes %s but failed to produce an object for it: %w", gvk, err)
+	}
+
+	unstructuredSerialized, err := json.Marshal(u)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize %T: %w", unstructuredSerialized, err)
+	}
+	if err := json.Unmarshal(unstructuredSerialized, typed); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal the content of %T into %T: %w", u, typed, err)
+	}
+
+	return typed, nil
+}
+
+func (t versionedTracker) Update(gvr schema.GroupVersionResource, obj runtime.Object, ns string, opts ...metav1.UpdateOptions) error {
+	updateOpts, err := getSingleOrZeroOptions(opts)
+	if err != nil {
+		return err
+	}
+
+	return t.update(gvr, obj, ns, false, false, updateOpts)
+}
+
+func (t versionedTracker) update(gvr schema.GroupVersionResource, obj runtime.Object, ns string, isStatus, deleting bool, opts metav1.UpdateOptions) error {
+	obj, err := t.updateObject(gvr, obj, ns, isStatus, deleting, opts.DryRun)
+	if err != nil {
+		return err
+	}
+	if obj == nil {
+		return nil
+	}
+
+	return t.ObjectTracker.Update(gvr, obj, ns, opts)
+}
+
+func (t versionedTracker) Patch(gvr schema.GroupVersionResource, obj runtime.Object, ns string, opts ...metav1.PatchOptions) error {
+	patchOptions, err := getSingleOrZeroOptions(opts)
+	if err != nil {
+		return err
+	}
+
+	isStatus := false
+	// We apply patches using a client-go reaction that ends up calling the trackers Patch. As we can't change
+	// that reaction, we use the callstack to figure out if this originated from the status client.
+	if bytes.Contains(debug.Stack(), []byte("sigs.k8s.io/controller-runtime/pkg/client/fake.(*fakeSubResourceClient).statusPatch")) {
+		isStatus = true
+	}
+
+	obj, err = t.updateObject(gvr, obj, ns, isStatus, false, patchOptions.DryRun)
+	if err != nil {
+		return err
+	}
+	if obj == nil {
+		return nil
+	}
+
+	return t.ObjectTracker.Patch(gvr, obj, ns, patchOptions)
+}
+
+func (t versionedTracker) updateObject(gvr schema.GroupVersionResource, obj runtime.Object, ns string, isStatus, deleting bool, dryRun []string) (runtime.Object, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get accessor for object: %w", err)
+	}
+
+	if accessor.GetName() == "" {
+		return nil, apierrors.NewInvalid(
+			obj.GetObjectKind().GroupVersionKind().GroupKind(),
+			accessor.GetName(),
+			field.ErrorList{field.Required(field.NewPath("metadata.name"), "name is required")})
+	}
+
+	gvk, err := apiutil.GVKForObject(obj, t.scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	oldObject, err := t.ObjectTracker.Get(gvr, ns, accessor.GetName())
+	if err != nil {
+		// If the resource is not found and the resource allows create on update, issue a
+		// create instead.
+		if apierrors.IsNotFound(err) && allowsCreateOnUpdate(gvk) {
+			return nil, t.Create(gvr, obj, ns)
+		}
+		return nil, err
+	}
+
+	if t.withStatusSubresource.Has(gvk) {
+		if isStatus { // copy everything but status and metadata.ResourceVersion from original object
+			if err := copyStatusFrom(obj, oldObject); err != nil {
+				return nil, fmt.Errorf("failed to copy non-status field for object with status subresouce: %w", err)
+			}
+			passedRV := accessor.GetResourceVersion()
+			if err := copyFrom(oldObject, obj); err != nil {
+				return nil, fmt.Errorf("failed to restore non-status fields: %w", err)
+			}
+			accessor.SetResourceVersion(passedRV)
+		} else { // copy status from original object
+			if err := copyStatusFrom(oldObject, obj); err != nil {
+				return nil, fmt.Errorf("failed to copy the status for object with status subresource: %w", err)
+			}
+		}
+	} else if isStatus {
+		return nil, apierrors.NewNotFound(gvr.GroupResource(), accessor.GetName())
+	}
+
+	oldAccessor, err := meta.Accessor(oldObject)
+	if err != nil {
+		return nil, err
+	}
+
+	// If the new object does not have the resource version set and it allows unconditional update,
+	// default it to the resource version of the existing resource
+	if accessor.GetResourceVersion() == "" {
+		switch {
+		case allowsUnconditionalUpdate(gvk):
+			accessor.SetResourceVersion(oldAccessor.GetResourceVersion())
+			// This is needed because if the patch explicitly sets the RV to null, the client-go reaction we use
+			// to apply it and whose output we process here will have it unset. It is not clear why the Kubernetes
+			// apiserver accepts such a patch, but it does so we just copy that behavior.
+			// Kubernetes apiserver behavior can be checked like this:
+			// `kubectl patch configmap foo --patch '{"metadata":{"annotations":{"foo":"bar"},"resourceVersion":null}}' -v=9`
+		case bytes.
+			Contains(debug.Stack(), []byte("sigs.k8s.io/controller-runtime/pkg/client/fake.(*fakeClient).Patch")):
+			// We apply patches using a client-go reaction that ends up calling the trackers Update. As we can't change
+			// that reaction, we use the callstack to figure out if this originated from the "fakeClient.Patch" func.
+			accessor.SetResourceVersion(oldAccessor.GetResourceVersion())
+		}
+	}
+
+	if accessor.GetResourceVersion() != oldAccessor.GetResourceVersion() {
+		return nil, apierrors.NewConflict(gvr.GroupResource(), accessor.GetName(), errors.New("object was modified"))
+	}
+	if oldAccessor.GetResourceVersion() == "" {
+		oldAccessor.SetResourceVersion("0")
+	}
+	intResourceVersion, err := strconv.ParseUint(oldAccessor.GetResourceVersion(), 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("can not convert resourceVersion %q to int: %w", oldAccessor.GetResourceVersion(), err)
+	}
+	intResourceVersion++
+	accessor.SetResourceVersion(strconv.FormatUint(intResourceVersion, 10))
+
+	if !deleting && !deletionTimestampEqual(accessor, oldAccessor) {
+		return nil, fmt.Errorf("error: Unable to edit %s: metadata.deletionTimestamp field is immutable", accessor.GetName())
+	}
+
+	if !accessor.GetDeletionTimestamp().IsZero() && len(accessor.GetFinalizers()) == 0 {
+		return nil, t.ObjectTracker.Delete(gvr, accessor.GetNamespace(), accessor.GetName(), metav1.DeleteOptions{DryRun: dryRun})
+	}
+	return convertFromUnstructuredIfNecessary(t.scheme, obj)
+}
+
+func (c *fakeClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	c.schemeLock.RLock()
+	defer c.schemeLock.RUnlock()
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	o, err := c.tracker.Get(gvr, key.Namespace, key.Name)
+	if err != nil {
+		return err
+	}
+
+	_, isUnstructured := obj.(runtime.Unstructured)
+	_, isPartialObject := obj.(*metav1.PartialObjectMetadata)
+
+	if isUnstructured || isPartialObject {
+		gvk, err := apiutil.GVKForObject(obj, c.scheme)
+		if err != nil {
+			return err
+		}
+		ta, err := meta.TypeAccessor(o)
+		if err != nil {
+			return err
+		}
+		ta.SetKind(gvk.Kind)
+		ta.SetAPIVersion(gvk.GroupVersion().String())
+	}
+
+	j, err := json.Marshal(o)
+	if err != nil {
+		return err
+	}
+	zero(obj)
+	return json.Unmarshal(j, obj)
+}
+
+func (c *fakeClient) Watch(ctx context.Context, list client.ObjectList, opts ...client.ListOption) (watch.Interface, error) {
+	gvk, err := apiutil.GVKForObject(list, c.scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
+
+	listOpts := client.ListOptions{}
+	listOpts.ApplyOptions(opts)
+
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	return c.tracker.Watch(gvr, listOpts.Namespace)
+}
+
+func (c *fakeClient) List(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) error {
+	c.schemeLock.RLock()
+	defer c.schemeLock.RUnlock()
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+
+	originalKind := gvk.Kind
+
+	gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
+
+	if _, isUnstructuredList := obj.(runtime.Unstructured); isUnstructuredList && !c.scheme.Recognizes(gvk) {
+		// We need to register the ListKind with UnstructuredList:
+		// https://github.com/kubernetes/kubernetes/blob/7b2776b89fb1be28d4e9203bdeec079be903c103/staging/src/k8s.io/client-go/dynamic/fake/simple.go#L44-L51
+		c.schemeLock.RUnlock()
+		c.schemeLock.Lock()
+		c.scheme.AddKnownTypeWithName(gvk.GroupVersion().WithKind(gvk.Kind+"List"), &unstructured.UnstructuredList{})
+		c.schemeLock.Unlock()
+		c.schemeLock.RLock()
+	}
+
+	listOpts := client.ListOptions{}
+	listOpts.ApplyOptions(opts)
+
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	o, err := c.tracker.List(gvr, gvk, listOpts.Namespace)
+	if err != nil {
+		return err
+	}
+
+	if _, isUnstructured := obj.(runtime.Unstructured); isUnstructured {
+		ta, err := meta.TypeAccessor(o)
+		if err != nil {
+			return err
+		}
+		ta.SetKind(originalKind)
+		ta.SetAPIVersion(gvk.GroupVersion().String())
+	}
+
+	j, err := json.Marshal(o)
+	if err != nil {
+		return err
+	}
+	zero(obj)
+	objCopy := obj.DeepCopyObject().(client.ObjectList)
+	if err := json.Unmarshal(j, objCopy); err != nil {
+		return err
+	}
+
+	if _, isUnstructured := obj.(runtime.Unstructured); isUnstructured {
+		ta, err := meta.TypeAccessor(obj)
+		if err != nil {
+			return err
+		}
+		ta.SetKind(originalKind)
+		ta.SetAPIVersion(gvk.GroupVersion().String())
+	}
+
+	objs, err := meta.ExtractList(objCopy)
+	if err != nil {
+		return err
+	}
+
+	if listOpts.LabelSelector == nil && listOpts.FieldSelector == nil {
+		return meta.SetList(obj, objs)
+	}
+
+	// If we're here, either a label or field selector are specified (or both), so before we return
+	// the list we must filter it. If both selectors are set, they are ANDed.
+	filteredList, err := c.filterList(objs, gvk, listOpts.LabelSelector, listOpts.FieldSelector)
+	if err != nil {
+		return err
+	}
+
+	return meta.SetList(obj, filteredList)
+}
+
+func (c *fakeClient) filterList(list []runtime.Object, gvk schema.GroupVersionKind, ls labels.Selector, fs fields.Selector) ([]runtime.Object, error) {
+	// Filter the objects with the label selector
+	filteredList := list
+	if ls != nil {
+		objsFilteredByLabel, err := objectutil.FilterWithLabels(list, ls)
+		if err != nil {
+			return nil, err
+		}
+		filteredList = objsFilteredByLabel
+	}
+
+	// Filter the result of the previous pass with the field selector
+	if fs != nil {
+		objsFilteredByField, err := c.filterWithFields(filteredList, gvk, fs)
+		if err != nil {
+			return nil, err
+		}
+		filteredList = objsFilteredByField
+	}
+
+	return filteredList, nil
+}
+
+func (c *fakeClient) filterWithFields(list []runtime.Object, gvk schema.GroupVersionKind, fs fields.Selector) ([]runtime.Object, error) {
+	requiresExact := selector.RequiresExactMatch(fs)
+	if !requiresExact {
+		return nil, fmt.Errorf(`field selector %s is not in one of the two supported forms "key==val" or "key=val"`, fs)
+	}
+
+	c.indexesLock.RLock()
+	defer c.indexesLock.RUnlock()
+	// Field selection is mimicked via indexes, so there's no sane answer this function can give
+	// if there are no indexes registered for the GroupVersionKind of the objects in the list.
+	indexes := c.indexes[gvk]
+	for _, req := range fs.Requirements() {
+		if len(indexes) == 0 || indexes[req.Field] == nil {
+			return nil, fmt.Errorf("List on GroupVersionKind %v specifies selector on field %s, but no "+
+				"index with name %s has been registered for GroupVersionKind %v", gvk, req.Field, req.Field, gvk)
+		}
+	}
+
+	filteredList := make([]runtime.Object, 0, len(list))
+	for _, obj := range list {
+		matches := true
+		for _, req := range fs.Requirements() {
+			indexExtractor := indexes[req.Field]
+			if !c.objMatchesFieldSelector(obj, indexExtractor, req.Value) {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			filteredList = append(filteredList, obj)
+		}
+	}
+	return filteredList, nil
+}
+
+func (c *fakeClient) objMatchesFieldSelector(o runtime.Object, extractIndex client.IndexerFunc, val string) bool {
+	obj, isClientObject := o.(client.Object)
+	if !isClientObject {
+		panic(fmt.Errorf("expected object %v to be of type client.Object, but it's not", o))
+	}
+
+	for _, extractedVal := range extractIndex(obj) {
+		if extractedVal == val {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (c *fakeClient) Scheme() *runtime.Scheme {
+	return c.scheme
+}
+
+func (c *fakeClient) RESTMapper() meta.RESTMapper {
+	return c.restMapper
+}
+
+// GroupVersionKindFor returns the GroupVersionKind for the given object.
+func (c *fakeClient) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
+	return apiutil.GVKForObject(obj, c.scheme)
+}
+
+// IsObjectNamespaced returns true if the GroupVersionKind of the object is namespaced.
+func (c *fakeClient) IsObjectNamespaced(obj runtime.Object) (bool, error) {
+	return apiutil.IsObjectNamespaced(obj, c.scheme, c.restMapper)
+}
+
+func (c *fakeClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	c.schemeLock.RLock()
+	defer c.schemeLock.RUnlock()
+	createOptions := &client.CreateOptions{}
+	createOptions.ApplyOptions(opts)
+
+	for _, dryRunOpt := range createOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
+
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	if accessor.GetName() == "" && accessor.GetGenerateName() != "" {
+		base := accessor.GetGenerateName()
+		if len(base) > maxGeneratedNameLength {
+			base = base[:maxGeneratedNameLength]
+		}
+		accessor.SetName(fmt.Sprintf("%s%s", base, utilrand.String(randomLength)))
+	}
+	// Ignore attempts to set deletion timestamp
+	if !accessor.GetDeletionTimestamp().IsZero() {
+		accessor.SetDeletionTimestamp(nil)
+	}
+
+	c.trackerWriteLock.Lock()
+	defer c.trackerWriteLock.Unlock()
+	return c.tracker.Create(gvr, obj, accessor.GetNamespace())
+}
+
+func (c *fakeClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	c.schemeLock.RLock()
+	defer c.schemeLock.RUnlock()
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	delOptions := client.DeleteOptions{}
+	delOptions.ApplyOptions(opts)
+
+	for _, dryRunOpt := range delOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
+
+	c.trackerWriteLock.Lock()
+	defer c.trackerWriteLock.Unlock()
+	// Check the ResourceVersion if that Precondition was specified.
+	if delOptions.Preconditions != nil && delOptions.Preconditions.ResourceVersion != nil {
+		name := accessor.GetName()
+		dbObj, err := c.tracker.Get(gvr, accessor.GetNamespace(), name)
+		if err != nil {
+			return err
+		}
+		oldAccessor, err := meta.Accessor(dbObj)
+		if err != nil {
+			return err
+		}
+		actualRV := oldAccessor.GetResourceVersion()
+		expectRV := *delOptions.Preconditions.ResourceVersion
+		if actualRV != expectRV {
+			msg := fmt.Sprintf(
+				"the ResourceVersion in the precondition (%s) does not match the ResourceVersion in record (%s). "+
+					"The object might have been modified",
+				expectRV, actualRV)
+			return apierrors.NewConflict(gvr.GroupResource(), name, errors.New(msg))
+		}
+	}
+
+	return c.deleteObjectLocked(gvr, accessor)
+}
+
+func (c *fakeClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	c.schemeLock.RLock()
+	defer c.schemeLock.RUnlock()
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+
+	dcOptions := client.DeleteAllOfOptions{}
+	dcOptions.ApplyOptions(opts)
+
+	for _, dryRunOpt := range dcOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
+
+	c.trackerWriteLock.Lock()
+	defer c.trackerWriteLock.Unlock()
+
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	o, err := c.tracker.List(gvr, gvk, dcOptions.Namespace)
+	if err != nil {
+		return err
+	}
+
+	objs, err := meta.ExtractList(o)
+	if err != nil {
+		return err
+	}
+	filteredObjs, err := objectutil.FilterWithLabels(objs, dcOptions.LabelSelector)
+	if err != nil {
+		return err
+	}
+	for _, o := range filteredObjs {
+		accessor, err := meta.Accessor(o)
+		if err != nil {
+			return err
+		}
+		err = c.deleteObjectLocked(gvr, accessor)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *fakeClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	return c.update(obj, false, opts...)
+}
+
+func (c *fakeClient) update(obj client.Object, isStatus bool, opts ...client.UpdateOption) error {
+	c.schemeLock.RLock()
+	defer c.schemeLock.RUnlock()
+	updateOptions := &client.UpdateOptions{}
+	updateOptions.ApplyOptions(opts)
+
+	for _, dryRunOpt := range updateOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
+
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	c.trackerWriteLock.Lock()
+	defer c.trackerWriteLock.Unlock()
+	return c.tracker.update(gvr, obj, accessor.GetNamespace(), isStatus, false, *updateOptions.AsUpdateOptions())
+}
+
+func (c *fakeClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return c.patch(obj, patch, opts...)
+}
+
+func (c *fakeClient) patch(obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	c.schemeLock.RLock()
+	defer c.schemeLock.RUnlock()
+	patchOptions := &client.PatchOptions{}
+	patchOptions.ApplyOptions(opts)
+
+	for _, dryRunOpt := range patchOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
+
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	data, err := patch.Data(obj)
+	if err != nil {
+		return err
+	}
+
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+
+	c.trackerWriteLock.Lock()
+	defer c.trackerWriteLock.Unlock()
+	oldObj, err := c.tracker.Get(gvr, accessor.GetNamespace(), accessor.GetName())
+	if err != nil {
+		return err
+	}
+	oldAccessor, err := meta.Accessor(oldObj)
+	if err != nil {
+		return err
+	}
+
+	// Apply patch without updating object.
+	// To remain in accordance with the behavior of k8s api behavior,
+	// a patch must not allow for changes to the deletionTimestamp of an object.
+	// The reaction() function applies the patch to the object and calls Update(),
+	// whereas dryPatch() replicates this behavior but skips the call to Update().
+	// This ensures that the patch may be rejected if a deletionTimestamp is modified, prior
+	// to updating the object.
+	action := testing.NewPatchAction(gvr, accessor.GetNamespace(), accessor.GetName(), patch.Type(), data)
+	o, err := dryPatch(action, c.tracker)
+	if err != nil {
+		return err
+	}
+	newObj, err := meta.Accessor(o)
+	if err != nil {
+		return err
+	}
+
+	// Validate that deletionTimestamp has not been changed
+	if !deletionTimestampEqual(newObj, oldAccessor) {
+		return fmt.Errorf("rejected patch, metadata.deletionTimestamp immutable")
+	}
+
+	reaction := testing.ObjectReaction(c.tracker)
+	handled, o, err := reaction(action)
+	if err != nil {
+		return err
+	}
+	if !handled {
+		panic("tracker could not handle patch method")
+	}
+
+	if _, isUnstructured := obj.(runtime.Unstructured); isUnstructured {
+		ta, err := meta.TypeAccessor(o)
+		if err != nil {
+			return err
+		}
+		ta.SetKind(gvk.Kind)
+		ta.SetAPIVersion(gvk.GroupVersion().String())
+	}
+
+	j, err := json.Marshal(o)
+	if err != nil {
+		return err
+	}
+	zero(obj)
+	return json.Unmarshal(j, obj)
+}
+
+// Applying a patch results in a deletionTimestamp that is truncated to the nearest second.
+// Check that the diff between a new and old deletion timestamp is within a reasonable threshold
+// to be considered unchanged.
+func deletionTimestampEqual(newObj metav1.Object, obj metav1.Object) bool {
+	newTime := newObj.GetDeletionTimestamp()
+	oldTime := obj.GetDeletionTimestamp()
+
+	if newTime == nil || oldTime == nil {
+		return newTime == oldTime
+	}
+	return newTime.Time.Sub(oldTime.Time).Abs() < time.Second
+}
+
+// The behavior of applying the patch is pulled out into dryPatch(),
+// which applies the patch and returns an object, but does not Update() the object.
+// This function returns a patched runtime object that may then be validated before a call to Update() is executed.
+// This results in some code duplication, but was found to be a cleaner alternative than unmarshalling and introspecting the patch data
+// and easier than refactoring the k8s client-go method upstream.
+// Duplicate of upstream: https://github.com/kubernetes/client-go/blob/783d0d33626e59d55d52bfd7696b775851f92107/testing/fixture.go#L146-L194
+func dryPatch(action testing.PatchActionImpl, tracker testing.ObjectTracker) (runtime.Object, error) {
+	ns := action.GetNamespace()
+	gvr := action.GetResource()
+
+	obj, err := tracker.Get(gvr, ns, action.GetName())
+	if err != nil {
+		return nil, err
+	}
+
+	old, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	// reset the object in preparation to unmarshal, since unmarshal does not guarantee that fields
+	// in obj that are removed by patch are cleared
+	value := reflect.ValueOf(obj)
+	value.Elem().Set(reflect.New(value.Type().Elem()).Elem())
+
+	switch action.GetPatchType() {
+	case types.JSONPatchType:
+		patch, err := jsonpatch.DecodePatch(action.GetPatch())
+		if err != nil {
+			return nil, err
+		}
+		modified, err := patch.Apply(old)
+		if err != nil {
+			return nil, err
+		}
+
+		if err = json.Unmarshal(modified, obj); err != nil {
+			return nil, err
+		}
+	case types.MergePatchType:
+		modified, err := jsonpatch.MergePatch(old, action.GetPatch())
+		if err != nil {
+			return nil, err
+		}
+
+		if err := json.Unmarshal(modified, obj); err != nil {
+			return nil, err
+		}
+	case types.StrategicMergePatchType:
+		mergedByte, err := strategicpatch.StrategicMergePatch(old, action.GetPatch(), obj)
+		if err != nil {
+			return nil, err
+		}
+		if err = json.Unmarshal(mergedByte, obj); err != nil {
+			return nil, err
+		}
+	case types.ApplyPatchType:
+		return nil, errors.New("apply patches are not supported in the fake client. Follow https://github.com/kubernetes/kubernetes/issues/115598 for the current status")
+	case types.ApplyCBORPatchType:
+		return nil, errors.New("apply CBOR patches are not supported in the fake client")
+	default:
+		return nil, fmt.Errorf("%s PatchType is not supported", action.GetPatchType())
+	}
+	return obj, nil
+}
+
+// copyStatusFrom copies the status from old into new
+func copyStatusFrom(old, new runtime.Object) error {
+	oldMapStringAny, err := toMapStringAny(old)
+	if err != nil {
+		return fmt.Errorf("failed to convert old to *unstructured.Unstructured: %w", err)
+	}
+	newMapStringAny, err := toMapStringAny(new)
+	if err != nil {
+		return fmt.Errorf("failed to convert new to *unststructured.Unstructured: %w", err)
+	}
+
+	newMapStringAny["status"] = oldMapStringAny["status"]
+
+	if err := fromMapStringAny(newMapStringAny, new); err != nil {
+		return fmt.Errorf("failed to convert back from map[string]any: %w", err)
+	}
+
+	return nil
+}
+
+// copyFrom copies from old into new
+func copyFrom(old, new runtime.Object) error {
+	oldMapStringAny, err := toMapStringAny(old)
+	if err != nil {
+		return fmt.Errorf("failed to convert old to *unstructured.Unstructured: %w", err)
+	}
+	if err := fromMapStringAny(oldMapStringAny, new); err != nil {
+		return fmt.Errorf("failed to convert back from map[string]any: %w", err)
+	}
+
+	return nil
+}
+
+func toMapStringAny(obj runtime.Object) (map[string]any, error) {
+	if unstructured, isUnstructured := obj.(*unstructured.Unstructured); isUnstructured {
+		return unstructured.Object, nil
+	}
+
+	serialized, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	u := map[string]any{}
+	return u, json.Unmarshal(serialized, &u)
+}
+
+func fromMapStringAny(u map[string]any, target runtime.Object) error {
+	if targetUnstructured, isUnstructured := target.(*unstructured.Unstructured); isUnstructured {
+		targetUnstructured.Object = u
+		return nil
+	}
+
+	serialized, err := json.Marshal(u)
+	if err != nil {
+		return fmt.Errorf("failed to serialize: %w", err)
+	}
+
+	zero(target)
+	if err := json.Unmarshal(serialized, &target); err != nil {
+		return fmt.Errorf("failed to deserialize: %w", err)
+	}
+
+	return nil
+}
+
+func (c *fakeClient) Status() client.SubResourceWriter {
+	return c.SubResource("status")
+}
+
+func (c *fakeClient) SubResource(subResource string) client.SubResourceClient {
+	return &fakeSubResourceClient{client: c, subResource: subResource}
+}
+
+func (c *fakeClient) deleteObjectLocked(gvr schema.GroupVersionResource, accessor metav1.Object) error {
+	old, err := c.tracker.Get(gvr, accessor.GetNamespace(), accessor.GetName())
+	if err == nil {
+		oldAccessor, err := meta.Accessor(old)
+		if err == nil {
+			if len(oldAccessor.GetFinalizers()) > 0 {
+				now := metav1.Now()
+				oldAccessor.SetDeletionTimestamp(&now)
+				// Call update directly with mutability parameter set to true to allow
+				// changes to deletionTimestamp
+				return c.tracker.update(gvr, old, accessor.GetNamespace(), false, true, metav1.UpdateOptions{})
+			}
+		}
+	}
+
+	//TODO: implement propagation
+	return c.tracker.Delete(gvr, accessor.GetNamespace(), accessor.GetName())
+}
+
+func getGVRFromObject(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersionResource, error) {
+	gvk, err := apiutil.GVKForObject(obj, scheme)
+	if err != nil {
+		return schema.GroupVersionResource{}, err
+	}
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+	return gvr, nil
+}
+
+type fakeSubResourceClient struct {
+	client      *fakeClient
+	subResource string
+}
+
+func (sw *fakeSubResourceClient) Get(ctx context.Context, obj, subResource client.Object, opts ...client.SubResourceGetOption) error {
+	switch sw.subResource {
+	case subResourceScale:
+		// Actual client looks up resource, then extracts the scale sub-resource:
+		// https://github.com/kubernetes/kubernetes/blob/fb6bbc9781d11a87688c398778525c4e1dcb0f08/pkg/registry/apps/deployment/storage/storage.go#L307
+		if err := sw.client.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+			return err
+		}
+		scale, isScale := subResource.(*autoscalingv1.Scale)
+		if !isScale {
+			return apierrors.NewBadRequest(fmt.Sprintf("expected Scale, got %T", subResource))
+		}
+		scaleOut, err := extractScale(obj)
+		if err != nil {
+			return err
+		}
+		*scale = *scaleOut
+		return nil
+	default:
+		return fmt.Errorf("fakeSubResourceClient does not support get for %s", sw.subResource)
+	}
+}
+
+func (sw *fakeSubResourceClient) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+	switch sw.subResource {
+	case "eviction":
+		_, isEviction := subResource.(*policyv1beta1.Eviction)
+		if !isEviction {
+			_, isEviction = subResource.(*policyv1.Eviction)
+		}
+		if !isEviction {
+			return apierrors.NewBadRequest(fmt.Sprintf("got invalid type %T, expected Eviction", subResource))
+		}
+		if _, isPod := obj.(*corev1.Pod); !isPod {
+			return apierrors.NewNotFound(schema.GroupResource{}, "")
+		}
+
+		return sw.client.Delete(ctx, obj)
+	case "token":
+		tokenRequest, isTokenRequest := subResource.(*authenticationv1.TokenRequest)
+		if !isTokenRequest {
+			return apierrors.NewBadRequest(fmt.Sprintf("got invalid type %T, expected TokenRequest", subResource))
+		}
+		if _, isServiceAccount := obj.(*corev1.ServiceAccount); !isServiceAccount {
+			return apierrors.NewNotFound(schema.GroupResource{}, "")
+		}
+
+		tokenRequest.Status.Token = "fake-token"
+		tokenRequest.Status.ExpirationTimestamp = metav1.Date(6041, 1, 1, 0, 0, 0, 0, time.UTC)
+
+		return sw.client.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+	default:
+		return fmt.Errorf("fakeSubResourceWriter does not support create for %s", sw.subResource)
+	}
+}
+
+func (sw *fakeSubResourceClient) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	updateOptions := client.SubResourceUpdateOptions{}
+	updateOptions.ApplyOptions(opts)
+
+	switch sw.subResource {
+	case subResourceScale:
+		if err := sw.client.Get(ctx, client.ObjectKeyFromObject(obj), obj.DeepCopyObject().(client.Object)); err != nil {
+			return err
+		}
+		if updateOptions.SubResourceBody == nil {
+			return apierrors.NewBadRequest("missing SubResourceBody")
+		}
+
+		scale, isScale := updateOptions.SubResourceBody.(*autoscalingv1.Scale)
+		if !isScale {
+			return apierrors.NewBadRequest(fmt.Sprintf("expected Scale, got %T", updateOptions.SubResourceBody))
+		}
+		if err := applyScale(obj, scale); err != nil {
+			return err
+		}
+		return sw.client.update(obj, false, &updateOptions.UpdateOptions)
+	default:
+		body := obj
+		if updateOptions.SubResourceBody != nil {
+			body = updateOptions.SubResourceBody
+		}
+		return sw.client.update(body, true, &updateOptions.UpdateOptions)
+	}
+}
+
+func (sw *fakeSubResourceClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+	patchOptions := client.SubResourcePatchOptions{}
+	patchOptions.ApplyOptions(opts)
+
+	body := obj
+	if patchOptions.SubResourceBody != nil {
+		body = patchOptions.SubResourceBody
+	}
+
+	// this is necessary to identify that last call was made for status patch, through stack trace.
+	if sw.subResource == "status" {
+		return sw.statusPatch(body, patch, patchOptions)
+	}
+
+	return sw.client.patch(body, patch, &patchOptions.PatchOptions)
+}
+
+func (sw *fakeSubResourceClient) statusPatch(body client.Object, patch client.Patch, patchOptions client.SubResourcePatchOptions) error {
+	return sw.client.patch(body, patch, &patchOptions.PatchOptions)
+}
+
+func allowsUnconditionalUpdate(gvk schema.GroupVersionKind) bool {
+	switch gvk.Group {
+	case "apps":
+		switch gvk.Kind {
+		case "ControllerRevision", "DaemonSet", "Deployment", "ReplicaSet", "StatefulSet":
+			return true
+		}
+	case "autoscaling":
+		switch gvk.Kind {
+		case "HorizontalPodAutoscaler":
+			return true
+		}
+	case "batch":
+		switch gvk.Kind {
+		case "CronJob", "Job":
+			return true
+		}
+	case "certificates":
+		switch gvk.Kind {
+		case "Certificates":
+			return true
+		}
+	case "flowcontrol":
+		switch gvk.Kind {
+		case "FlowSchema", "PriorityLevelConfiguration":
+			return true
+		}
+	case "networking":
+		switch gvk.Kind {
+		case "Ingress", "IngressClass", "NetworkPolicy":
+			return true
+		}
+	case "policy":
+		switch gvk.Kind {
+		case "PodSecurityPolicy":
+			return true
+		}
+	case "rbac.authorization.k8s.io":
+		switch gvk.Kind {
+		case "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding":
+			return true
+		}
+	case "scheduling":
+		switch gvk.Kind {
+		case "PriorityClass":
+			return true
+		}
+	case "settings":
+		switch gvk.Kind {
+		case "PodPreset":
+			return true
+		}
+	case "storage":
+		switch gvk.Kind {
+		case "StorageClass":
+			return true
+		}
+	case "":
+		switch gvk.Kind {
+		case "ConfigMap", "Endpoint", "Event", "LimitRange", "Namespace", "Node",
+			"PersistentVolume", "PersistentVolumeClaim", "Pod", "PodTemplate",
+			"ReplicationController", "ResourceQuota", "Secret", "Service",
+			"ServiceAccount", "EndpointSlice":
+			return true
+		}
+	}
+
+	return false
+}
+
+func allowsCreateOnUpdate(gvk schema.GroupVersionKind) bool {
+	switch gvk.Group {
+	case "coordination":
+		switch gvk.Kind {
+		case "Lease":
+			return true
+		}
+	case "node":
+		switch gvk.Kind {
+		case "RuntimeClass":
+			return true
+		}
+	case "rbac":
+		switch gvk.Kind {
+		case "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding":
+			return true
+		}
+	case "":
+		switch gvk.Kind {
+		case "Endpoint", "Event", "LimitRange", "Service":
+			return true
+		}
+	}
+
+	return false
+}
+
+func inTreeResourcesWithStatus() []schema.GroupVersionKind {
+	return []schema.GroupVersionKind{
+		{Version: "v1", Kind: "Namespace"},
+		{Version: "v1", Kind: "Node"},
+		{Version: "v1", Kind: "PersistentVolumeClaim"},
+		{Version: "v1", Kind: "PersistentVolume"},
+		{Version: "v1", Kind: "Pod"},
+		{Version: "v1", Kind: "ReplicationController"},
+		{Version: "v1", Kind: "Service"},
+
+		{Group: "apps", Version: "v1", Kind: "Deployment"},
+		{Group: "apps", Version: "v1", Kind: "DaemonSet"},
+		{Group: "apps", Version: "v1", Kind: "ReplicaSet"},
+		{Group: "apps", Version: "v1", Kind: "StatefulSet"},
+
+		{Group: "autoscaling", Version: "v1", Kind: "HorizontalPodAutoscaler"},
+
+		{Group: "batch", Version: "v1", Kind: "CronJob"},
+		{Group: "batch", Version: "v1", Kind: "Job"},
+
+		{Group: "certificates.k8s.io", Version: "v1", Kind: "CertificateSigningRequest"},
+
+		{Group: "networking.k8s.io", Version: "v1", Kind: "Ingress"},
+		{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"},
+
+		{Group: "policy", Version: "v1", Kind: "PodDisruptionBudget"},
+
+		{Group: "storage.k8s.io", Version: "v1", Kind: "VolumeAttachment"},
+
+		{Group: "apiextensions.k8s.io", Version: "v1", Kind: "CustomResourceDefinition"},
+
+		{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta2", Kind: "FlowSchema"},
+		{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta2", Kind: "PriorityLevelConfiguration"},
+		{Group: "flowcontrol.apiserver.k8s.io", Version: "v1", Kind: "FlowSchema"},
+		{Group: "flowcontrol.apiserver.k8s.io", Version: "v1", Kind: "PriorityLevelConfiguration"},
+	}
+}
+
+// zero zeros the value of a pointer.
+func zero(x interface{}) {
+	if x == nil {
+		return
+	}
+	res := reflect.ValueOf(x).Elem()
+	res.Set(reflect.Zero(res.Type()))
+}
+
+// getSingleOrZeroOptions returns the single options value in the slice, its
+// zero value if the slice is empty, or an error if the slice contains more than
+// one option value.
+func getSingleOrZeroOptions[T any](opts []T) (opt T, err error) {
+	switch len(opts) {
+	case 0:
+	case 1:
+		opt = opts[0]
+	default:
+		err = fmt.Errorf("expected single or no options value, got %d values", len(opts))
+	}
+	return
+}
+
+func extractScale(obj client.Object) (*autoscalingv1.Scale, error) {
+	switch obj := obj.(type) {
+	case *appsv1.Deployment:
+		var replicas int32 = 1
+		if obj.Spec.Replicas != nil {
+			replicas = *obj.Spec.Replicas
+		}
+		var selector string
+		if obj.Spec.Selector != nil {
+			selector = obj.Spec.Selector.String()
+		}
+		return &autoscalingv1.Scale{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         obj.Namespace,
+				Name:              obj.Name,
+				UID:               obj.UID,
+				ResourceVersion:   obj.ResourceVersion,
+				CreationTimestamp: obj.CreationTimestamp,
+			},
+			Spec: autoscalingv1.ScaleSpec{
+				Replicas: replicas,
+			},
+			Status: autoscalingv1.ScaleStatus{
+				Replicas: obj.Status.Replicas,
+				Selector: selector,
+			},
+		}, nil
+	case *appsv1.ReplicaSet:
+		var replicas int32 = 1
+		if obj.Spec.Replicas != nil {
+			replicas = *obj.Spec.Replicas
+		}
+		var selector string
+		if obj.Spec.Selector != nil {
+			selector = obj.Spec.Selector.String()
+		}
+		return &autoscalingv1.Scale{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         obj.Namespace,
+				Name:              obj.Name,
+				UID:               obj.UID,
+				ResourceVersion:   obj.ResourceVersion,
+				CreationTimestamp: obj.CreationTimestamp,
+			},
+			Spec: autoscalingv1.ScaleSpec{
+				Replicas: replicas,
+			},
+			Status: autoscalingv1.ScaleStatus{
+				Replicas: obj.Status.Replicas,
+				Selector: selector,
+			},
+		}, nil
+	case *corev1.ReplicationController:
+		var replicas int32 = 1
+		if obj.Spec.Replicas != nil {
+			replicas = *obj.Spec.Replicas
+		}
+		return &autoscalingv1.Scale{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         obj.Namespace,
+				Name:              obj.Name,
+				UID:               obj.UID,
+				ResourceVersion:   obj.ResourceVersion,
+				CreationTimestamp: obj.CreationTimestamp,
+			},
+			Spec: autoscalingv1.ScaleSpec{
+				Replicas: replicas,
+			},
+			Status: autoscalingv1.ScaleStatus{
+				Replicas: obj.Status.Replicas,
+				Selector: labels.Set(obj.Spec.Selector).String(),
+			},
+		}, nil
+	case *appsv1.StatefulSet:
+		var replicas int32 = 1
+		if obj.Spec.Replicas != nil {
+			replicas = *obj.Spec.Replicas
+		}
+		var selector string
+		if obj.Spec.Selector != nil {
+			selector = obj.Spec.Selector.String()
+		}
+		return &autoscalingv1.Scale{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:         obj.Namespace,
+				Name:              obj.Name,
+				UID:               obj.UID,
+				ResourceVersion:   obj.ResourceVersion,
+				CreationTimestamp: obj.CreationTimestamp,
+			},
+			Spec: autoscalingv1.ScaleSpec{
+				Replicas: replicas,
+			},
+			Status: autoscalingv1.ScaleStatus{
+				Replicas: obj.Status.Replicas,
+				Selector: selector,
+			},
+		}, nil
+	default:
+		// TODO: CRDs https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#scale-subresource
+		return nil, fmt.Errorf("unimplemented scale subresource for resource %T", obj)
+	}
+}
+
+func applyScale(obj client.Object, scale *autoscalingv1.Scale) error {
+	switch obj := obj.(type) {
+	case *appsv1.Deployment:
+		obj.Spec.Replicas = ptr.To(scale.Spec.Replicas)
+	case *appsv1.ReplicaSet:
+		obj.Spec.Replicas = ptr.To(scale.Spec.Replicas)
+	case *corev1.ReplicationController:
+		obj.Spec.Replicas = ptr.To(scale.Spec.Replicas)
+	case *appsv1.StatefulSet:
+		obj.Spec.Replicas = ptr.To(scale.Spec.Replicas)
+	default:
+		// TODO: CRDs https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#scale-subresource
+		return fmt.Errorf("unimplemented scale subresource for resource %T", obj)
+	}
+	return nil
+}
+
+// AddIndex adds an index to a fake client. It will panic if used with a client that is not a fake client.
+// It will error if there is already an index for given object with the same name as field.
+//
+// It can be used to test code that adds indexes to the cache at runtime.
+func AddIndex(c client.Client, obj runtime.Object, field string, extractValue client.IndexerFunc) error {
+	fakeClient, isFakeClient := c.(*fakeClient)
+	if !isFakeClient {
+		panic("AddIndex can only be used with a fake client")
+	}
+	fakeClient.indexesLock.Lock()
+	defer fakeClient.indexesLock.Unlock()
+
+	if fakeClient.indexes == nil {
+		fakeClient.indexes = make(map[schema.GroupVersionKind]map[string]client.IndexerFunc, 1)
+	}
+
+	gvk, err := apiutil.GVKForObject(obj, fakeClient.scheme)
+	if err != nil {
+		return fmt.Errorf("failed to get gvk for %T: %w", obj, err)
+	}
+
+	if fakeClient.indexes[gvk] == nil {
+		fakeClient.indexes[gvk] = make(map[string]client.IndexerFunc, 1)
+	}
+
+	if fakeClient.indexes[gvk][field] != nil {
+		return fmt.Errorf("index %s already exists", field)
+	}
+
+	fakeClient.indexes[gvk][field] = extractValue
+
+	return nil
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/doc.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/fake/doc.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package fake provides a fake client for testing.
+
+A fake client is backed by its simple object store indexed by GroupVersionResource.
+You can create a fake client with optional objects.
+
+	client := NewClientBuilder().WithScheme(scheme).WithObjects(initObjs...).Build()
+
+You can invoke the methods defined in the Client interface.
+
+When in doubt, it's almost always better not to use this package and instead use
+envtest.Environment with a real client and API server.
+
+WARNING: ⚠️ Current Limitations / Known Issues with the fake Client ⚠️
+  - This client does not have a way to inject specific errors to test handled vs. unhandled errors.
+  - There is some support for sub resources which can cause issues with tests if you're trying to update
+    e.g. metadata and status in the same reconcile.
+  - No OpenAPI validation is performed when creating or updating objects.
+  - ObjectMeta's `Generation` and `ResourceVersion` don't behave properly, Patch or Update
+    operations that rely on these fields will fail, or give false positives.
+*/
+package fake

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/client/interceptor/intercept.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/client/interceptor/intercept.go
@@ -1,0 +1,166 @@
+package interceptor
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Funcs contains functions that are called instead of the underlying client's methods.
+type Funcs struct {
+	Get               func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error
+	List              func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error
+	Create            func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error
+	Delete            func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.DeleteOption) error
+	DeleteAllOf       func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.DeleteAllOfOption) error
+	Update            func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.UpdateOption) error
+	Patch             func(ctx context.Context, client client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error
+	Watch             func(ctx context.Context, client client.WithWatch, obj client.ObjectList, opts ...client.ListOption) (watch.Interface, error)
+	SubResource       func(client client.WithWatch, subResource string) client.SubResourceClient
+	SubResourceGet    func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, subResource client.Object, opts ...client.SubResourceGetOption) error
+	SubResourceCreate func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error
+	SubResourceUpdate func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error
+	SubResourcePatch  func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error
+}
+
+// NewClient returns a new interceptor client that calls the functions in funcs instead of the underlying client's methods, if they are not nil.
+func NewClient(interceptedClient client.WithWatch, funcs Funcs) client.WithWatch {
+	return interceptor{
+		client: interceptedClient,
+		funcs:  funcs,
+	}
+}
+
+type interceptor struct {
+	client client.WithWatch
+	funcs  Funcs
+}
+
+var _ client.WithWatch = &interceptor{}
+
+func (c interceptor) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
+	return c.client.GroupVersionKindFor(obj)
+}
+
+func (c interceptor) IsObjectNamespaced(obj runtime.Object) (bool, error) {
+	return c.client.IsObjectNamespaced(obj)
+}
+
+func (c interceptor) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if c.funcs.Get != nil {
+		return c.funcs.Get(ctx, c.client, key, obj, opts...)
+	}
+	return c.client.Get(ctx, key, obj, opts...)
+}
+
+func (c interceptor) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if c.funcs.List != nil {
+		return c.funcs.List(ctx, c.client, list, opts...)
+	}
+	return c.client.List(ctx, list, opts...)
+}
+
+func (c interceptor) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if c.funcs.Create != nil {
+		return c.funcs.Create(ctx, c.client, obj, opts...)
+	}
+	return c.client.Create(ctx, obj, opts...)
+}
+
+func (c interceptor) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	if c.funcs.Delete != nil {
+		return c.funcs.Delete(ctx, c.client, obj, opts...)
+	}
+	return c.client.Delete(ctx, obj, opts...)
+}
+
+func (c interceptor) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if c.funcs.Update != nil {
+		return c.funcs.Update(ctx, c.client, obj, opts...)
+	}
+	return c.client.Update(ctx, obj, opts...)
+}
+
+func (c interceptor) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	if c.funcs.Patch != nil {
+		return c.funcs.Patch(ctx, c.client, obj, patch, opts...)
+	}
+	return c.client.Patch(ctx, obj, patch, opts...)
+}
+
+func (c interceptor) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	if c.funcs.DeleteAllOf != nil {
+		return c.funcs.DeleteAllOf(ctx, c.client, obj, opts...)
+	}
+	return c.client.DeleteAllOf(ctx, obj, opts...)
+}
+
+func (c interceptor) Status() client.SubResourceWriter {
+	return c.SubResource("status")
+}
+
+func (c interceptor) SubResource(subResource string) client.SubResourceClient {
+	if c.funcs.SubResource != nil {
+		return c.funcs.SubResource(c.client, subResource)
+	}
+	return subResourceInterceptor{
+		subResourceName: subResource,
+		client:          c.client,
+		funcs:           c.funcs,
+	}
+}
+
+func (c interceptor) Scheme() *runtime.Scheme {
+	return c.client.Scheme()
+}
+
+func (c interceptor) RESTMapper() meta.RESTMapper {
+	return c.client.RESTMapper()
+}
+
+func (c interceptor) Watch(ctx context.Context, obj client.ObjectList, opts ...client.ListOption) (watch.Interface, error) {
+	if c.funcs.Watch != nil {
+		return c.funcs.Watch(ctx, c.client, obj, opts...)
+	}
+	return c.client.Watch(ctx, obj, opts...)
+}
+
+type subResourceInterceptor struct {
+	subResourceName string
+	client          client.Client
+	funcs           Funcs
+}
+
+var _ client.SubResourceClient = &subResourceInterceptor{}
+
+func (s subResourceInterceptor) Get(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceGetOption) error {
+	if s.funcs.SubResourceGet != nil {
+		return s.funcs.SubResourceGet(ctx, s.client, s.subResourceName, obj, subResource, opts...)
+	}
+	return s.client.SubResource(s.subResourceName).Get(ctx, obj, subResource, opts...)
+}
+
+func (s subResourceInterceptor) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+	if s.funcs.SubResourceCreate != nil {
+		return s.funcs.SubResourceCreate(ctx, s.client, s.subResourceName, obj, subResource, opts...)
+	}
+	return s.client.SubResource(s.subResourceName).Create(ctx, obj, subResource, opts...)
+}
+
+func (s subResourceInterceptor) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+	if s.funcs.SubResourceUpdate != nil {
+		return s.funcs.SubResourceUpdate(ctx, s.client, s.subResourceName, obj, opts...)
+	}
+	return s.client.SubResource(s.subResourceName).Update(ctx, obj, opts...)
+}
+
+func (s subResourceInterceptor) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+	if s.funcs.SubResourcePatch != nil {
+		return s.funcs.SubResourcePatch(ctx, s.client, s.subResourceName, obj, patch, opts...)
+	}
+	return s.client.SubResource(s.subResourceName).Patch(ctx, obj, patch, opts...)
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/internal/objectutil/objectutil.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/internal/objectutil/objectutil.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objectutil
+
+import (
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// FilterWithLabels returns a copy of the items in objs matching labelSel.
+func FilterWithLabels(objs []runtime.Object, labelSel labels.Selector) ([]runtime.Object, error) {
+	outItems := make([]runtime.Object, 0, len(objs))
+	for _, obj := range objs {
+		meta, err := apimeta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		if labelSel != nil {
+			lbls := labels.Set(meta.GetLabels())
+			if !labelSel.Matches(lbls) {
+				continue
+			}
+		}
+		outItems = append(outItems, obj.DeepCopyObject())
+	}
+	return outItems, nil
+}


### PR DESCRIPTION
# Description
Adds `CredentialMirrorSet`: mirrors worker RBAC (ServiceAccount/Role/RoleBinding) and Secrets (e.g. gateway certs) to the Standby, so a promoted hub can serve workers without manual re-provisioning. Service-account token Secrets are excluded (a token minted by the Active is invalid on the Standby).

Also adds a reverse-diff anti-entropy pass: an Active-side object with no Standby mirror gets re-enqueued, covering mirrors deleted by hand or missed during namespace sync.

Wires `ha.FullMirrorSet` into `main.go` and extends the sample `ClusterRole` with the needed read grants.

Stacked on #415. Only 3 commits are new here.

Fixes #295

## How Has This Been Tested?
`go build`, `go vet`, `gofmt` clean. `go test -race -count=1 ./pkg/ha/...`. Verified live on a two-hub Kind topology: RBAC and Secrets mirror correctly, token Secrets and controller-internal namespaces stay excluded.

## Checklist:

* [x] The title of the PR states what changed and the related issues number (used for the release note).
* [x] Does this PR requires documentation updates?
* [x] I've updated documentation as required by this PR.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [x] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like worker-operator?
No. Additive mirroring on the Standby side only.
```release-note

```
